### PR TITLE
Ensure DTSTAMP is of kind UTC when set automatically

### DIFF
--- a/ical.NET.UnitTests/EventTest.cs
+++ b/ical.NET.UnitTests/EventTest.cs
@@ -2,6 +2,8 @@ using Ical.Net.DataTypes;
 using Ical.Net.ExtensionMethods;
 using Ical.Net.Interfaces;
 using NUnit.Framework;
+using System;
+using System.Linq;
 
 namespace Ical.Net.UnitTests
 {
@@ -74,6 +76,82 @@ namespace Ical.Net.UnitTests
             cal.Events.Remove(evt);
             Assert.AreEqual(0, cal.Children.Count);
             Assert.AreEqual(0, cal.Events.Count);
+        }
+
+        /// <summary>
+        /// Ensures that event DTSTAMP is set.
+        /// </summary>
+        [Test, Category("Event")]
+        public void EnsureDTSTAMPisNotNull()
+        {
+            ICalendar cal = new Calendar();
+
+            // Do not set DTSTAMP manually
+            var evt = new Event
+            {
+                Summary = "Testing",
+                Start = new CalDateTime(2010, 3, 25),
+                End = new CalDateTime(2010, 3, 26)
+            };
+
+            cal.Events.Add(evt);
+            Assert.IsNotNull(evt.DtStamp);
+        }
+
+        /// <summary>
+        /// Ensures that automatically set DTSTAMP property is of kind UTC.
+        /// </summary>
+        [Test, Category("Event")]
+        public void EnsureDTSTAMPisOfTypeUTC()
+        {
+            ICalendar cal = new Calendar();
+
+            var evt = new Event
+            {
+                Summary = "Testing",
+                Start = new CalDateTime(2010, 3, 25),
+                End = new CalDateTime(2010, 3, 26)
+            };
+
+            cal.Events.Add(evt);
+            Assert.IsTrue(evt.DtStamp.IsUniversalTime, "DTSTAMP should always be of type UTC.");
+        }
+
+        /// <summary>
+        /// Ensures that correct set DTSTAMP property is being serialized with kind UTC.
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void EnsureCorrectSetDTSTAMPisSerializedAsKindUTC()
+        {
+            var ical = new Ical.Net.Calendar();
+            var evt = new Ical.Net.Event();
+            evt.DtStamp = new CalDateTime(new DateTime(2016, 8, 17, 2, 30, 0, DateTimeKind.Utc));
+            ical.Events.Add(evt);
+
+            var serializer = new Ical.Net.Serialization.iCalendar.Serializers.CalendarSerializer();
+            var serializedCalendar = serializer.SerializeToString(ical);
+
+            var lines = serializedCalendar.Split(new string[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries).ToList();
+            var result = lines.First(s => s.StartsWith("DTSTAMP"));
+            Assert.AreEqual("DTSTAMP:20160817T023000Z", result);
+        }
+
+        /// <summary>
+        /// Ensures that automatically set DTSTAMP property is being serialized with kind UTC.
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void EnsureAutomaticallySetDTSTAMPisSerializedAsKindUTC()
+        {
+            var ical = new Ical.Net.Calendar();
+            var evt = new Ical.Net.Event();
+            ical.Events.Add(evt);
+
+            var serializer = new Ical.Net.Serialization.iCalendar.Serializers.CalendarSerializer();
+            var serializedCalendar = serializer.SerializeToString(ical);
+
+            var lines = serializedCalendar.Split(new string[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries).ToList();
+            var result = lines.First(s => s.StartsWith("DTSTAMP"));
+            Assert.AreEqual($"DTSTAMP:{evt.DtStamp.Year}{evt.DtStamp.Month:00}{evt.DtStamp.Day:00}T{evt.DtStamp.Hour:00}{evt.DtStamp.Minute:00}{evt.DtStamp.Second:00}Z", result);
         }
     }
 }

--- a/ical.NET/Components/UniqueComponent.cs
+++ b/ical.NET/Components/UniqueComponent.cs
@@ -45,8 +45,8 @@ namespace Ical.Net
                 // the iCalendar standard doesn't care at all about milliseconds.  Therefore, when comparing
                 // two calendars, one generated, and one loaded from file, they may be functionally identical,
                 // but be determined to be different due to millisecond differences.
-                var now = DateTime.Now;
-                DtStamp = new CalDateTime(now.Year, now.Month, now.Day, now.Hour, now.Minute, now.Second);
+                var now = DateTime.SpecifyKind(DateTime.Today.Add(DateTime.UtcNow.TimeOfDay), DateTimeKind.Utc);
+                DtStamp = new CalDateTime(now);
             }
         }
 


### PR DESCRIPTION
As discussed in #89 

For Events where DtStamp-Property is not set, create a UTC-DateTime of now. 
UTC-check-tests included.
Serialization-Tests included.

This merge request is independent of #93 
