### PR TITLE
Event equality and hashing should take recurrence rules and dates into

### DIFF
--- a/v2/Ical.Net.nuspec
+++ b/v2/Ical.Net.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>Ical.Net</id>
-        <version>2.2.16</version>
+        <version>2.2.17</version>
         <title>Ical.Net</title>
         <authors>Rian Stockbower, Douglas Day, M. David Peterson</authors>
         <owners>Rian Stockbower</owners>

--- a/v2/ical.NET.UnitTests/EqualityAndHashingTests.cs
+++ b/v2/ical.NET.UnitTests/EqualityAndHashingTests.cs
@@ -32,6 +32,16 @@ namespace Ical.Net.UnitTests
             yield return new TestCaseData(nowCalDtWithTz, new CalDateTime(_nowTime, _someTz)).SetName("Now, with time zone");
         }
 
+        [Test]
+        public void RecurrencePatternTests()
+        {
+            var patternA = GetSimpleRecurrencePattern();
+            var patternB = GetSimpleRecurrencePattern();
+
+            Assert.AreEqual(patternA, patternB);
+            Assert.AreEqual(patternA.GetHashCode(), patternB.GetHashCode());
+        }
+
         [Test, TestCaseSource(nameof(Event_TestCases))]
         public void Event_Tests(Event incoming, Event expected)
         {
@@ -46,34 +56,31 @@ namespace Ical.Net.UnitTests
             Assert.IsTrue(incoming.Equals(expected));
         }
 
+        private static RecurrencePattern GetSimpleRecurrencePattern() => new RecurrencePattern(FrequencyType.Daily, 1)
+        {
+            Count = 5
+        };
+
+        private static Event GetSimpleEvent() => new Event
+        {
+            DtStart = new CalDateTime(_nowTime),
+            DtEnd = new CalDateTime(_later),
+            Duration = TimeSpan.FromHours(1),
+        };
+
         public static IEnumerable<ITestCaseData> Event_TestCases()
         {
-            var outgoing = new Event
-            {
-                DtStart = new CalDateTime(_nowTime),
-                DtEnd = new CalDateTime(_later),
-                Duration = TimeSpan.FromHours(1),
-            };
-
-            var expected = new Event
-            {
-                DtStart = new CalDateTime(_nowTime),
-                DtEnd = new CalDateTime(_later),
-                Duration = TimeSpan.FromHours(1),
-            };
+            var outgoing = GetSimpleEvent();
+            var expected = GetSimpleEvent();
             yield return new TestCaseData(outgoing, expected).SetName("Events with start, end, and duration");
 
-            var fiveA = new RecurrencePattern(FrequencyType.Daily, 1)
-            {
-                Count = 5
-            };
+            var fiveA = GetSimpleRecurrencePattern();
+            var fiveB = GetSimpleRecurrencePattern();
 
-            var fiveB = new RecurrencePattern(FrequencyType.Daily, 1)
-            {
-                Count = 5
-            };
-            outgoing.RecurrenceRules = new List<IRecurrencePattern> {fiveA};
-            expected.RecurrenceRules = new List<IRecurrencePattern> {fiveB};
+            outgoing = GetSimpleEvent();
+            expected = GetSimpleEvent();
+            outgoing.RecurrenceRules = new List<IRecurrencePattern> { fiveA };
+            expected.RecurrenceRules = new List<IRecurrencePattern> { fiveB };
             yield return new TestCaseData(outgoing, expected).SetName("Events with start, end, duration, and one recurrence rule");
         }
 

--- a/v2/ical.NET.UnitTests/EventTest.cs
+++ b/v2/ical.NET.UnitTests/EventTest.cs
@@ -3,13 +3,20 @@ using Ical.Net.ExtensionMethods;
 using Ical.Net.Interfaces;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using Ical.Net.Interfaces.DataTypes;
