### PR TITLE
Fix local date time provider on mono

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: csharp
+
+sudo: false  # use the new container-based Travis infrastructure 
+
+install:
+  - nuget restore v2
+  - nuget restore v3
+  - nuget install NUnit.Runners -Version 3.4.1 -OutputDirectory testrunner
+
+script: 
+  - xbuild v2/ical-v2.sln
+  - mono ./testrunner/NUnit.ConsoleRunner.3.4.1/tools/nunit3-console.exe v2/ical.NET.UnitTests/bin/Debug/net46/Ical.Net.UnitTests.dll
+  - xbuild v3/ical-v3.sln
+  - mono ./testrunner/NUnit.ConsoleRunner.3.4.1/tools/nunit3-console.exe v3/ical.NET.UnitTests/bin/Debug/net46/Ical.Net.UnitTests.dll

--- a/v2/ical-v2.sln
+++ b/v2/ical-v2.sln
@@ -3,11 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ical.Net", "ical.net\Ical.Net.csproj", "{F88DB6D3-CB95-4707-9C88-B53403AADC61}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ical.Net", "ical.NET\Ical.Net.csproj", "{F88DB6D3-CB95-4707-9C88-B53403AADC61}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ical.Net.UnitTests", "ical.net.UnitTests\Ical.Net.UnitTests.csproj", "{38A02D06-15CC-436A-9C8F-07B84A7E2CE0}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ical.Net.UnitTests", "ical.NET.UnitTests\Ical.Net.UnitTests.csproj", "{38A02D06-15CC-436A-9C8F-07B84A7E2CE0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ical.Net.Collections", "ical.net.Collections\ical.net.Collections\Ical.Net.Collections.csproj", "{E04EFEB6-4625-4D58-AC91-7B8B8A2C97BB}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ical.Net.Collections", "ical.NET.Collections\ical.NET.Collections\Ical.Net.Collections.csproj", "{E04EFEB6-4625-4D58-AC91-7B8B8A2C97BB}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "antlr.runtime", "antlr.runtime\antlr.runtime.csproj", "{CB7CC882-ED47-46C0-AAAE-7A437F22F1C6}"
 EndProject

--- a/v2/ical.NET.UnitTests/Ical.Net.UnitTests.csproj
+++ b/v2/ical.NET.UnitTests/Ical.Net.UnitTests.csproj
@@ -103,11 +103,11 @@
       <Project>{cb7cc882-ed47-46c0-aaae-7a437f22f1c6}</Project>
       <Name>antlr.runtime</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Ical.Net.Collections\Ical.Net.Collections\Ical.Net.Collections.csproj">
+    <ProjectReference Include="..\ical.NET.Collections\ical.NET.Collections\Ical.Net.Collections.csproj">
       <Project>{E04EFEB6-4625-4D58-AC91-7B8B8A2C97BB}</Project>
       <Name>Ical.Net.Collections</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Ical.Net\Ical.Net.csproj">
+    <ProjectReference Include="..\ical.NET\Ical.Net.csproj">
       <Project>{F88DB6D3-CB95-4707-9C88-B53403AADC61}</Project>
       <Name>Ical.Net</Name>
     </ProjectReference>

--- a/v2/ical.NET/Ical.Net.csproj
+++ b/v2/ical.NET/Ical.Net.csproj
@@ -262,7 +262,7 @@
       <Project>{cb7cc882-ed47-46c0-aaae-7a437f22f1c6}</Project>
       <Name>antlr.runtime</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Ical.Net.Collections\Ical.Net.Collections\Ical.Net.Collections.csproj">
+    <ProjectReference Include="..\ical.NET.Collections\ical.NET.Collections\Ical.Net.Collections.csproj">
       <Project>{E04EFEB6-4625-4D58-AC91-7B8B8A2C97BB}</Project>
       <Name>Ical.Net.Collections</Name>
     </ProjectReference>

--- a/v2/ical.NET/Utility/DateUtil.cs
+++ b/v2/ical.NET/Utility/DateUtil.cs
@@ -10,6 +10,8 @@ namespace Ical.Net.Utility
 {
     public class DateUtil
     {
+        private const string UNIX_TIME_ZONE_CONFIG_FILE = "/etc/timezone";
+
         public static IDateTime StartOfDay(IDateTime dt)
         {
             return dt.AddHours(-dt.Hour).AddMinutes(-dt.Minute).AddSeconds(-dt.Second);
@@ -94,7 +96,42 @@ namespace Ical.Net.Utility
 
         private static readonly Dictionary<string, string> _windowsMapping =
             TzdbDateTimeZoneSource.Default.WindowsMapping.PrimaryMapping.ToDictionary(k => k.Key, v => v.Value, StringComparer.OrdinalIgnoreCase);
-        public static readonly DateTimeZone LocalDateTimeZone = DateTimeZoneProviders.Tzdb.GetSystemDefault();
+        public static readonly DateTimeZone LocalDateTimeZone = GetLocalDateTimeZone();
+
+        /// <summary>
+        /// Alternative to NodaTime.DateTimeZoneProviders.Tzdb.GetSystemDefault that works on both Windows and
+        /// Linux/Mono systems.
+        /// System.TimeZoneInfo.Local on Mono contains "Local" for the Local property.  NodaTime cannot deal with this,
+        /// and throws DateTimeZoneNotFoundException whenever you call
+        /// NodaTime.DateTimeZoneProviders.Tzdb.GetSystemDefault().
+        /// This workaround will, on PlatformID.Unix systems, manually open and read the content of the /etc/timezone
+        /// file as the timezone ID.  Typically, this will be something like "US/Central" which NodaTime can indeed
+        /// recognize and happily give us back a NodaTime.DateTimeZone.
+        /// </summary>
+        /// <remarks>Source: https://github.com/nodatime/nodatime/issues/235#issuecomment-80932114 </remarks>
+        private static DateTimeZone GetLocalDateTimeZone()
+        {
+            // If we aren't running on Linux (which assumes Mono), then get the DTZ from NodaTime like normal.
+            if (Environment.OSVersion.Platform != PlatformID.Unix)
+            {
+                return DateTimeZoneProviders.Tzdb.GetSystemDefault();
+            }
+
+            string sTimezoneId;
+            try
+            {
+                using(var reader = System.IO.File.OpenText(UNIX_TIME_ZONE_CONFIG_FILE))
+                {
+                    sTimezoneId = reader.ReadLine();
+                }
+            }
+            catch(Exception ex)
+            {
+                throw new Exception($"Could not open and read '{UNIX_TIME_ZONE_CONFIG_FILE}'", ex);
+            }
+            return DateTimeZoneProviders.Tzdb.GetZoneOrNull(sTimezoneId);
+        }
+
         public static DateTimeZone GetZone(string tzId)
         {
             if (string.IsNullOrWhiteSpace(tzId))

--- a/v3/ical-v3.sln
+++ b/v3/ical-v3.sln
@@ -3,11 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ical.Net", "ical.net\Ical.Net.csproj", "{F88DB6D3-CB95-4707-9C88-B53403AADC61}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ical.Net", "ical.NET\Ical.Net.csproj", "{F88DB6D3-CB95-4707-9C88-B53403AADC61}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ical.Net.UnitTests", "ical.net.UnitTests\Ical.Net.UnitTests.csproj", "{38A02D06-15CC-436A-9C8F-07B84A7E2CE0}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ical.Net.UnitTests", "ical.NET.UnitTests\Ical.Net.UnitTests.csproj", "{38A02D06-15CC-436A-9C8F-07B84A7E2CE0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ical.Net.Collections", "ical.net.Collections\ical.net.Collections\Ical.Net.Collections.csproj", "{E04EFEB6-4625-4D58-AC91-7B8B8A2C97BB}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ical.Net.Collections", "ical.NET.Collections\ical.NET.Collections\Ical.Net.Collections.csproj", "{E04EFEB6-4625-4D58-AC91-7B8B8A2C97BB}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "antlr.runtime", "antlr.runtime\antlr.runtime.csproj", "{CB7CC882-ED47-46C0-AAAE-7A437F22F1C6}"
 EndProject

--- a/v3/ical.NET.UnitTests/Ical.Net.UnitTests.csproj
+++ b/v3/ical.NET.UnitTests/Ical.Net.UnitTests.csproj
@@ -102,11 +102,11 @@
       <Project>{cb7cc882-ed47-46c0-aaae-7a437f22f1c6}</Project>
       <Name>antlr.runtime</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Ical.Net.Collections\Ical.Net.Collections\Ical.Net.Collections.csproj">
+    <ProjectReference Include="..\ical.NET.Collections\ical.NET.Collections\Ical.Net.Collections.csproj">
       <Project>{E04EFEB6-4625-4D58-AC91-7B8B8A2C97BB}</Project>
       <Name>Ical.Net.Collections</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Ical.Net\Ical.Net.csproj">
+    <ProjectReference Include="..\ical.NET\Ical.Net.csproj">
       <Project>{F88DB6D3-CB95-4707-9C88-B53403AADC61}</Project>
       <Name>Ical.Net</Name>
     </ProjectReference>

--- a/v3/ical.NET/Ical.Net.csproj
+++ b/v3/ical.NET/Ical.Net.csproj
@@ -238,7 +238,7 @@
       <Project>{cb7cc882-ed47-46c0-aaae-7a437f22f1c6}</Project>
       <Name>antlr.runtime</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Ical.Net.Collections\Ical.Net.Collections\Ical.Net.Collections.csproj">
+    <ProjectReference Include="..\ical.NET.Collections\ical.NET.Collections\Ical.Net.Collections.csproj">
       <Project>{E04EFEB6-4625-4D58-AC91-7B8B8A2C97BB}</Project>
       <Name>Ical.Net.Collections</Name>
     </ProjectReference>


### PR DESCRIPTION
Solve issue #152 

When using Calendar.LoadFromStream on mime content with missing (or local) timezones, default provider (Tzdb) was throwing `NodaTime.TimeZones.DateTimeZoneNotFoundException` at runtime.

