### PR TITLE
TZID property parameter MUST NOT be applied to values in UTC.

### DIFF
--- a/ical.NET.UnitTests/DateTimeSerializerTests.cs
+++ b/ical.NET.UnitTests/DateTimeSerializerTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+using Ical.Net.DataTypes;
+using Ical.Net.Interfaces.DataTypes;
+using Ical.Net.Serialization.iCalendar.Serializers.DataTypes;
+using NUnit.Framework;
+
+namespace Ical.Net.UnitTests.Serialization.iCalendar.Serializers.DataTypes
+{
+    [TestFixture]
+    public class DateTimeSerializerTests
+    {
+        [Test, Category("Deserialization")]
+        public void TZIDPropertyMustNotBeAppliedToUtcDateTime()
+        {
+            var ical = new Ical.Net.Calendar();
+            var evt = new Ical.Net.Event();
+            evt.DtStamp = new CalDateTime(new DateTime(2016, 8, 17, 2, 30, 0, DateTimeKind.Utc));
+            ical.Events.Add(evt);
+
+            var serializer = new Ical.Net.Serialization.iCalendar.Serializers.CalendarSerializer();
+            var serializedCalendar = serializer.SerializeToString(ical);
+
+            var lines = serializedCalendar.Split(new string[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries).ToList();
+            var result = lines.First(s => s.StartsWith("DTSTAMP"));
+            Assert.AreEqual("DTSTAMP:20160817T023000Z", result);
+        }
+
+        [Test, Category("Deserialization")]
+        public void TZIDPropertyShouldBeAppliedForLocalTimezones()
+        {
+            // see http://www.ietf.org/rfc/rfc2445.txt p.36
+            var result = DateTimeSerializer()
+                .SerializeToString(
+                new CalDateTime(new DateTime(1997, 7, 14, 13, 30, 0, DateTimeKind.Local), "US-Eastern"));
+
+            // TZID is applied elsewhere - just make sure this doesn't have 'Z' appended. 
+            Assert.AreEqual("19970714T133000", result);
+        }
+
+
+        private static DateTimeSerializer DateTimeSerializer()
+        {
+            return new DateTimeSerializer();
+        }
+    }
+}

--- a/ical.NET.UnitTests/ical.NET.UnitTests.csproj
+++ b/ical.NET.UnitTests/ical.NET.UnitTests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="CalendarPropertiesTest.cs" />
     <Compile Include="ComponentTest.cs" />
     <Compile Include="ConcurrentDeserializationTests.cs" />
+    <Compile Include="DateTimeSerializerTests.cs" />
     <Compile Include="DeserializationTests.cs" />
     <Compile Include="DocumentationExamples.cs" />
     <Compile Include="EqualityAndHashingTests.cs" />
@@ -573,6 +574,9 @@
       <ProductName>Windows Installer 3.1</ProductName>
       <Install>true</Install>
     </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/ical.NET/Serialization/iCalendar/Serializers/DataTypes/DateTimeSerializer.cs
+++ b/ical.NET/Serialization/iCalendar/Serializers/DataTypes/DateTimeSerializer.cs
@@ -41,7 +41,11 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
             var dt = obj as IDateTime;
 
             // Assign the TZID for the date/time value.
-            if (dt.TzId != null)
+            if (dt.IsUniversalTime)
+            {
+                dt.Parameters.Remove("TZID");
+            }
+            else if (dt.TzId != null)
             {
                 dt.Parameters.Set("TZID", dt.TzId);
             }


### PR DESCRIPTION
As discussed in #89 
All tests are running. @jhsowter has partially created tests.