+using NUnit.Framework.Internal;
 
 namespace Ical.Net.UnitTests
 {
     [TestFixture]
     public class EventTest
     {
+        private static readonly DateTime _now = DateTime.UtcNow;
+        private static readonly DateTime _later = _now.AddHours(1);
+
         /// <summary>
         /// Ensures that events can be properly added to a calendar.
         /// </summary>
@@ -152,6 +159,86 @@ namespace Ical.Net.UnitTests
             var lines = serializedCalendar.Split(new string[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries).ToList();
             var result = lines.First(s => s.StartsWith("DTSTAMP"));
             Assert.AreEqual($"DTSTAMP:{evt.DtStamp.Year}{evt.DtStamp.Month:00}{evt.DtStamp.Day:00}T{evt.DtStamp.Hour:00}{evt.DtStamp.Minute:00}{evt.DtStamp.Second:00}Z", result);
+        }
+
+        [Test]
+        public void EventWithExDateShouldNotBeEqualToSameEventWithoutExDate()
+        {
+            const string icalNoException = @"BEGIN:VCALENDAR
+PRODID:-//Telerik Inc.//NONSGML RadScheduler//EN
+VERSION:2.0
+CALSCALE:GREGORIAN
+METHOD:PUBLISH
+BEGIN:VTIMEZONE
+TZID:UTC
+BEGIN:STANDARD
+TZNAME:UTC
+TZOFFSETTO:+0000
+TZOFFSETFROM:+0000
+DTSTART:16010101T000000
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+DTSTART;TZID=UTC:20161020T170000
+DTEND;TZID=UTC:20161020T230000
+UID:694f818f-6d67-4307-9c4d-0b5211686ff0
+IMPORTANCE:None
+RRULE:FREQ=DAILY
+END:VEVENT
+END:VCALENDAR";
+
+            const string icalWithException = @"BEGIN:VCALENDAR
+PRODID:-//Telerik Inc.//NONSGML RadScheduler//EN
+VERSION:2.0
+CALSCALE:GREGORIAN
+METHOD:PUBLISH
+BEGIN:VTIMEZONE
+TZID:UTC
+BEGIN:STANDARD
+TZNAME:UTC
+TZOFFSETTO:+0000
+TZOFFSETFROM:+0000
+DTSTART:16010101T000000
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+DTSTART;TZID=UTC:20161020T170000
+DTEND;TZID=UTC:20161020T230000
+UID:694f818f-6d67-4307-9c4d-0b5211686ff0
+IMPORTANCE:None
+RRULE:FREQ=DAILY
+EXDATE;TZID=UTC:20161020T170000
+END:VEVENT
+END:VCALENDAR";
+
+            var noException = Calendar.LoadFromStream(new StringReader(icalNoException)).First().Events.First();
+            var withException = Calendar.LoadFromStream(new StringReader(icalWithException)).First().Events.First();
+
+            Assert.AreNotEqual(noException, withException);
+            Assert.AreNotEqual(noException.GetHashCode(), withException.GetHashCode());
+        }
+
+        private static Event GetSimpleEvent() => new Event
+        {
+            DtStart = new CalDateTime(_now),
+            DtEnd = new CalDateTime(_later),
+        };
+
+        [Test]
+        public void RrulesAreSignificantTests()
+        {
+            var rrule = new RecurrencePattern(FrequencyType.Daily, 1);
+            var testRrule = GetSimpleEvent();
+            testRrule.RecurrenceRules = new List<IRecurrencePattern> {rrule};
+
+            var simpleEvent = GetSimpleEvent();
+            Assert.AreNotEqual(simpleEvent, testRrule);
+            Assert.AreNotEqual(simpleEvent.GetHashCode(), testRrule.GetHashCode());
+
+            var testRdate = GetSimpleEvent();
+            testRdate.RecurrenceDates = new List<IPeriodList> {new PeriodList {new Period(new CalDateTime(_now))} };
+            Assert.AreNotEqual(simpleEvent, testRdate);
+            Assert.AreNotEqual(simpleEvent.GetHashCode(), testRdate.GetHashCode());
         }
     }
 }

