### PR TITLE
Fixed Concurrency issue around parallel deserialization #40

### DIFF
--- a/ical.NET.UnitTests/ConcurrentDeserializationTests.cs
+++ b/ical.NET.UnitTests/ConcurrentDeserializationTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Ical.Net.DataTypes;
+using Ical.Net.Interfaces;
+using Ical.Net.Serialization;
+using Ical.Net.Serialization.iCalendar.Serializers;
+using NUnit.Framework;
+
+namespace Ical.Net.UnitTests
+{
+    public class ConcurrentDeserializationTests
+    {
+        [Test]
+        public void ConcurrentDeserialization_Test()
+        {
+            // https://github.com/rianjs/ical.net/issues/40
+            var calendars = new List<string>
+            {
+                IcsFiles.DailyCount2,
+                IcsFiles.DailyInterval2,
+                IcsFiles.DailyByDay1,
+                IcsFiles.RecurrenceDates1,
+                IcsFiles.DailyByHourMinute1,
+            };
+
+            var deserializedCalendars = calendars.AsParallel().SelectMany(c =>
+            {
+                IICalendarCollection calendar;
+                using (var reader = new StringReader(c ?? string.Empty))
+                {
+                    calendar = Calendar.LoadFromStream(reader);
+                }
+                return calendar;
+            });
+
+            var materialized = deserializedCalendars.ToList();
+            Assert.AreEqual(5, materialized.Count);
+        }
+    }
+}

--- a/ical.NET/Utility/SerializationUtil.cs
+++ b/ical.NET/Utility/SerializationUtil.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -26,7 +27,7 @@ namespace Ical.Net.Utility
 
         private const BindingFlags _bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
 
-        private static Dictionary<Type, List<MethodInfo>> _onDeserializingMethods = new Dictionary<Type, List<MethodInfo>>(16);
+        private static readonly ConcurrentDictionary<Type, List<MethodInfo>> _onDeserializingMethods = new ConcurrentDictionary<Type, List<MethodInfo>>();
         private static List<MethodInfo> GetDeserializingMethods(Type targetType)
         {
             if (targetType == null)
@@ -49,11 +50,11 @@ namespace Ical.Net.Utility
                 .Select(t => t.targetTypeMethodInfo)
                 .ToList();
 
-            _onDeserializingMethods.Add(targetType, methodInfo);
+            _onDeserializingMethods.AddOrUpdate(targetType, methodInfo, (type, list) => methodInfo);
             return methodInfo;
         }
 
-        private static Dictionary<Type, List<MethodInfo>> _onDeserializedMethods = new Dictionary<Type, List<MethodInfo>>(16);
+        private static ConcurrentDictionary<Type, List<MethodInfo>> _onDeserializedMethods = new ConcurrentDictionary<Type, List<MethodInfo>>();
         private static List<MethodInfo> GetDeserializedMethods(Type targetType)
         {
             if (targetType == null)
@@ -76,7 +77,7 @@ namespace Ical.Net.Utility
                 .Select(t => t.targetTypeMethodInfo)
                 .ToList();
 
-            _onDeserializedMethods.Add(targetType, methodInfo);
+            _onDeserializedMethods.AddOrUpdate(targetType, methodInfo, (type, list) => methodInfo);
             return methodInfo;
         }
     }


### PR DESCRIPTION
The unit test successfully reproduced the failure from https://github.com/rianjs/ical.net/issues/40 with duplicate key exceptions.

Switching to the `ConcurrentDictionary` allowed the test to pass.
