### PR TITLE
DURATION and DTEND are mutually exclusive, so use DTEND during serialization because it's more powerful

### DIFF
--- a/v2/Ical.Net.nuspec
+++ b/v2/Ical.Net.nuspec
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>Ical.Net</id>
-        <version>2.2.21</version>
+        <version>2.2.22</version>
         <title>Ical.Net</title>
         <authors>Rian Stockbower, Douglas Day, M. David Peterson</authors>
         <owners>Rian Stockbower</owners>

--- a/v2/ical.NET.UnitTests/SerializationTests.cs
+++ b/v2/ical.NET.UnitTests/SerializationTests.cs
@@ -364,8 +364,9 @@ namespace Ical.Net.UnitTests
             var originalDuration = e.Duration;
             var c = new Calendar();
             c.Events.Add(e);
-            SerializeToString(c);
+            var serialized = SerializeToString(c);
             Assert.AreEqual(originalDuration, e.Duration);
+            Assert.IsTrue(!serialized.Contains("DURATION"));
         }
     }
 }

--- a/v2/ical.NET/Serialization/iCalendar/Serializers/Components/EventSerializer.cs
+++ b/v2/ical.NET/Serialization/iCalendar/Serializers/Components/EventSerializer.cs
@@ -11,10 +11,16 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.Components
         {
             var evt = obj as IEvent;
 
-            var actualEvent = evt.Properties.ContainsKey("DURATION") && evt.Properties.ContainsKey("DTEND")
-                ? evt.Copy<IEvent>()
-                : evt;
-
+            IEvent actualEvent;
+            if (evt.Properties.ContainsKey("DURATION") && evt.Properties.ContainsKey("DTEND"))
+            {
+                actualEvent = evt.Copy<IEvent>();
+                actualEvent.Properties.Remove("DURATION");
+            }
+            else
+            {
+                actualEvent = evt;
+            }
             return base.SerializeToString(actualEvent);
         }
     }

--- a/v3/ical.NET.UnitTests/SerializationTests.cs
+++ b/v3/ical.NET.UnitTests/SerializationTests.cs
@@ -363,8 +363,9 @@ namespace Ical.Net.UnitTests
             var originalDuration = e.Duration;
             var c = new Calendar();
             c.Events.Add(e);
-            SerializeToString(c);
+            var serialized = SerializeToString(c);
             Assert.AreEqual(originalDuration, e.Duration);
+            Assert.IsTrue(!serialized.Contains("DURATION"));
         }
     }
 }

--- a/v3/ical.NET/Serialization/iCalendar/Serializers/Components/EventSerializer.cs
+++ b/v3/ical.NET/Serialization/iCalendar/Serializers/Components/EventSerializer.cs
@@ -10,10 +10,16 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.Components
         {
             var evt = obj as CalendarEvent;
 
-            var actualEvent = evt.Properties.ContainsKey("DURATION") && evt.Properties.ContainsKey("DTEND")
-                ? evt.Copy<CalendarEvent>()
-                : evt;
-
+            CalendarEvent actualEvent;
+            if (evt.Properties.ContainsKey("DURATION") && evt.Properties.ContainsKey("DTEND"))
+            {
+                actualEvent = evt.Copy<CalendarEvent>();
+                actualEvent.Properties.Remove("DURATION");
+            }
+            else
+            {
+                actualEvent = evt;
+            }
             return base.SerializeToString(actualEvent);
         }
     }


### PR DESCRIPTION
 #199