--- a/v2/ical.NET.UnitTests/RecurrenceTests.cs
+++ b/v2/ical.NET.UnitTests/RecurrenceTests.cs
@@ -2944,8 +2944,7 @@ END:VCALENDAR";
         {
             //https://github.com/rianjs/ical.net/issues/121
 
-            const string ical =
-    @"BEGIN:VCALENDAR
+            const string ical = @"BEGIN:VCALENDAR
 PRODID:-//github.com/rianjs/ical.net//NONSGML ical.net 2.2//EN
 VERSION:2.0
 BEGIN:VEVENT
@@ -2953,7 +2952,7 @@ SUMMARY:This is an event
 DTEND;TZID=UTC:20160801T080000
 DTSTAMP:20160905T142724Z
 DTSTART;TZID=UTC:20160801T070000
-RRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=WE;UNTIL=20160901T070000
+RRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=WE;UNTIL=20160831T070000
 UID:abab717c-1786-4efc-87dd-6859c2b48eb6
 END:VEVENT
 END:VCALENDAR";
@@ -3087,63 +3086,6 @@ END:VCALENDAR";
             var expectedSept3End = new CalDateTime(DateTime.Parse("2016-09-01T12:30:00"), "Europe/Bucharest");
             Assert.AreEqual(expectedSept3Start, orderedOccurrences[5].StartTime);
             Assert.AreEqual(expectedSept3End, orderedOccurrences[5].EndTime);
-        }
-
-        [Test]
-        public void EventWithExDateShouldNotBeEqualToSameEventWithoutExDate()
-        {
-            const string icalNoException = @"BEGIN:VCALENDAR
-PRODID:-//Telerik Inc.//NONSGML RadScheduler//EN
-VERSION:2.0
-CALSCALE:GREGORIAN
-METHOD:PUBLISH
-BEGIN:VTIMEZONE
-TZID:UTC
-BEGIN:STANDARD
-TZNAME:UTC
-TZOFFSETTO:+0000
-TZOFFSETFROM:+0000
-DTSTART:16010101T000000
-END:STANDARD
-END:VTIMEZONE
-BEGIN:VEVENT
-DTSTART;TZID=UTC:20161020T170000
-DTEND;TZID=UTC:20161020T230000
-UID:694f818f-6d67-4307-9c4d-0b5211686ff0
-IMPORTANCE:None
-RRULE:FREQ=DAILY
-END:VEVENT
-END:VCALENDAR";
-
-            const string icalWithException = @"BEGIN:VCALENDAR
-PRODID:-//Telerik Inc.//NONSGML RadScheduler//EN
-VERSION:2.0
-CALSCALE:GREGORIAN
-METHOD:PUBLISH
-BEGIN:VTIMEZONE
-TZID:UTC
-BEGIN:STANDARD
-TZNAME:UTC
-TZOFFSETTO:+0000
-TZOFFSETFROM:+0000
-DTSTART:16010101T000000
-END:STANDARD
-END:VTIMEZONE
-BEGIN:VEVENT
-DTSTART;TZID=UTC:20161020T170000
-DTEND;TZID=UTC:20161020T230000
-UID:694f818f-6d67-4307-9c4d-0b5211686ff0
-IMPORTANCE:None
-RRULE:FREQ=DAILY
-EXDATE;TZID=UTC:20161020T170000
-END:VEVENT
-END:VCALENDAR";
-
-            var noException = Calendar.LoadFromStream(new StringReader(icalNoException)).First().Events.First();
-            var withException = Calendar.LoadFromStream(new StringReader(icalWithException)).First().Events.First();
-
-            Assert.AreNotEqual(noException, withException);
-            Assert.AreNotEqual(noException.GetHashCode(), withException.GetHashCode());
         }
     }
 }

--- a/v2/ical.NET.UnitTests/SymmetricSerializationTests.cs
+++ b/v2/ical.NET.UnitTests/SymmetricSerializationTests.cs
@@ -51,11 +51,10 @@ namespace Ical.Net.UnitTests
 
             var calendar = new Calendar();
             calendar.Events.Add(e);
-
             yield return new TestCaseData(calendar).SetName("readme.md example");
+
             e = GetSimpleEvent();
             e.Description = "This is an event description that is really rather long. Hopefully the line breaks work now, and it's serialized properly.";
-
             calendar = new Calendar();
             calendar.Events.Add(e);
             yield return new TestCaseData(calendar).SetName("Description serialization isn't working properly. Issue #60");

--- a/v2/ical.NET/Calendar.cs
+++ b/v2/ical.NET/Calendar.cs
@@ -209,7 +209,7 @@ namespace Ical.Net
         {
             unchecked
             {
-                var hashCode = Name.GetHashCode();
+                var hashCode = Name?.GetHashCode() ?? 0;
                 hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(UniqueComponents);
                 hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(Events);
                 hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(Todos);

--- a/v2/ical.NET/Components/Event.cs
+++ b/v2/ical.NET/Components/Event.cs
@@ -286,7 +286,7 @@ namespace Ical.Net
             var resourcesSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             resourcesSet.UnionWith(Resources);
 
-            return Equals(DtStart, other.DtStart)
+            var result = Equals(DtStart, other.DtStart)
                 && Equals(DtEnd, other.DtEnd)
                 && string.Equals(Location, other.Location, StringComparison.OrdinalIgnoreCase)
                 && resourcesSet.SetEquals(other.Resources)
@@ -296,7 +296,11 @@ namespace Ical.Net
                 && EvaluationIncludesReferenceDate == other.EvaluationIncludesReferenceDate
                 && Attachments.SequenceEqual(other.Attachments)
                 && (ExceptionDates != null && CollectionHelpers.Equals(ExceptionDates, other.ExceptionDates))
-                && (ExceptionRules != null && CollectionHelpers.Equals(ExceptionRules, other.ExceptionRules));
+                && (ExceptionRules != null && CollectionHelpers.Equals(ExceptionRules, other.ExceptionRules))
+                && (RecurrenceRules != null && CollectionHelpers.Equals(RecurrenceRules, other.RecurrenceRules, true))
+                && (RecurrenceDates != null && CollectionHelpers.Equals(RecurrenceDates, other.RecurrenceDates, true));
+                
+            return result;
         }
 
         public override bool Equals(object obj)
@@ -320,6 +324,8 @@ namespace Ical.Net
                 hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(Resources);
                 hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(ExceptionDates);
                 hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(ExceptionRules);
+                hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(RecurrenceRules);
+                hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(RecurrenceDates);
                 return hashCode;
             }
         }

