### PR TITLE
Convert all structs to objects to avoid stack-based memory allocation…

### DIFF
--- a/ical.NET.UnitTests/RecurrenceTest.cs
+++ b/ical.NET.UnitTests/RecurrenceTest.cs
@@ -14,7 +14,6 @@ using Ical.Net.Interfaces.Components;
 using Ical.Net.Interfaces.DataTypes;
 using Ical.Net.Interfaces.Evaluation;
 using Ical.Net.Serialization.iCalendar.Serializers.DataTypes;
-using Ical.Net.Structs;
 using Ical.Net.Utility;
 using NUnit.Framework;
 using Calendar = Ical.Net.Calendar;

--- a/ical.NET/Calendar.cs
+++ b/ical.NET/Calendar.cs
@@ -16,7 +16,6 @@ using Ical.Net.Interfaces.Evaluation;
 using Ical.Net.Interfaces.General;
 using Ical.Net.Interfaces.Serialization;
 using Ical.Net.Serialization.iCalendar.Serializers;
-using Ical.Net.Structs;
 
 namespace Ical.Net
 {

--- a/ical.NET/Components/Alarm.cs
+++ b/ical.NET/Components/Alarm.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using Ical.Net.DataTypes;
 using Ical.Net.Interfaces.Components;
 using Ical.Net.Interfaces.DataTypes;
-using Ical.Net.Structs;
 
 namespace Ical.Net
 {

--- a/ical.NET/Components/RecurringComponent.cs
+++ b/ical.NET/Components/RecurringComponent.cs
@@ -7,7 +7,6 @@ using Ical.Net.General.Proxies;
 using Ical.Net.Interfaces.Components;
 using Ical.Net.Interfaces.DataTypes;
 using Ical.Net.Interfaces.General;
-using Ical.Net.Structs;
 using Ical.Net.Utility;
 
 namespace Ical.Net

--- a/ical.NET/DataTypes/AlarmOccurrence.cs
+++ b/ical.NET/DataTypes/AlarmOccurrence.cs
@@ -1,9 +1,8 @@
 using System;
-using Ical.Net.DataTypes;
 using Ical.Net.Interfaces.Components;
 using Ical.Net.Interfaces.DataTypes;
 
-namespace Ical.Net.Structs
+namespace Ical.Net.DataTypes
 {
     /// <summary>
     /// A class that represents a specific occurrence of an <see cref="Alarm"/>.        
@@ -14,7 +13,7 @@ namespace Ical.Net.Structs
     /// component on which the alarm fired.
     /// </remarks>
     [Serializable]
-    public struct AlarmOccurrence : IComparable<AlarmOccurrence>
+    public class AlarmOccurrence : IComparable<AlarmOccurrence>
     {
         private IPeriod _mPeriod;
         private IRecurringComponent _mComponent;

--- a/ical.NET/DataTypes/Occurrence.cs
+++ b/ical.NET/DataTypes/Occurrence.cs
@@ -2,10 +2,10 @@ using System;
 using Ical.Net.Interfaces.DataTypes;
 using Ical.Net.Interfaces.Evaluation;
 
-namespace Ical.Net.Structs
+namespace Ical.Net.DataTypes
 {
     [Serializable]
-    public struct Occurrence : IComparable<Occurrence>
+    public class Occurrence : IComparable<Occurrence>
     {
         public IPeriod Period { get; set; }
         public IRecurrable Source { get; set; }

--- a/ical.NET/Interfaces/Components/IAlarm.cs
+++ b/ical.NET/Interfaces/Components/IAlarm.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using Ical.Net.DataTypes;
 using Ical.Net.Interfaces.DataTypes;
-using Ical.Net.Structs;
 
 namespace Ical.Net.Interfaces.Components
 {

--- a/ical.NET/Interfaces/Components/IAlarmContainer.cs
+++ b/ical.NET/Interfaces/Components/IAlarmContainer.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
+using Ical.Net.DataTypes;
 using Ical.Net.Interfaces.DataTypes;
 using Ical.Net.Interfaces.General;
-using Ical.Net.Structs;
 
 namespace Ical.Net.Interfaces.Components
 {

--- a/ical.NET/Interfaces/Evaluation/IGetOccurrences.cs
+++ b/ical.NET/Interfaces/Evaluation/IGetOccurrences.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using Ical.Net.DataTypes;
 using Ical.Net.Interfaces.Components;
 using Ical.Net.Interfaces.DataTypes;
-using Ical.Net.Structs;
 
 namespace Ical.Net.Interfaces.Evaluation
 {

--- a/ical.NET/Serialization/DataTypeMapper.cs
+++ b/ical.NET/Serialization/DataTypeMapper.cs
@@ -11,7 +11,7 @@ namespace Ical.Net.Serialization
 
     public class DataTypeMapper : IDataTypeMapper
     {
-        private struct PropertyMapping
+        private class PropertyMapping
         {
             public Type ObjectType { get; set; }
             public TypeResolverDelegate Resolver { get; set; }

--- a/ical.NET/Utility/RecurrenceUtil.cs
+++ b/ical.NET/Utility/RecurrenceUtil.cs
@@ -3,7 +3,6 @@ using Ical.Net.DataTypes;
 using Ical.Net.Interfaces.DataTypes;
 using Ical.Net.Interfaces.Evaluation;
 using Ical.Net.Interfaces.General;
-using Ical.Net.Structs;
 
 namespace Ical.Net.Utility
 {

--- a/ical.NET/iCalendarCollection.cs
+++ b/ical.NET/iCalendarCollection.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
+using Ical.Net.DataTypes;
 using Ical.Net.Interfaces;
 using Ical.Net.Interfaces.Components;
 using Ical.Net.Interfaces.DataTypes;
-using Ical.Net.Structs;
 
 namespace Ical.Net
 {

--- a/ical.NET/ical.NET.csproj
+++ b/ical.NET/ical.NET.csproj
@@ -179,8 +179,8 @@
     <Compile Include="Serialization\iCalendar\Serializers\GenericListSerializer.cs" />
     <Compile Include="Serialization\iCalendar\Serializers\Other\StringSerializer.cs" />
     <Compile Include="Serialization\EncodingProvider.cs" />
-    <Compile Include="Structs\AlarmOccurrence.cs" />
-    <Compile Include="Structs\Occurrence.cs" />
+    <Compile Include="DataTypes\AlarmOccurrence.cs" />
+    <Compile Include="DataTypes\Occurrence.cs" />
     <Compile Include="DataTypes\Period.cs" />
     <Compile Include="Serialization\Factory\ComponentFactory.cs" />
     <Compile Include="General\CalendarObject.cs">


### PR DESCRIPTION
… and

needless copy-on-assignment behavior
