### PR TITLE
fixes #27: Using Calendar.AddProperty duplicates property name into value

### DIFF
--- a/ical.NET.UnitTests/CalendarPropertiesTest.cs
+++ b/ical.NET.UnitTests/CalendarPropertiesTest.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Ical.Net.Interfaces.Serialization;
+using Ical.Net.Serialization;
+using Ical.Net.Serialization.iCalendar.Factory;
+using NUnit.Framework;
+
+namespace Ical.Net.UnitTests
+{
+    [TestFixture]
+    public class CalendarPropertiesTest
+    {
+        [Test]
+        public void AddPropertyShouldNotIncludePropertyNameInValue()
+        {
+            var propName = "X-WR-CALNAME";
+            var propValue = "Testname";
+
+            var iCal = new Calendar();
+            iCal.AddProperty(propName, propValue);
+
+            var ctx = new SerializationContext();
+            var factory = new SerializerFactory();
+
+            // Get a serializer for our object
+            var serializer = factory.Build(iCal.GetType(), ctx) as IStringSerializer;
+
+            var result = serializer.SerializeToString(iCal);
+
+            Console.WriteLine(result);
+            var lines = result.Split(new [] { "\r\n" }, StringSplitOptions.None);
+            var propLine = lines.FirstOrDefault(x => x.StartsWith("X-WR-CALNAME:"));
+            Assert.AreEqual($"{propName}:{propValue}", propLine);
+        }
+    }
+}

--- a/ical.NET.UnitTests/ical.NET.UnitTests.csproj
+++ b/ical.NET.UnitTests/ical.NET.UnitTests.csproj
@@ -73,6 +73,7 @@
   <ItemGroup>
     <Compile Include="AlarmTest.cs" />
     <Compile Include="AttendeeTest.cs" />
+    <Compile Include="CalendarPropertiesTest.cs" />
     <Compile Include="ComponentTest.cs" />
     <Compile Include="ConcurrentDeserializationTests.cs" />
     <Compile Include="DeserializationTests.cs" />

--- a/ical.NET/Components/CalendarComponent.cs
+++ b/ical.NET/Components/CalendarComponent.cs
@@ -105,7 +105,7 @@ namespace Ical.Net
         public virtual void AddProperty(ICalendarProperty p)
         {
             p.Parent = this;
-            Properties.Set(p.Name, p);
+            Properties.Set(p.Name, p.Value);
         }
     }
 }


### PR DESCRIPTION
This simple change consists of adding just the value of the property instead of its .ToString()-serialization to the object value store.

See bug/issue #27 for details.