--- a/v2/ical.NET/DataTypes/RecurrencePattern.cs
+++ b/v2/ical.NET/DataTypes/RecurrencePattern.cs
@@ -6,6 +6,7 @@ using Ical.Net.Evaluation;
 using Ical.Net.Interfaces.DataTypes;
 using Ical.Net.Interfaces.General;
 using Ical.Net.Serialization.iCalendar.Serializers.DataTypes;
+using Ical.Net.Utility;
 
 namespace Ical.Net.DataTypes
 {
@@ -106,68 +107,62 @@ namespace Ical.Net.DataTypes
             CopyFrom(serializer.Deserialize(new StringReader(value)) as ICopyable);
         }
 
-        public override bool Equals(object obj)
-        {
-            if (!(obj is RecurrencePattern))
-            {
-                return false;
-            }
-
-            var r = (RecurrencePattern) obj;
-            if (!CollectionEquals(r.ByDay, ByDay) || !CollectionEquals(r.ByHour, ByHour) || !CollectionEquals(r.ByMinute, ByMinute) ||
-                !CollectionEquals(r.ByMonth, ByMonth) || !CollectionEquals(r.ByMonthDay, ByMonthDay) || !CollectionEquals(r.BySecond, BySecond) ||
-                !CollectionEquals(r.BySetPosition, BySetPosition) || !CollectionEquals(r.ByWeekNo, ByWeekNo) || !CollectionEquals(r.ByYearDay, ByYearDay))
-            {
-                return false;
-            }
-            if (r.Count != Count)
-            {
-                return false;
-            }
-            if (r.Frequency != Frequency)
-            {
-                return false;
-            }
-            if (r.Interval != Interval)
-            {
-                return false;
-            }
-            if (r.Until != DateTime.MinValue && !r.Until.Equals(Until))
-            {
-                return false;
-            }
-            if (Until != DateTime.MinValue)
-            {
-                return false;
-            }
-            return r.FirstDayOfWeek == FirstDayOfWeek;
-        }
-
         public override string ToString()
         {
             var serializer = new RecurrencePatternSerializer();
             return serializer.SerializeToString(this);
         }
 
-        //ToDo: This needs a memberwise hash code implementation
+        protected bool Equals(RecurrencePattern other)
+        {
+            return (Interval == other.Interval)
+                && (RestrictionType == other.RestrictionType)
+                && (EvaluationMode == other.EvaluationMode)
+                && (Frequency == other.Frequency)
+                && Until.Equals(other.Until)
+                && (Count == other.Count)
+                && (FirstDayOfWeek == other.FirstDayOfWeek)
+                && CollectionEquals(BySecond, other.BySecond)
+                && CollectionEquals(ByMinute, other.ByMinute)
+                && CollectionEquals(ByHour, other.ByHour)
+                && CollectionEquals(ByDay, other.ByDay)
+                && CollectionEquals(ByMonthDay, other.ByMonthDay)
+                && CollectionEquals(ByYearDay, other.ByYearDay)
+                && CollectionEquals(ByWeekNo, other.ByWeekNo)
+                && CollectionEquals(ByMonth, other.ByMonth)
+                && CollectionEquals(BySetPosition, other.BySetPosition);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((RecurrencePattern) obj);
+        }
+
         public override int GetHashCode()
         {
-            var hashCode = ByDay.GetHashCode() ^ ByHour.GetHashCode() ^ ByMinute.GetHashCode() ^ ByMonth.GetHashCode()
-                ^ ByMonthDay.GetHashCode() ^ BySecond.GetHashCode() ^ BySetPosition.GetHashCode() ^ ByWeekNo.GetHashCode()
-                ^ ByYearDay.GetHashCode() ^ Count.GetHashCode() ^ Frequency.GetHashCode();
-
-            if (Interval.Equals(1))
+            unchecked
             {
-                hashCode ^= 0x1;
+                var hashCode = _interval;
+                hashCode = (hashCode * 397) ^ _restrictionType.GetHashCode();
+                hashCode = (hashCode * 397) ^ _evaluationMode.GetHashCode();
+                hashCode = (hashCode * 397) ^ (int) Frequency;
+                hashCode = (hashCode * 397) ^ Until.GetHashCode();
+                hashCode = (hashCode * 397) ^ Count;
+                hashCode = (hashCode * 397) ^ (int)FirstDayOfWeek;
+                hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(BySecond);
+                hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(ByMinute);
+                hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(ByHour);
+                hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(ByDay);
+                hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(ByMonthDay);
+                hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(ByYearDay);
+                hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(ByWeekNo);
+                hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(ByMonth);
+                hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(BySetPosition);
+                return hashCode;
             }
-            else
-            {
-                hashCode ^= Interval.GetHashCode();
-            }
-
-            hashCode ^= Until.GetHashCode();
-            hashCode ^= FirstDayOfWeek.GetHashCode();
-            return hashCode;
         }
 
         public override void CopyFrom(ICopyable obj)

--- a/v3/ical.NET.UnitTests/EqualityAndHashingTests.cs
+++ b/v3/ical.NET.UnitTests/EqualityAndHashingTests.cs
@@ -31,6 +31,16 @@ namespace Ical.Net.UnitTests
             yield return new TestCaseData(nowCalDtWithTz, new CalDateTime(_nowTime, _someTz)).SetName("Now, with time zone");
         }
 
+        [Test]
+        public void RecurrencePatternTests()
+        {
+            var patternA = GetSimpleRecurrencePattern();
+            var patternB = GetSimpleRecurrencePattern();
+
+            Assert.AreEqual(patternA, patternB);
+            Assert.AreEqual(patternA.GetHashCode(), patternB.GetHashCode());
+        }
+
         [Test, TestCaseSource(nameof(Event_TestCases))]
         public void Event_Tests(CalendarEvent incoming, CalendarEvent expected)
         {
@@ -45,34 +55,31 @@ namespace Ical.Net.UnitTests
             Assert.IsTrue(incoming.Equals(expected));
         }
 
+        private static RecurrencePattern GetSimpleRecurrencePattern() => new RecurrencePattern(FrequencyType.Daily, 1)
+        {
+            Count = 5
+        };
+
+        private static CalendarEvent GetSimpleEvent() => new CalendarEvent
+        {
+            DtStart = new CalDateTime(_nowTime),
+            DtEnd = new CalDateTime(_later),
+            Duration = TimeSpan.FromHours(1),
+        };
+
         public static IEnumerable<ITestCaseData> Event_TestCases()
         {
-            var outgoing = new CalendarEvent
-            {
-                DtStart = new CalDateTime(_nowTime),
-                DtEnd = new CalDateTime(_later),
-                Duration = TimeSpan.FromHours(1),
-            };
-
-            var expected = new CalendarEvent
-            {
-                DtStart = new CalDateTime(_nowTime),
-                DtEnd = new CalDateTime(_later),
-                Duration = TimeSpan.FromHours(1),
-            };
+            var outgoing = GetSimpleEvent();
+            var expected = GetSimpleEvent();
             yield return new TestCaseData(outgoing, expected).SetName("Events with start, end, and duration");
 
-            var fiveA = new RecurrencePattern(FrequencyType.Daily, 1)
-            {
-                Count = 5
-            };
+            var fiveA = GetSimpleRecurrencePattern();
+            var fiveB = GetSimpleRecurrencePattern();
 
-            var fiveB = new RecurrencePattern(FrequencyType.Daily, 1)
-            {
-                Count = 5
-            };
-            outgoing.RecurrenceRules = new List<RecurrencePattern> {fiveA};
-            expected.RecurrenceRules = new List<RecurrencePattern> {fiveB};
+            outgoing = GetSimpleEvent();
+            expected = GetSimpleEvent();
+            outgoing.RecurrenceRules = new List<RecurrencePattern> { fiveA };
+            expected.RecurrenceRules = new List<RecurrencePattern> { fiveB };
             yield return new TestCaseData(outgoing, expected).SetName("Events with start, end, duration, and one recurrence rule");
         }
 

--- a/v3/ical.NET.UnitTests/EventTest.cs
+++ b/v3/ical.NET.UnitTests/EventTest.cs
@@ -2,6 +2,8 @@ using Ical.Net.DataTypes;
 using Ical.Net.ExtensionMethods;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace Ical.Net.UnitTests
@@ -9,6 +11,9 @@ namespace Ical.Net.UnitTests
     [TestFixture]
     public class EventTest
     {
+        private static readonly DateTime _now = DateTime.UtcNow;
+        private static readonly DateTime _later = _now.AddHours(1);
+
         /// <summary>
         /// Ensures that events can be properly added to a calendar.
         /// </summary>
@@ -151,6 +156,86 @@ namespace Ical.Net.UnitTests
             var lines = serializedCalendar.Split(new string[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries).ToList();
             var result = lines.First(s => s.StartsWith("DTSTAMP"));
             Assert.AreEqual($"DTSTAMP:{evt.DtStamp.Year}{evt.DtStamp.Month:00}{evt.DtStamp.Day:00}T{evt.DtStamp.Hour:00}{evt.DtStamp.Minute:00}{evt.DtStamp.Second:00}Z", result);
+        }
+
+        [Test]
+        public void EventWithExDateShouldNotBeEqualToSameEventWithoutExDate()
+        {
+            const string icalNoException = @"BEGIN:VCALENDAR
+PRODID:-//Telerik Inc.//NONSGML RadScheduler//EN
+VERSION:2.0
+CALSCALE:GREGORIAN
+METHOD:PUBLISH
+BEGIN:VTIMEZONE
+TZID:UTC
+BEGIN:STANDARD
+TZNAME:UTC
+TZOFFSETTO:+0000
+TZOFFSETFROM:+0000
+DTSTART:16010101T000000
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+DTSTART;TZID=UTC:20161020T170000
+DTEND;TZID=UTC:20161020T230000
+UID:694f818f-6d67-4307-9c4d-0b5211686ff0
+IMPORTANCE:None
+RRULE:FREQ=DAILY
+END:VEVENT
+END:VCALENDAR";
+
+            const string icalWithException = @"BEGIN:VCALENDAR
+PRODID:-//Telerik Inc.//NONSGML RadScheduler//EN
+VERSION:2.0
+CALSCALE:GREGORIAN
+METHOD:PUBLISH
+BEGIN:VTIMEZONE
+TZID:UTC
+BEGIN:STANDARD
+TZNAME:UTC
+TZOFFSETTO:+0000
+TZOFFSETFROM:+0000
+DTSTART:16010101T000000
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+DTSTART;TZID=UTC:20161020T170000
+DTEND;TZID=UTC:20161020T230000
+UID:694f818f-6d67-4307-9c4d-0b5211686ff0
+IMPORTANCE:None
+RRULE:FREQ=DAILY
+EXDATE;TZID=UTC:20161020T170000
+END:VEVENT
+END:VCALENDAR";
+
+            var noException = Calendar.LoadFromStream(new StringReader(icalNoException)).First().Events.First();
+            var withException = Calendar.LoadFromStream(new StringReader(icalWithException)).First().Events.First();
+
+            Assert.AreNotEqual(noException, withException);
+            Assert.AreNotEqual(noException.GetHashCode(), withException.GetHashCode());
+        }
+
+        private static CalendarEvent GetSimpleEvent() => new CalendarEvent
+        {
+            DtStart = new CalDateTime(_now),
+            DtEnd = new CalDateTime(_later),
+        };
+
+        [Test]
+        public void RrulesAreSignificantTests()
+        {
+            var rrule = new RecurrencePattern(FrequencyType.Daily, 1);
+            var testRrule = GetSimpleEvent();
+            testRrule.RecurrenceRules = new List<RecurrencePattern> { rrule };
+
+            var simpleEvent = GetSimpleEvent();
+            Assert.AreNotEqual(simpleEvent, testRrule);
+            Assert.AreNotEqual(simpleEvent.GetHashCode(), testRrule.GetHashCode());
+
+            var testRdate = GetSimpleEvent();
+            testRdate.RecurrenceDates = new List<PeriodList> { new PeriodList { new Period(new CalDateTime(_now)) } };
+            Assert.AreNotEqual(simpleEvent, testRdate);
+            Assert.AreNotEqual(simpleEvent.GetHashCode(), testRdate.GetHashCode());
         }
     }
 }

--- a/v3/ical.NET.UnitTests/RecurrenceTests.cs
+++ b/v3/ical.NET.UnitTests/RecurrenceTests.cs
@@ -2942,8 +2942,7 @@ END:VCALENDAR";
         {
             //https://github.com/rianjs/ical.net/issues/121
 
-            const string ical =
-    @"BEGIN:VCALENDAR
+            const string ical = @"BEGIN:VCALENDAR
 PRODID:-//github.com/rianjs/ical.net//NONSGML ical.net 2.2//EN
 VERSION:2.0
 BEGIN:VEVENT
@@ -2951,7 +2950,7 @@ SUMMARY:This is an event
 DTEND;TZID=UTC:20160801T080000
 DTSTAMP:20160905T142724Z
 DTSTART;TZID=UTC:20160801T070000
-RRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=WE;UNTIL=20160901T070000
+RRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=WE;UNTIL=20160831T070000
 UID:abab717c-1786-4efc-87dd-6859c2b48eb6
 END:VEVENT
 END:VCALENDAR";
@@ -3085,63 +3084,6 @@ END:VCALENDAR";
             var expectedSept3End = new CalDateTime(DateTime.Parse("2016-09-01T12:30:00"), "Europe/Bucharest");
             Assert.AreEqual(expectedSept3Start, orderedOccurrences[5].StartTime);
             Assert.AreEqual(expectedSept3End, orderedOccurrences[5].EndTime);
-        }
-
-        [Test]
-        public void EventWithExDateShouldNotBeEqualToSameEventWithoutExDate()
-        {
-            const string icalNoException = @"BEGIN:VCALENDAR
-PRODID:-//Telerik Inc.//NONSGML RadScheduler//EN
-VERSION:2.0
-CALSCALE:GREGORIAN
-METHOD:PUBLISH
-BEGIN:VTIMEZONE
-TZID:UTC
-BEGIN:STANDARD
-TZNAME:UTC
-TZOFFSETTO:+0000
-TZOFFSETFROM:+0000
-DTSTART:16010101T000000
-END:STANDARD
-END:VTIMEZONE
-BEGIN:VEVENT
-DTSTART;TZID=UTC:20161020T170000
-DTEND;TZID=UTC:20161020T230000
-UID:694f818f-6d67-4307-9c4d-0b5211686ff0
-IMPORTANCE:None
-RRULE:FREQ=DAILY
-END:VEVENT
-END:VCALENDAR";
-
-            const string icalWithException = @"BEGIN:VCALENDAR
-PRODID:-//Telerik Inc.//NONSGML RadScheduler//EN
-VERSION:2.0
-CALSCALE:GREGORIAN
-METHOD:PUBLISH
-BEGIN:VTIMEZONE
-TZID:UTC
-BEGIN:STANDARD
-TZNAME:UTC
-TZOFFSETTO:+0000
-TZOFFSETFROM:+0000
-DTSTART:16010101T000000
-END:STANDARD
-END:VTIMEZONE
-BEGIN:VEVENT
-DTSTART;TZID=UTC:20161020T170000
-DTEND;TZID=UTC:20161020T230000
-UID:694f818f-6d67-4307-9c4d-0b5211686ff0
-IMPORTANCE:None
-RRULE:FREQ=DAILY
-EXDATE;TZID=UTC:20161020T170000
-END:VEVENT
-END:VCALENDAR";
-
-            var noException = Calendar.LoadFromStream(new StringReader(icalNoException)).First().Events.First();
-            var withException = Calendar.LoadFromStream(new StringReader(icalWithException)).First().Events.First();
-
-            Assert.AreNotEqual(noException, withException);
-            Assert.AreNotEqual(noException.GetHashCode(), withException.GetHashCode());
         }
     }
 }

--- a/v3/ical.NET.UnitTests/SymmetricSerializationTests.cs
+++ b/v3/ical.NET.UnitTests/SymmetricSerializationTests.cs
@@ -39,7 +39,7 @@ namespace Ical.Net.UnitTests
 
         public static IEnumerable<ITestCaseData> Event_TestCases()
         {
-            var rrule = new RecurrencePattern(FrequencyType.Daily, 1) { Count = 5};
+            var rrule = new RecurrencePattern(FrequencyType.Daily, 1) { Count = 5 };
             var e = new CalendarEvent
             {
                 DtStart = new CalDateTime(_nowTime),
@@ -50,11 +50,10 @@ namespace Ical.Net.UnitTests
 
             var calendar = new Calendar();
             calendar.Events.Add(e);
-
             yield return new TestCaseData(calendar).SetName("readme.md example");
+
             e = GetSimpleEvent();
             e.Description = "This is an event description that is really rather long. Hopefully the line breaks work now, and it's serialized properly.";
-
             calendar = new Calendar();
             calendar.Events.Add(e);
             yield return new TestCaseData(calendar).SetName("Description serialization isn't working properly. Issue #60");

--- a/v3/ical.NET/Calendar.cs
+++ b/v3/ical.NET/Calendar.cs
@@ -208,7 +208,7 @@ namespace Ical.Net
         {
             unchecked
             {
-                var hashCode = Name.GetHashCode();
+                var hashCode = Name?.GetHashCode() ?? 0;
                 hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(UniqueComponents);
                 hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(Events);
                 hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(Todos);

--- a/v3/ical.NET/Components/CalendarEvent.cs
+++ b/v3/ical.NET/Components/CalendarEvent.cs
@@ -287,7 +287,7 @@ namespace Ical.Net
             var resourcesSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             resourcesSet.UnionWith(Resources);
 
-            return Equals(DtStart, other.DtStart)
+            var result = Equals(DtStart, other.DtStart)
                 && Equals(DtEnd, other.DtEnd)
                 && string.Equals(Location, other.Location, StringComparison.OrdinalIgnoreCase)
                 && resourcesSet.SetEquals(other.Resources)
@@ -297,7 +297,11 @@ namespace Ical.Net
                 && EvaluationIncludesReferenceDate == other.EvaluationIncludesReferenceDate
                 && Attachments.SequenceEqual(other.Attachments)
                 && (ExceptionDates != null && CollectionHelpers.Equals(ExceptionDates, other.ExceptionDates))
-                && (ExceptionRules != null && CollectionHelpers.Equals(ExceptionRules, other.ExceptionRules));
+                && (ExceptionRules != null && CollectionHelpers.Equals(ExceptionRules, other.ExceptionRules))
+                && (RecurrenceRules != null && CollectionHelpers.Equals(RecurrenceRules, other.RecurrenceRules, true))
+                && (RecurrenceDates != null && CollectionHelpers.Equals(RecurrenceDates, other.RecurrenceDates, true));
+
+            return result;
         }
 
         public override bool Equals(object obj)
@@ -321,6 +325,8 @@ namespace Ical.Net
                 hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(Resources);
                 hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(ExceptionDates);
                 hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(ExceptionRules);
+                hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(RecurrenceRules);
+                hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(RecurrenceDates);
                 return hashCode;
             }
         }

--- a/v3/ical.NET/DataTypes/RecurrencePattern.cs
+++ b/v3/ical.NET/DataTypes/RecurrencePattern.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Ical.Net.Evaluation;
 using Ical.Net.Interfaces.General;
 using Ical.Net.Serialization.iCalendar.Serializers.DataTypes;
+using Ical.Net.Utility;
 
 namespace Ical.Net.DataTypes
 {
@@ -105,68 +106,62 @@ namespace Ical.Net.DataTypes
             CopyFrom(serializer.Deserialize(new StringReader(value)) as ICopyable);
         }
 
-        public override bool Equals(object obj)
-        {
-            if (!(obj is RecurrencePattern))
-            {
-                return false;
-            }
-
-            var r = (RecurrencePattern) obj;
-            if (!CollectionEquals(r.ByDay, ByDay) || !CollectionEquals(r.ByHour, ByHour) || !CollectionEquals(r.ByMinute, ByMinute) ||
-                !CollectionEquals(r.ByMonth, ByMonth) || !CollectionEquals(r.ByMonthDay, ByMonthDay) || !CollectionEquals(r.BySecond, BySecond) ||
-                !CollectionEquals(r.BySetPosition, BySetPosition) || !CollectionEquals(r.ByWeekNo, ByWeekNo) || !CollectionEquals(r.ByYearDay, ByYearDay))
-            {
-                return false;
-            }
-            if (r.Count != Count)
-            {
-                return false;
-            }
-            if (r.Frequency != Frequency)
-            {
-                return false;
-            }
-            if (r.Interval != Interval)
-            {
-                return false;
-            }
-            if (r.Until != DateTime.MinValue && !r.Until.Equals(Until))
-            {
-                return false;
-            }
-            if (Until != DateTime.MinValue)
-            {
-                return false;
-            }
-            return r.FirstDayOfWeek == FirstDayOfWeek;
-        }
-
         public override string ToString()
         {
             var serializer = new RecurrencePatternSerializer();
             return serializer.SerializeToString(this);
         }
 
-        //ToDo: This needs a memberwise hash code implementation
+        protected bool Equals(RecurrencePattern other)
+        {
+            return (Interval == other.Interval)
+                && (RestrictionType == other.RestrictionType)
+                && (EvaluationMode == other.EvaluationMode)
+                && (Frequency == other.Frequency)
+                && Until.Equals(other.Until)
+                && (Count == other.Count)
+                && (FirstDayOfWeek == other.FirstDayOfWeek)
+                && CollectionEquals(BySecond, other.BySecond)
+                && CollectionEquals(ByMinute, other.ByMinute)
+                && CollectionEquals(ByHour, other.ByHour)
+                && CollectionEquals(ByDay, other.ByDay)
+                && CollectionEquals(ByMonthDay, other.ByMonthDay)
+                && CollectionEquals(ByYearDay, other.ByYearDay)
+                && CollectionEquals(ByWeekNo, other.ByWeekNo)
+                && CollectionEquals(ByMonth, other.ByMonth)
+                && CollectionEquals(BySetPosition, other.BySetPosition);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((RecurrencePattern)obj);
+        }
+
         public override int GetHashCode()
         {
-            var hashCode = ByDay.GetHashCode() ^ ByHour.GetHashCode() ^ ByMinute.GetHashCode() ^ ByMonth.GetHashCode()
-                ^ ByMonthDay.GetHashCode() ^ BySecond.GetHashCode() ^ BySetPosition.GetHashCode() ^ ByWeekNo.GetHashCode()
-                ^ ByYearDay.GetHashCode() ^ Count.GetHashCode() ^ Frequency.GetHashCode();
-
-            if (Interval.Equals(1))
+            unchecked
             {
-                hashCode ^= 0x1;
+                var hashCode = Interval;
+                hashCode = (hashCode * 397) ^ RestrictionType.GetHashCode();
+                hashCode = (hashCode * 397) ^ EvaluationMode.GetHashCode();
+                hashCode = (hashCode * 397) ^ (int)Frequency;
+                hashCode = (hashCode * 397) ^ Until.GetHashCode();
+                hashCode = (hashCode * 397) ^ Count;
+                hashCode = (hashCode * 397) ^ (int)FirstDayOfWeek;
+                hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(BySecond);
+                hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(ByMinute);
+                hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(ByHour);
+                hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(ByDay);
+                hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(ByMonthDay);
+                hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(ByYearDay);
+                hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(ByWeekNo);
+                hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(ByMonth);
+                hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(BySetPosition);
+                return hashCode;
             }
-            else
-            {
-                hashCode ^= Interval.GetHashCode();
-            }
-
-            hashCode ^= Until.GetHashCode();
-            hashCode ^= FirstDayOfWeek.GetHashCode();
-            return hashCode;
         }
 
         public override void CopyFrom(ICopyable obj)


### PR DESCRIPTION
account. Necessitated creating reasonable equality and hashing methods for
RecurrencePattern objects, finally #181
