### PR TITLE
Faster deserialization

### DIFF
--- a/net-core/Ical.Net/Ical.Net.Collections/Ical.Net.Collections.csproj
+++ b/net-core/Ical.Net/Ical.Net.Collections/Ical.Net.Collections.csproj
@@ -3,11 +3,6 @@
     <TargetFramework>netstandard1.4</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="**\*.cs" />
-    <EmbeddedResource Include="**\*.resx" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="NETStandard.Library" Version="1.6" />
     <PackageReference Include="System.Linq" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/net-core/Ical.Net/Ical.Net.UnitTests/Ical.Net.UnitTests.csproj
+++ b/net-core/Ical.Net/Ical.Net.UnitTests/Ical.Net.UnitTests.csproj
@@ -6,11 +6,6 @@
     <OutputType>library</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="**\*.cs" />
-    <EmbeddedResource Include="**\*.resx" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="NETStandard.Library" Version="1.6" />
     <PackageReference Include="NUnit" Version="3.6.0" />
   </ItemGroup>
   <ItemGroup>

--- a/net-core/Ical.Net/Ical.Net.UnitTests/SimpleDeserializationTests.cs
+++ b/net-core/Ical.Net/Ical.Net.UnitTests/SimpleDeserializationTests.cs
@@ -1,0 +1,511 @@
+﻿using Ical.Net.DataTypes;
+using Ical.Net.General;
+using Ical.Net.Interfaces;
+using Ical.Net.Interfaces.Components;
+using Ical.Net.Interfaces.DataTypes;
+using Ical.Net.Interfaces.General;
+using Ical.Net.Serialization;
+using Ical.Net.Serialization.iCalendar.Serializers;
+using Ical.Net.Serialization.iCalendar.Serializers.Other;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Ical.Net.UnitTests
+{
+    [TestFixture]
+    public class SimpleDeserializationTests
+    {
+
+        [Test, Category("Deserialization")]
+        public void Attendee1()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Attendee1)).Cast<Calendar>().Single();
+            Assert.AreEqual(1, iCal.Events.Count);
+
+            var evt = iCal.Events.First();
+            // Ensure there are 2 attendees
+            Assert.AreEqual(2, evt.Attendees.Count);
+
+            var attendee1 = evt.Attendees[0];
+            var attendee2 = evt.Attendees[1];
+
+            // Values
+            Assert.AreEqual(new Uri("mailto:joecool@example.com"), attendee1.Value);
+            Assert.AreEqual(new Uri("mailto:ildoit@example.com"), attendee2.Value);
+
+            // MEMBERS
+            Assert.AreEqual(1, attendee1.Members.Count);
+            Assert.AreEqual(0, attendee2.Members.Count);
+            Assert.AreEqual(new Uri("mailto:DEV-GROUP@example.com"), attendee1.Members[0]);
+
+            // DELEGATED-FROM
+            Assert.AreEqual(0, attendee1.DelegatedFrom.Count);
+            Assert.AreEqual(1, attendee2.DelegatedFrom.Count);
+            Assert.AreEqual(new Uri("mailto:immud@example.com"), attendee2.DelegatedFrom[0]);
+
+            // DELEGATED-TO
+            Assert.AreEqual(0, attendee1.DelegatedTo.Count);
+            Assert.AreEqual(0, attendee2.DelegatedTo.Count);
+        }
+
+        /// <summary>
+        /// Tests that multiple parameters of the
+        /// same name are correctly aggregated into
+        /// a single list.
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void Attendee2()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Attendee2)).Cast<Calendar>().Single();
+            Assert.AreEqual(1, iCal.Events.Count);
+
+            var evt = iCal.Events.First();
+            // Ensure there is 1 attendee
+            Assert.AreEqual(1, evt.Attendees.Count);
+
+            var attendee1 = evt.Attendees[0];
+
+            // Values
+            Assert.AreEqual(new Uri("mailto:joecool@example.com"), attendee1.Value);
+
+            // MEMBERS
+            Assert.AreEqual(3, attendee1.Members.Count);
+            Assert.AreEqual(new Uri("mailto:DEV-GROUP@example.com"), attendee1.Members[0]);
+            Assert.AreEqual(new Uri("mailto:ANOTHER-GROUP@example.com"), attendee1.Members[1]);
+            Assert.AreEqual(new Uri("mailto:THIRD-GROUP@example.com"), attendee1.Members[2]);
+        }
+
+        /// <summary>
+        /// Tests that Lotus Notes-style properties are properly handled.
+        /// https://sourceforge.net/tracker/?func=detail&aid=2033495&group_id=187422&atid=921236
+        /// Sourceforge bug #2033495
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void Bug2033495()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Bug2033495)).Cast<Calendar>().Single();
+            Assert.AreEqual(1, iCal.Events.Count);
+            Assert.AreEqual(iCal.Properties["X-LOTUS-CHILD_UID"].Value, "XXX");
+        }
+
+        /// <summary>
+        /// Tests bug #2938007 - involving the HasTime property in IDateTime values.
+        /// See https://sourceforge.net/tracker/?func=detail&aid=2938007&group_id=187422&atid=921236
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void Bug2938007()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Bug2938007)).Cast<Calendar>().Single();
+            Assert.AreEqual(1, iCal.Events.Count);
+
+            var evt = iCal.Events.First();
+            Assert.AreEqual(true, evt.Start.HasTime);
+            Assert.AreEqual(true, evt.End.HasTime);
+
+            foreach (var o in evt.GetOccurrences(new CalDateTime(2010, 1, 17, 0, 0, 0), new CalDateTime(2010, 2, 1, 0, 0, 0)))
+            {
+                Assert.AreEqual(true, o.Period.StartTime.HasTime);
+                Assert.AreEqual(true, o.Period.EndTime.HasTime);
+            }
+        }
+
+        /// <summary>
+        /// Tests bug #3177278 - Serialize closes stream
+        /// See https://sourceforge.net/tracker/?func=detail&aid=3177278&group_id=187422&atid=921236
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void Bug3177278()
+        {
+            var calendar = new Calendar();
+            var serializer = new CalendarSerializer();
+
+            var ms = new MemoryStream();
+            serializer.Serialize(calendar, ms, Encoding.UTF8);
+
+            Assert.IsTrue(ms.CanWrite);
+        }
+
+        /// <summary>
+        /// Tests that a mixed-case VERSION property is loaded properly
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void CaseInsensitive4()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.CaseInsensitive4)).Cast<Calendar>().Single();
+            Assert.AreEqual("2.5", iCal.Version);
+        }
+
+        [Test, Category("Deserialization")]
+        public void Categories1_2()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Categories1)).Cast<Calendar>().Single();
+            ProgramTest.TestCal(iCal);
+            var evt = iCal.Events.First();
+
+            var items = new List<string>();
+            items.AddRange(new[]
+            {
+                "One", "Two", "Three",
+                "Four", "Five", "Six",
+                "Seven", "A string of text with nothing less than a comma, semicolon; and a newline\n."
+            });
+
+            var found = new Dictionary<string, bool>();
+            foreach (var s in evt.Categories.Where(s => items.Contains(s)))
+            {
+                found[s] = true;
+            }
+
+            foreach (string item in items)
+                Assert.IsTrue(found.ContainsKey(item), "Event should contain CATEGORY '" + item + "', but it was not found.");
+        }
+
+        [Test, Category("Deserialization")]
+        public void EmptyLines1()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.EmptyLines1)).Cast<Calendar>().Single();
+            Assert.AreEqual(2, iCal.Events.Count, "iCalendar should have 2 events");
+        }
+
+        [Test, Category("Deserialization")]
+        public void EmptyLines2()
+        {
+            var calendars = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.EmptyLines2)).Cast<Calendar>().ToList();
+            Assert.AreEqual(2, calendars.Count);
+            Assert.AreEqual(2, calendars[0].Events.Count, "iCalendar should have 2 events");
+            Assert.AreEqual(2, calendars[1].Events.Count, "iCalendar should have 2 events");
+        }
+
+        /// <summary>
+        /// Verifies that blank lines between components are allowed
+        /// (as occurs with some applications/parsers - i.e. KOrganizer)
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void EmptyLines3()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.EmptyLines3)).Cast<Calendar>().Single();
+            Assert.AreEqual(1, iCal.Todos.Count, "iCalendar should have 1 todo");
+        }
+
+        /// <summary>
+        /// Similar to PARSE4 and PARSE5 tests.
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void EmptyLines4()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.EmptyLines4)).Cast<Calendar>().Single();
+            Assert.AreEqual(28, iCal.Events.Count);
+        }
+
+        [Test]
+        public void Encoding2()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Encoding2)).Cast<Calendar>().Single();
+            ProgramTest.TestCal(iCal);
+            var evt = iCal.Events.First();
+
+            Assert.AreEqual(
+"This is a test to try out base64 encoding without being too large.\r\n" +
+"This is a test to try out base64 encoding without being too large.\r\n" +
+"This is a test to try out base64 encoding without being too large.\r\n" +
+"This is a test to try out base64 encoding without being too large.\r\n" +
+"This is a test to try out base64 encoding without being too large.\r\n" +
+"This is a test to try out base64 encoding without being too large.\r\n" +
+"This is a test to try out base64 encoding without being too large.\r\n" +
+"This is a test to try out base64 encoding without being too large.\r\n" +
+"This is a test to try out base64 encoding without being too large.\r\n" +
+"This is a test to try out base64 encoding without being too large.\r\n" +
+"This is a test to try out base64 encoding without being too large.\r\n" +
+"This is a test to try out base64 encoding without being too large.",
+                evt.Attachments[0].ToString(),
+                "Attached value does not match.");
+        }
+
+        [Test]
+        public void Encoding3()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Encoding3)).Cast<Calendar>().Single();
+            ProgramTest.TestCal(iCal);
+            var evt = iCal.Events.First();
+
+            Assert.AreEqual("uuid1153170430406", evt.Uid, "UID should be 'uuid1153170430406'; it is " + evt.Uid);
+            Assert.AreEqual(1, evt.Sequence, "SEQUENCE should be 1; it is " + evt.Sequence);
+        }
+
+        [Test, Category("Deserialization")]
+        public void Event8()
+        {
+            var sr = new StringReader(@"BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Computer\, Inc//iCal 1.0//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+CREATED:20070404T211714Z
+DTEND:20070407T010000Z
+DTSTAMP:20070404T211714Z
+DTSTART:20070406T230000Z
+DURATION:PT2H
+RRULE:FREQ=WEEKLY;UNTIL=20070801T070000Z;BYDAY=FR
+SUMMARY:Friday Meetings
+DTSTAMP:20040103T033800Z
+SEQUENCE:1
+UID:fd940618-45e2-4d19-b118-37fd7a8e3906
+END:VEVENT
+BEGIN:VEVENT
+CREATED:20070404T204310Z
+DTEND:20070416T030000Z
+DTSTAMP:20070404T204310Z
+DTSTART:20070414T200000Z
+DURATION:P1DT7H
+RRULE:FREQ=DAILY;COUNT=12;BYDAY=SA,SU
+SUMMARY:Weekend Yea!
+DTSTAMP:20040103T033800Z
+SEQUENCE:1
+UID:ebfbd3e3-cc1e-4a64-98eb-ced2598b3908
+END:VEVENT
+END:VCALENDAR
+");
+            var iCal = SimpleDeserializer.Default.Deserialize(sr).Cast<Calendar>().Single();
+            Assert.IsTrue(iCal.Events.Count == 2, "There should be 2 events in the parsed calendar");
+            Assert.IsNotNull(iCal.Events["fd940618-45e2-4d19-b118-37fd7a8e3906"], "Event fd940618-45e2-4d19-b118-37fd7a8e3906 should exist in the calendar");
+            Assert.IsNotNull(iCal.Events["ebfbd3e3-cc1e-4a64-98eb-ced2598b3908"], "Event ebfbd3e3-cc1e-4a64-98eb-ced2598b3908 should exist in the calendar");
+        }
+
+        [Test]
+        public void GeographicLocation1_2()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.GeographicLocation1)).Cast<Calendar>().Single();
+            ProgramTest.TestCal(iCal);
+            var evt = iCal.Events.First();
+
+            Assert.AreEqual(37.386013, evt.GeographicLocation.Latitude, "Latitude should be 37.386013; it is not.");
+            Assert.AreEqual(-122.082932, evt.GeographicLocation.Longitude, "Longitude should be -122.082932; it is not.");
+        }
+
+        [Test, Category("Deserialization")]
+        public void Google1()
+        {
+            var tzId = "Europe/Berlin";
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Google1)).Cast<Calendar>().Single();
+            var evt = iCal.Events["594oeajmftl3r9qlkb476rpr3c@google.com"];
+            Assert.IsNotNull(evt);
+
+            IDateTime dtStart = new CalDateTime(2006, 12, 18, tzId);
+            IDateTime dtEnd = new CalDateTime(2006, 12, 23, tzId);
+            var occurrences = iCal.GetOccurrences(dtStart, dtEnd).OrderBy(o => o.Period.StartTime).ToList();
+
+            var dateTimes = new[]
+            {
+                new CalDateTime(2006, 12, 18, 7, 0, 0, tzId),
+                new CalDateTime(2006, 12, 19, 7, 0, 0, tzId),
+                new CalDateTime(2006, 12, 20, 7, 0, 0, tzId),
+                new CalDateTime(2006, 12, 21, 7, 0, 0, tzId),
+                new CalDateTime(2006, 12, 22, 7, 0, 0, tzId)
+            };
+
+            for (var i = 0; i < dateTimes.Length; i++)
+                Assert.AreEqual(dateTimes[i], occurrences[i].Period.StartTime, "Event should occur at " + dateTimes[i]);
+
+            Assert.AreEqual(dateTimes.Length, occurrences.Count, "There should be exactly " + dateTimes.Length + " occurrences; there were " + occurrences.Count);
+        }
+
+        /// <summary>
+        /// Tests that valid RDATE properties are parsed correctly.
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void RecurrenceDates1()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.RecurrenceDates1)).Cast<Calendar>().Single();
+            Assert.AreEqual(1, iCal.Events.Count);
+            Assert.AreEqual(3, iCal.Events.First().RecurrenceDates.Count);
+
+            Assert.AreEqual((CalDateTime)new DateTime(1997, 7, 14, 12, 30, 0, DateTimeKind.Utc), iCal.Events.First().RecurrenceDates[0][0].StartTime);
+            Assert.AreEqual((CalDateTime)new DateTime(1996, 4, 3, 2, 0, 0, DateTimeKind.Utc), iCal.Events.First().RecurrenceDates[1][0].StartTime);
+            Assert.AreEqual((CalDateTime)new DateTime(1996, 4, 3, 4, 0, 0, DateTimeKind.Utc), iCal.Events.First().RecurrenceDates[1][0].EndTime);
+            Assert.AreEqual(new CalDateTime(1997, 1, 1), iCal.Events.First().RecurrenceDates[2][0].StartTime);
+            Assert.AreEqual(new CalDateTime(1997, 1, 20), iCal.Events.First().RecurrenceDates[2][1].StartTime);
+            Assert.AreEqual(new CalDateTime(1997, 2, 17), iCal.Events.First().RecurrenceDates[2][2].StartTime);
+            Assert.AreEqual(new CalDateTime(1997, 4, 21), iCal.Events.First().RecurrenceDates[2][3].StartTime);
+            Assert.AreEqual(new CalDateTime(1997, 5, 26), iCal.Events.First().RecurrenceDates[2][4].StartTime);
+            Assert.AreEqual(new CalDateTime(1997, 7, 4), iCal.Events.First().RecurrenceDates[2][5].StartTime);
+            Assert.AreEqual(new CalDateTime(1997, 9, 1), iCal.Events.First().RecurrenceDates[2][6].StartTime);
+            Assert.AreEqual(new CalDateTime(1997, 10, 14), iCal.Events.First().RecurrenceDates[2][7].StartTime);
+            Assert.AreEqual(new CalDateTime(1997, 11, 28), iCal.Events.First().RecurrenceDates[2][8].StartTime);
+            Assert.AreEqual(new CalDateTime(1997, 11, 29), iCal.Events.First().RecurrenceDates[2][9].StartTime);
+            Assert.AreEqual(new CalDateTime(1997, 12, 25), iCal.Events.First().RecurrenceDates[2][10].StartTime);
+        }
+
+        /// <summary>
+        /// Tests that valid REQUEST-STATUS properties are parsed correctly.
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void RequestStatus1()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.RequestStatus1)).Cast<Calendar>().Single();
+            Assert.AreEqual(1, iCal.Events.Count);
+            Assert.AreEqual(4, iCal.Events.First().RequestStatuses.Count);
+
+            var rs = iCal.Events.First().RequestStatuses[0];
+            Assert.AreEqual(2, rs.StatusCode.Primary);
+            Assert.AreEqual(0, rs.StatusCode.Secondary);
+            Assert.AreEqual("Success", rs.Description);
+            Assert.IsNull(rs.ExtraData);
+
+            rs = iCal.Events.First().RequestStatuses[1];
+            Assert.AreEqual(3, rs.StatusCode.Primary);
+            Assert.AreEqual(1, rs.StatusCode.Secondary);
+            Assert.AreEqual("Invalid property value", rs.Description);
+            Assert.AreEqual("DTSTART:96-Apr-01", rs.ExtraData);
+
+            rs = iCal.Events.First().RequestStatuses[2];
+            Assert.AreEqual(2, rs.StatusCode.Primary);
+            Assert.AreEqual(8, rs.StatusCode.Secondary);
+            Assert.AreEqual(" Success, repeating event ignored. Scheduled as a single event.", rs.Description);
+            Assert.AreEqual("RRULE:FREQ=WEEKLY;INTERVAL=2", rs.ExtraData);
+
+            rs = iCal.Events.First().RequestStatuses[3];
+            Assert.AreEqual(4, rs.StatusCode.Primary);
+            Assert.AreEqual(1, rs.StatusCode.Secondary);
+            Assert.AreEqual("Event conflict. Date/time is busy.", rs.Description);
+            Assert.IsNull(rs.ExtraData);
+        }
+
+        /// <summary>
+        /// Tests that string escaping works with Text elements.
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void String2()
+        {
+            var serializer = new StringSerializer();
+            var value = @"test\with\;characters";
+            var unescaped = (string)serializer.Deserialize(new StringReader(value));
+
+            Assert.AreEqual(@"test\with;characters", unescaped, "String unescaping was incorrect.");
+
+            value = @"C:\Path\To\My\New\Information";
+            unescaped = (string)serializer.Deserialize(new StringReader(value));
+            Assert.AreEqual("C:\\Path\\To\\My\new\\Information", unescaped, "String unescaping was incorrect.");
+
+            value = @"\""This\r\nis\Na\, test\""\;\\;,";
+            unescaped = (string)serializer.Deserialize(new StringReader(value));
+
+            Assert.AreEqual("\"This\\r\nis\na, test\";\\;,", unescaped, "String unescaping was incorrect.");
+        }
+
+        [Test, Category("Deserialization")]
+        public void Transparency2()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Transparency2)).Cast<Calendar>().Single();
+
+            Assert.AreEqual(1, iCal.Events.Count);
+            var evt = iCal.Events.First();
+
+            Assert.AreEqual(TransparencyType.Transparent, evt.Transparency);
+        }
+
+        /// <summary>
+        /// Tests that DateTime values that are out-of-range are still parsed correctly
+        /// and set to the closest representable date/time in .NET.
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void DateTime1()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.DateTime1)).Cast<Calendar>().Single();
+            Assert.AreEqual(6, iCal.Events.Count);
+
+            var evt = iCal.Events["nc2o66s0u36iesitl2l0b8inn8@google.com"];
+            Assert.IsNotNull(evt);
+
+            // The "Created" date is out-of-bounds.  It should be coerced to the
+            // closest representable date/time.
+            Assert.AreEqual(DateTime.MinValue, evt.Created.Value);
+        }
+
+        [Test, Category("Deserialization")]
+        public void Language4()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Language4)).Cast<Calendar>().Single();
+            Assert.IsNotNull(iCal);
+        }
+
+        [Test, Category("Deserialization")]
+        public void Outlook2007_LineFolds1()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Outlook2007LineFolds)).Cast<Calendar>().Single();
+            var events = iCal.GetOccurrences(new CalDateTime(2009, 06, 20), new CalDateTime(2009, 06, 22));
+            Assert.AreEqual(1, events.Count);
+        }
+
+        [Test, Category("Deserialization")]
+        public void Outlook2007_LineFolds2()
+        {
+            var longName = "The Exceptionally Long Named Meeting Room Whose Name Wraps Over Several Lines When Exported From Leading Calendar and Office Software Application Microsoft Office 2007";
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Outlook2007LineFolds)).Cast<Calendar>().Single();
+            var events = iCal.GetOccurrences<CalendarEvent>(new CalDateTime(2009, 06, 20), new CalDateTime(2009, 06, 22)).OrderBy(o => o.Period.StartTime).ToList();
+            Assert.AreEqual(longName, ((CalendarEvent)events[0].Source).Location);
+        }
+
+        /// <summary>
+        /// Tests that multiple parameters are allowed in iCalObjects
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void Parameter1()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Parameter1)).Cast<Calendar>().Single();
+
+            var evt = iCal.Events.First();
+            IList<CalendarParameter> parms = evt.Properties["DTSTART"].Parameters.AllOf("VALUE").ToList();
+            Assert.AreEqual(2, parms.Count);
+            Assert.AreEqual("DATE", parms[0].Values.First());
+            Assert.AreEqual("OTHER", parms[1].Values.First());
+        }
+
+        /// <summary>
+        /// Tests that empty parameters are allowed in iCalObjects
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void Parameter2()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Parameter2)).Cast<Calendar>().Single();
+            Assert.AreEqual(2, iCal.Events.Count);
+        }
+
+        /// <summary>
+        /// Tests a calendar that should fail to properly parse.
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void Parse1()
+        {
+            try
+            {
+                var content = IcsFiles.Parse1;
+                var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(content)).Cast<Calendar>().Single();
+                Assert.IsNotNull(iCal);
+            }
+            catch (Exception e)
+            {
+                Assert.IsInstanceOf<SerializationException>(e);
+            }
+        }
+
+        /// <summary>
+        /// Tests that multiple properties are allowed in iCalObjects
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void Property1()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Property1)).Cast<Calendar>().Single();
+
+            IList<ICalendarProperty> props = iCal.Properties.AllOf("VERSION").ToList();
+            Assert.AreEqual(2, props.Count);
+
+            for (var i = 0; i < props.Count; i++)
+                Assert.AreEqual("2." + i, props[i].Value);
+        }
+    }
+}

--- a/net-core/Ical.Net/Ical.Net/Ical.Net.csproj
+++ b/net-core/Ical.Net/Ical.Net/Ical.Net.csproj
@@ -6,11 +6,6 @@
     <OutputType>library</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="**\*.cs" />
-    <EmbeddedResource Include="**\*.resx" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="NETStandard.Library" Version="1.6" />
     <PackageReference Include="NodaTime" Version="2.0.0-beta20170123" />
     <PackageReference Include="System.Linq.Parallel" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />

--- a/net-core/Ical.Net/Ical.Net/Serialization/Factory/ComponentFactory.cs
+++ b/net-core/Ical.Net/Ical.Net/Serialization/Factory/ComponentFactory.cs
@@ -30,6 +30,9 @@ namespace Ical.Net.Serialization.Factory
                 case Components.Todo:
                     c = new Todo();
                     break;
+                case Components.Calendar:
+                    c = new Calendar();
+                    break;
                 default:
                     c = new CalendarComponent();
                     break;

--- a/net-core/Ical.Net/Ical.Net/Serialization/SimpleDeserializer.cs
+++ b/net-core/Ical.Net/Ical.Net/Serialization/SimpleDeserializer.cs
@@ -1,0 +1,221 @@
+﻿using Ical.Net.General;
+using Ical.Net.Interfaces.Components;
+using Ical.Net.Interfaces.Serialization;
+using Ical.Net.Interfaces.Serialization.Factory;
+using Ical.Net.Serialization.Factory;
+using Ical.Net.Serialization.iCalendar.Factory;
+using Ical.Net.Serialization.iCalendar.Serializers;
+using Ical.Net.Utility;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Ical.Net.Serialization
+{
+    public class SimpleDeserializer
+    {
+        internal SimpleDeserializer(
+            IDataTypeMapper dataTypeMapper,
+            ISerializerFactory serializerFactory,
+            ICalendarComponentFactory componentFactory)
+        {
+            _dataTypeMapper = dataTypeMapper;
+            _serializerFactory = serializerFactory;
+            _componentFactory = componentFactory;
+        }
+
+        public static readonly SimpleDeserializer Default = new SimpleDeserializer(
+            new DataTypeMapper(),
+            new SerializerFactory(),
+            new ComponentFactory());
+
+        private const string _nameGroup = "name";
+        private const string _valueGroup = "value";
+        private const string _paramNameGroup = "paramName";
+        private const string _paramValueGroup = "paramValue";
+
+        private static Regex _contentLineRegex = new Regex(BuildContentLineRegex(), RegexOptions.Compiled);
+
+        private readonly IDataTypeMapper _dataTypeMapper;
+        private readonly ISerializerFactory _serializerFactory;
+        private readonly ICalendarComponentFactory _componentFactory;
+
+        static string BuildContentLineRegex()
+        {
+            // name          = iana-token / x-name
+            // iana-token    = 1*(ALPHA / DIGIT / "-")
+            // x-name        = "X-" [vendorid "-"] 1*(ALPHA / DIGIT / "-")
+            // vendorid      = 3*(ALPHA / DIGIT)
+            // Add underscore to match behavior of bug 2033495
+            var identifier = "[-A-Za-z0-9_]+";
+
+            // param-value   = paramtext / quoted-string
+            // paramtext     = *SAFE-CHAR
+            // quoted-string = DQUOTE *QSAFE-CHAR DQUOTE
+            // QSAFE-CHAR    = WSP / %x21 / %x23-7E / NON-US-ASCII
+            // ; Any character except CONTROL and DQUOTE
+            // SAFE-CHAR     = WSP / %x21 / %x23-2B / %x2D-39 / %x3C-7E
+            //               / NON-US-ASCII
+            // ; Any character except CONTROL, DQUOTE, ";", ":", ","
+            var paramValue = $"((?<{_paramValueGroup}>[^\\x00-\\x08\\x0A-\\x1F\\x7F\";:,]*)|\"(?<{_paramValueGroup}>[^\\x00-\\x08\\x0A-\\x1F\\x7F\"]*)\")";
+
+            // param         = param-name "=" param-value *("," param-value)
+            // param-name    = iana-token / x-name
+            var paramName = $"(?<{_paramNameGroup}>{identifier})";
+            var param = $"{paramName}={paramValue}(,{paramValue})*";
+
+            // contentline   = name *(";" param ) ":" value CRLF
+            var name = $"(?<{_nameGroup}>{identifier})";
+            // value         = *VALUE-CHAR
+            var value = $"(?<{_valueGroup}>[^\\x00-\\x19]*)";
+            var contentLine = $"^{name}(;{param})*:{value}$";
+            return contentLine;
+        }
+
+        public IEnumerable<ICalendarComponent> Deserialize(TextReader reader)
+        {
+            var context = new SerializationContext();
+            var stack = new Stack<ICalendarComponent>();
+            var current = default(ICalendarComponent);
+            foreach (var contentLineString in GetContentLines(reader))
+            {
+                var contentLine = ParseContentLine(context, contentLineString);
+                if (string.Equals(contentLine.Name, "BEGIN", StringComparison.OrdinalIgnoreCase))
+                {
+                    stack.Push(current);
+                    current = _componentFactory.Build((string)contentLine.Value);
+                    SerializationUtil.OnDeserializing(current);
+                }
+                else
+                {
+                    if (current == null)
+                    {
+                        throw new SerializationException($"Expected 'BEGIN', found '{contentLine.Name}'");
+                    }
+                    if (string.Equals(contentLine.Name, "END", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (!string.Equals((string)contentLine.Value, current.Name, StringComparison.OrdinalIgnoreCase))
+                        {
+                            throw new SerializationException($"Expected 'END:{current.Name}', found 'END:{contentLine.Value}'");
+                        }
+                        SerializationUtil.OnDeserialized(current);
+                        var finished = current;
+                        current = stack.Pop();
+                        if (current == null)
+                        {
+                            yield return finished;
+                        }
+                        else
+                        {
+                            current.Children.Add(finished);
+                        }
+                    }
+                    else
+                    {
+                        current.Properties.Add(contentLine);
+                    }
+                }
+            }
+            if (current != null)
+            {
+                throw new SerializationException($"Unclosed component {current.Name}");
+            }
+        }
+
+        private CalendarProperty ParseContentLine(SerializationContext context, string input)
+        {
+            var match = _contentLineRegex.Match(input);
+            if (!match.Success)
+            {
+                throw new SerializationException($"Could not parse line: '{input}'");
+            }
+            var name = match.Groups[_nameGroup].Value;
+            var value = match.Groups[_valueGroup].Value;
+            var paramNames = match.Groups[_paramNameGroup].Captures;
+            var paramValues = match.Groups[_paramValueGroup].Captures;
+
+            var property = new CalendarProperty(name.ToUpperInvariant());
+            context.Push(property);
+            SetPropertyParameters(property, paramNames, paramValues);
+            SetPropertyValue(context, property, value);
+            context.Pop();
+            return property;
+        }
+
+        private static void SetPropertyParameters(CalendarProperty property, CaptureCollection paramNames, CaptureCollection paramValues)
+        {
+            var paramValueIndex = 0;
+            for (var paramNameIndex = 0; paramNameIndex < paramNames.Count; paramNameIndex++)
+            {
+                var paramName = paramNames[paramNameIndex].Value;
+                var parameter = new CalendarParameter(paramName);
+                var nextParamIndex = paramNameIndex + 1 < paramNames.Count ? paramNames[paramNameIndex + 1].Index : int.MaxValue;
+                while (paramValueIndex < paramValues.Count && paramValues[paramValueIndex].Index < nextParamIndex)
+                {
+                    var paramValue = paramValues[paramValueIndex].Value;
+                    parameter.AddValue(paramValue);
+                    paramValueIndex++;
+                }
+                property.AddParameter(parameter);
+            }
+        }
+
+        private void SetPropertyValue(SerializationContext context, CalendarProperty property, string value)
+        {
+            var type = _dataTypeMapper.GetPropertyMapping(property) ?? typeof(string);
+            var serializer = (SerializerBase)_serializerFactory.Build(type, context);
+            using (var valueReader = new StringReader(value))
+            {
+                var propertyValue = serializer.Deserialize(valueReader);
+                var propertyValues = propertyValue as IEnumerable<string>;
+                if (propertyValues != null)
+                {
+                    foreach (var singlePropertyValue in propertyValues)
+                    {
+                        property.AddValue(singlePropertyValue);
+                    }
+                }
+                else
+                {
+                    property.AddValue(propertyValue);
+                }
+            }
+        }
+
+        private static IEnumerable<string> GetContentLines(TextReader reader)
+        {
+            var currentLine = new StringBuilder();
+            while (true)
+            {
+                var nextLine = reader.ReadLine();
+                if (nextLine == null)
+                {
+                    break;
+                }
+                if (nextLine.Length > 0)
+                {
+                    if ((nextLine[0] == ' ' || nextLine[0] == '\t'))
+                    {
+                        currentLine.Append(nextLine, 1, nextLine.Length - 1);
+                    }
+                    else
+                    {
+                        if (currentLine.Length > 0)
+                        {
+                            yield return currentLine.ToString();
+                        }
+                        currentLine.Clear();
+                        currentLine.Append(nextLine);
+                    }
+                }
+            }
+            if (currentLine.Length > 0)
+            {
+                yield return currentLine.ToString();
+            }
+        }
+    }
+}

--- a/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Factory/DataTypeSerializerFactory.cs
+++ b/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Factory/DataTypeSerializerFactory.cs
@@ -28,69 +28,66 @@ namespace Ical.Net.Serialization.iCalendar.Factory
 
                 if (typeof (Attachment).IsAssignableFrom(objectType))
                 {
-                    s = new AttachmentSerializer();
+                    s = new AttachmentSerializer(ctx);
                 }
                 else if (typeof (Attendee).IsAssignableFrom(objectType))
                 {
-                    s = new AttendeeSerializer();
+                    s = new AttendeeSerializer(ctx);
                 }
                 else if (typeof (IDateTime).IsAssignableFrom(objectType))
                 {
-                    s = new DateTimeSerializer();
+                    s = new DateTimeSerializer(ctx);
                 }
                 else if (typeof (FreeBusyEntry).IsAssignableFrom(objectType))
                 {
-                    s = new FreeBusyEntrySerializer();
+                    s = new FreeBusyEntrySerializer(ctx);
                 }
                 else if (typeof (GeographicLocation).IsAssignableFrom(objectType))
                 {
-                    s = new GeographicLocationSerializer();
+                    s = new GeographicLocationSerializer(ctx);
                 }
                 else if (typeof (Organizer).IsAssignableFrom(objectType))
                 {
-                    s = new OrganizerSerializer();
+                    s = new OrganizerSerializer(ctx);
                 }
                 else if (typeof (Period).IsAssignableFrom(objectType))
                 {
-                    s = new PeriodSerializer();
+                    s = new PeriodSerializer(ctx);
                 }
                 else if (typeof (PeriodList).IsAssignableFrom(objectType))
                 {
-                    s = new PeriodListSerializer();
+                    s = new PeriodListSerializer(ctx);
                 }
                 else if (typeof (RecurrencePattern).IsAssignableFrom(objectType))
                 {
-                    s = new RecurrencePatternSerializer();
+                    s = new RecurrencePatternSerializer(ctx);
                 }
                 else if (typeof (RequestStatus).IsAssignableFrom(objectType))
                 {
-                    s = new RequestStatusSerializer();
+                    s = new RequestStatusSerializer(ctx);
                 }
                 else if (typeof (StatusCode).IsAssignableFrom(objectType))
                 {
-                    s = new StatusCodeSerializer();
+                    s = new StatusCodeSerializer(ctx);
                 }
                 else if (typeof (Trigger).IsAssignableFrom(objectType))
                 {
-                    s = new TriggerSerializer();
+                    s = new TriggerSerializer(ctx);
                 }
                 else if (typeof (UtcOffset).IsAssignableFrom(objectType))
                 {
-                    s = new UtcOffsetSerializer();
+                    s = new UtcOffsetSerializer(ctx);
                 }
                 else if (typeof (WeekDay).IsAssignableFrom(objectType))
                 {
-                    s = new WeekDaySerializer();
+                    s = new WeekDaySerializer(ctx);
                 }
                 // Default to a string serializer, which simply calls
                 // ToString() on the value to serialize it.
                 else
                 {
-                    s = new StringSerializer();
+                    s = new StringSerializer(ctx);
                 }
-
-                // Set the serialization context
-                s.SerializationContext = ctx;
 
                 return s;
             }

--- a/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Factory/SerializerFactory.cs
+++ b/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Factory/SerializerFactory.cs
@@ -38,48 +38,48 @@ namespace Ical.Net.Serialization.iCalendar.Factory
 
                 if (typeof (Calendar).IsAssignableFrom(objectType))
                 {
-                    s = new CalendarSerializer();
+                    s = new CalendarSerializer(ctx);
                 }
                 else if (typeof (ICalendarComponent).IsAssignableFrom(objectType))
                 {
                     s = typeof (CalendarEvent).IsAssignableFrom(objectType)
-                        ? new EventSerializer()
-                        : new ComponentSerializer();
+                        ? new EventSerializer(ctx)
+                        : new ComponentSerializer(ctx);
                 }
                 else if (typeof (ICalendarProperty).IsAssignableFrom(objectType))
                 {
-                    s = new PropertySerializer();
+                    s = new PropertySerializer(ctx);
                 }
                 else if (typeof (CalendarParameter).IsAssignableFrom(objectType))
                 {
-                    s = new ParameterSerializer();
+                    s = new ParameterSerializer(ctx);
                 }
                 else if (typeof (string).IsAssignableFrom(objectType))
                 {
-                    s = new StringSerializer();
+                    s = new StringSerializer(ctx);
                 }
 #if NET_4
                 else if (objectType.IsEnum)
                 {
-                    s = new EnumSerializer(objectType);
+                    s = new EnumSerializer(objectType, ctx);
                 }
 #else
                 else if (objectType.GetTypeInfo().IsEnum)
                 {
-                    s = new EnumSerializer(objectType);
+                    s = new EnumSerializer(objectType, ctx);
                 }
 #endif
                 else if (typeof (TimeSpan).IsAssignableFrom(objectType))
                 {
-                    s = new TimeSpanSerializer();
+                    s = new TimeSpanSerializer(ctx);
                 }
                 else if (typeof (int).IsAssignableFrom(objectType))
                 {
-                    s = new IntegerSerializer();
+                    s = new IntegerSerializer(ctx);
                 }
                 else if (typeof (Uri).IsAssignableFrom(objectType))
                 {
-                    s = new UriSerializer();
+                    s = new UriSerializer(ctx);
                 }
                 else if (typeof (ICalendarDataType).IsAssignableFrom(objectType))
                 {
@@ -89,13 +89,7 @@ namespace Ical.Net.Serialization.iCalendar.Factory
                 // ToString() on the value to serialize it.
                 else
                 {
-                    s = new StringSerializer();
-                }
-
-                // Set the serialization context
-                if (s != null)
-                {
-                    s.SerializationContext = ctx;
+                    s = new StringSerializer(ctx);
                 }
 
                 return s;

--- a/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/Components/EventSerializer.cs
+++ b/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/Components/EventSerializer.cs
@@ -4,6 +4,10 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.Components
 {
     public class EventSerializer : ComponentSerializer
     {
+        public EventSerializer() { }
+
+        public EventSerializer(SerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (CalendarEvent);
 
         public override string SerializeToString(object obj)

--- a/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/AttachmentSerializer.cs
+++ b/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/AttachmentSerializer.cs
@@ -6,6 +6,10 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class AttachmentSerializer : EncodableDataTypeSerializer
     {
+        public AttachmentSerializer() { }
+
+        public AttachmentSerializer(SerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (Attachment);
 
         public override string SerializeToString(object obj)

--- a/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/AttendeeSerializer.cs
+++ b/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/AttendeeSerializer.cs
@@ -7,6 +7,10 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class AttendeeSerializer : StringSerializer
     {
+        public AttendeeSerializer() { }
+
+        public AttendeeSerializer(SerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (Attendee);
 
         public override string SerializeToString(object obj)

--- a/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/DateTimeSerializer.cs
+++ b/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/DateTimeSerializer.cs
@@ -9,6 +9,10 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class DateTimeSerializer : EncodableDataTypeSerializer
     {
+        public DateTimeSerializer() { }
+
+        public DateTimeSerializer(SerializationContext ctx) : base(ctx) { }
+
         private DateTime CoerceDateTime(int year, int month, int day, int hour, int minute, int second, DateTimeKind kind)
         {
             var dt = DateTime.MinValue;

--- a/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/FreeBusyEntrySerializer.cs
+++ b/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/FreeBusyEntrySerializer.cs
@@ -6,6 +6,10 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class FreeBusyEntrySerializer : PeriodSerializer
     {
+        public FreeBusyEntrySerializer() { }
+
+        public FreeBusyEntrySerializer(SerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (FreeBusyEntry);
 
         public override string SerializeToString(object obj)

--- a/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/GeographicLocationSerializer.cs
+++ b/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/GeographicLocationSerializer.cs
@@ -7,6 +7,10 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class GeographicLocationSerializer : EncodableDataTypeSerializer
     {
+        public GeographicLocationSerializer() { }
+
+        public GeographicLocationSerializer(SerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (GeographicLocation);
 
         public override string SerializeToString(object obj)

--- a/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/OrganizerSerializer.cs
+++ b/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/OrganizerSerializer.cs
@@ -7,6 +7,10 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class OrganizerSerializer : StringSerializer
     {
+        public OrganizerSerializer() { }
+
+        public OrganizerSerializer(SerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (Organizer);
 
         public override string SerializeToString(object obj)

--- a/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/PeriodListSerializer.cs
+++ b/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/PeriodListSerializer.cs
@@ -10,6 +10,10 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class PeriodListSerializer : EncodableDataTypeSerializer
     {
+        public PeriodListSerializer() { }
+
+        public PeriodListSerializer(SerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (PeriodList);
 
         public override string SerializeToString(object obj)

--- a/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/PeriodSerializer.cs
+++ b/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/PeriodSerializer.cs
@@ -10,6 +10,10 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class PeriodSerializer : EncodableDataTypeSerializer
     {
+        public PeriodSerializer() { }
+
+        public PeriodSerializer(SerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (Period);
 
         public override string SerializeToString(object obj)

--- a/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/RecurrencePatternSerializer.cs
+++ b/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/RecurrencePatternSerializer.cs
@@ -13,6 +13,10 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class RecurrencePatternSerializer : EncodableDataTypeSerializer
     {
+        public RecurrencePatternSerializer() { }
+
+        public RecurrencePatternSerializer(SerializationContext ctx) : base(ctx) { }
+
         public static DayOfWeek GetDayOfWeek(string value)
         {
             switch (value.ToUpper())

--- a/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/RequestStatusSerializer.cs
+++ b/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/RequestStatusSerializer.cs
@@ -11,6 +11,10 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class RequestStatusSerializer : StringSerializer
     {
+        public RequestStatusSerializer() { }
+
+        public RequestStatusSerializer(SerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (RequestStatus);
 
         public override string SerializeToString(object obj)

--- a/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/StatusCodeSerializer.cs
+++ b/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/StatusCodeSerializer.cs
@@ -8,6 +8,10 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class StatusCodeSerializer : StringSerializer
     {
+        public StatusCodeSerializer() { }
+
+        public StatusCodeSerializer(SerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (StatusCode);
 
         public override string SerializeToString(object obj)

--- a/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/TriggerSerializer.cs
+++ b/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/TriggerSerializer.cs
@@ -10,6 +10,10 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class TriggerSerializer : StringSerializer
     {
+        public TriggerSerializer() { }
+
+        public TriggerSerializer(SerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (Trigger);
 
         public override string SerializeToString(object obj)

--- a/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/UTCOffsetSerializer.cs
+++ b/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/UTCOffsetSerializer.cs
@@ -8,6 +8,10 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class UtcOffsetSerializer : EncodableDataTypeSerializer
     {
+        public UtcOffsetSerializer() { }
+
+        public UtcOffsetSerializer(SerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (UtcOffset);
 
         public override string SerializeToString(object obj)

--- a/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/WeekDaySerializer.cs
+++ b/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/WeekDaySerializer.cs
@@ -7,6 +7,10 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class WeekDaySerializer : EncodableDataTypeSerializer
     {
+        public WeekDaySerializer() { }
+
+        public WeekDaySerializer(SerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (WeekDay);
 
         public override string SerializeToString(object obj)

--- a/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/Other/EnumSerializer.cs
+++ b/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/Other/EnumSerializer.cs
@@ -15,6 +15,11 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.Other
             _mEnumType = enumType;
         }
 
+        public EnumSerializer(Type enumType, SerializationContext ctx) : base(ctx)
+        {
+            _mEnumType = enumType;
+        }
+
         public override Type TargetType => _mEnumType;
 
         public override string SerializeToString(object enumValue)

--- a/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/Other/IntegerSerializer.cs
+++ b/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/Other/IntegerSerializer.cs
@@ -8,6 +8,10 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.Other
 {
     public class IntegerSerializer : EncodableDataTypeSerializer
     {
+        public IntegerSerializer() { }
+
+        public IntegerSerializer(SerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (int);
 
         public override string SerializeToString(object integer)

--- a/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/Other/TimeSpanSerializer.cs
+++ b/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/Other/TimeSpanSerializer.cs
@@ -7,6 +7,10 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.Other
 {
     public class TimeSpanSerializer : SerializerBase
     {
+        public TimeSpanSerializer() { }
+
+        public TimeSpanSerializer(SerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (TimeSpan);
 
         public override string SerializeToString(object obj)

--- a/net-core/Ical.Net/antlr.runtime/antlr.runtime.csproj
+++ b/net-core/Ical.Net/antlr.runtime/antlr.runtime.csproj
@@ -5,11 +5,4 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OutputType>library</OutputType>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="**\*.cs" />
-    <EmbeddedResource Include="**\*.resx" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="NETStandard.Library" Version="1.6" />
-  </ItemGroup>
 </Project>

--- a/v2/ical.NET.UnitTests/Ical.Net.UnitTests.csproj
+++ b/v2/ical.NET.UnitTests/Ical.Net.UnitTests.csproj
@@ -78,6 +78,7 @@
     <Compile Include="ComponentTest.cs" />
     <Compile Include="ConcurrentDeserializationTests.cs" />
     <Compile Include="DateTimeSerializerTests.cs" />
+    <Compile Include="SimpleDeserializationTests.cs" />
     <Compile Include="DeserializationTests.cs" />
     <Compile Include="DocumentationExamples.cs" />
     <Compile Include="EqualityAndHashingTests.cs" />

--- a/v2/ical.NET.UnitTests/SimpleDeserializationTests.cs
+++ b/v2/ical.NET.UnitTests/SimpleDeserializationTests.cs
@@ -1,0 +1,511 @@
+using Ical.Net.DataTypes;
+using Ical.Net.General;
+using Ical.Net.Interfaces;
+using Ical.Net.Interfaces.Components;
+using Ical.Net.Interfaces.DataTypes;
+using Ical.Net.Interfaces.General;
+using Ical.Net.Serialization;
+using Ical.Net.Serialization.iCalendar.Serializers;
+using Ical.Net.Serialization.iCalendar.Serializers.Other;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Ical.Net.UnitTests
+{
+    [TestFixture]
+    public class SimpleDeserializationTests
+    {
+
+        [Test, Category("Deserialization")]
+        public void Attendee1()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Attendee1)).Cast<ICalendar>().Single();
+            Assert.AreEqual(1, iCal.Events.Count);
+            
+            var evt = iCal.Events.First();
+            // Ensure there are 2 attendees
+            Assert.AreEqual(2, evt.Attendees.Count);            
+
+            var attendee1 = evt.Attendees[0];
+            var attendee2 = evt.Attendees[1];
+
+            // Values
+            Assert.AreEqual(new Uri("mailto:joecool@example.com"), attendee1.Value);
+            Assert.AreEqual(new Uri("mailto:ildoit@example.com"), attendee2.Value);
+
+            // MEMBERS
+            Assert.AreEqual(1, attendee1.Members.Count);
+            Assert.AreEqual(0, attendee2.Members.Count);
+            Assert.AreEqual(new Uri("mailto:DEV-GROUP@example.com"), attendee1.Members[0]);
+
+            // DELEGATED-FROM
+            Assert.AreEqual(0, attendee1.DelegatedFrom.Count);
+            Assert.AreEqual(1, attendee2.DelegatedFrom.Count);
+            Assert.AreEqual(new Uri("mailto:immud@example.com"), attendee2.DelegatedFrom[0]);
+
+            // DELEGATED-TO
+            Assert.AreEqual(0, attendee1.DelegatedTo.Count);
+            Assert.AreEqual(0, attendee2.DelegatedTo.Count);
+        }
+
+        /// <summary>
+        /// Tests that multiple parameters of the
+        /// same name are correctly aggregated into
+        /// a single list.
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void Attendee2()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Attendee2)).Cast<ICalendar>().Single();
+            Assert.AreEqual(1, iCal.Events.Count);
+
+            var evt = iCal.Events.First();
+            // Ensure there is 1 attendee
+            Assert.AreEqual(1, evt.Attendees.Count);
+
+            var attendee1 = evt.Attendees[0];
+
+            // Values
+            Assert.AreEqual(new Uri("mailto:joecool@example.com"), attendee1.Value);
+
+            // MEMBERS
+            Assert.AreEqual(3, attendee1.Members.Count);
+            Assert.AreEqual(new Uri("mailto:DEV-GROUP@example.com"), attendee1.Members[0]);
+            Assert.AreEqual(new Uri("mailto:ANOTHER-GROUP@example.com"), attendee1.Members[1]);
+            Assert.AreEqual(new Uri("mailto:THIRD-GROUP@example.com"), attendee1.Members[2]);
+        }
+
+        /// <summary>
+        /// Tests that Lotus Notes-style properties are properly handled.
+        /// https://sourceforge.net/tracker/?func=detail&aid=2033495&group_id=187422&atid=921236
+        /// Sourceforge bug #2033495
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void Bug2033495()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Bug2033495)).Cast<ICalendar>().Single();
+            Assert.AreEqual(1, iCal.Events.Count);
+            Assert.AreEqual(iCal.Properties["X-LOTUS-CHILD_UID"].Value, "XXX");
+        }
+
+        /// <summary>
+        /// Tests bug #2938007 - involving the HasTime property in IDateTime values.
+        /// See https://sourceforge.net/tracker/?func=detail&aid=2938007&group_id=187422&atid=921236
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void Bug2938007()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Bug2938007)).Cast<ICalendar>().Single();
+            Assert.AreEqual(1, iCal.Events.Count);
+
+            var evt = iCal.Events.First();
+            Assert.AreEqual(true, evt.Start.HasTime);
+            Assert.AreEqual(true, evt.End.HasTime);
+
+            foreach (var o in evt.GetOccurrences(new CalDateTime(2010, 1, 17, 0, 0, 0), new CalDateTime(2010, 2, 1, 0, 0, 0)))
+            {
+                Assert.AreEqual(true, o.Period.StartTime.HasTime);
+                Assert.AreEqual(true, o.Period.EndTime.HasTime);
+            }
+        }
+
+        /// <summary>
+        /// Tests bug #3177278 - Serialize closes stream
+        /// See https://sourceforge.net/tracker/?func=detail&aid=3177278&group_id=187422&atid=921236
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void Bug3177278()
+        {
+            var calendar = new Calendar();
+            var serializer = new CalendarSerializer();
+
+            var ms = new MemoryStream();
+            serializer.Serialize(calendar, ms, Encoding.UTF8);
+
+            Assert.IsTrue(ms.CanWrite);
+        }
+
+        /// <summary>
+        /// Tests that a mixed-case VERSION property is loaded properly
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void CaseInsensitive4()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.CaseInsensitive4)).Cast<ICalendar>().Single();
+            Assert.AreEqual("2.5", iCal.Version);
+        }
+
+        [Test, Category("Deserialization")]
+        public void Categories1_2()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Categories1)).Cast<ICalendar>().Single();
+            ProgramTest.TestCal(iCal);
+            var evt = iCal.Events.First();
+
+            var items = new List<string>();
+            items.AddRange(new[]
+            {
+                "One", "Two", "Three",
+                "Four", "Five", "Six",
+                "Seven", "A string of text with nothing less than a comma, semicolon; and a newline\n."
+            });
+
+            var found = new Dictionary<string, bool>();
+            foreach (var s in evt.Categories.Where(s => items.Contains(s)))
+            {
+                found[s] = true;
+            }
+
+            foreach (string item in items)
+                Assert.IsTrue(found.ContainsKey(item), "Event should contain CATEGORY '" + item + "', but it was not found.");
+        }
+
+        [Test, Category("Deserialization")]
+        public void EmptyLines1()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.EmptyLines1)).Cast<ICalendar>().Single();
+            Assert.AreEqual(2, iCal.Events.Count, "iCalendar should have 2 events");
+        }
+
+        [Test, Category("Deserialization")]
+        public void EmptyLines2()
+        {
+            var calendars = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.EmptyLines2)).Cast<ICalendar>().ToList();
+            Assert.AreEqual(2, calendars.Count);
+            Assert.AreEqual(2, calendars[0].Events.Count, "iCalendar should have 2 events");
+            Assert.AreEqual(2, calendars[1].Events.Count, "iCalendar should have 2 events");
+        }
+
+        /// <summary>
+        /// Verifies that blank lines between components are allowed
+        /// (as occurs with some applications/parsers - i.e. KOrganizer)
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void EmptyLines3()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.EmptyLines3)).Cast<ICalendar>().Single();
+            Assert.AreEqual(1, iCal.Todos.Count, "iCalendar should have 1 todo");
+        }
+
+        /// <summary>
+        /// Similar to PARSE4 and PARSE5 tests.
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void EmptyLines4()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.EmptyLines4)).Cast<ICalendar>().Single();
+            Assert.AreEqual(28, iCal.Events.Count);
+        }
+
+        [Test]
+        public void Encoding2()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Encoding2)).Cast<ICalendar>().Single();
+            ProgramTest.TestCal(iCal);
+            var evt = iCal.Events.First();
+
+            Assert.AreEqual(
+"This is a test to try out base64 encoding without being too large.\r\n" +
+"This is a test to try out base64 encoding without being too large.\r\n" +
+"This is a test to try out base64 encoding without being too large.\r\n" +
+"This is a test to try out base64 encoding without being too large.\r\n" +
+"This is a test to try out base64 encoding without being too large.\r\n" +
+"This is a test to try out base64 encoding without being too large.\r\n" +
+"This is a test to try out base64 encoding without being too large.\r\n" +
+"This is a test to try out base64 encoding without being too large.\r\n" +
+"This is a test to try out base64 encoding without being too large.\r\n" +
+"This is a test to try out base64 encoding without being too large.\r\n" +
+"This is a test to try out base64 encoding without being too large.\r\n" +
+"This is a test to try out base64 encoding without being too large.",
+                evt.Attachments[0].ToString(),
+                "Attached value does not match.");
+        }
+
+        [Test]
+        public void Encoding3()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Encoding3)).Cast<ICalendar>().Single();
+            ProgramTest.TestCal(iCal);
+            var evt = iCal.Events.First();
+
+            Assert.AreEqual("uuid1153170430406", evt.Uid, "UID should be 'uuid1153170430406'; it is " + evt.Uid);
+            Assert.AreEqual(1, evt.Sequence, "SEQUENCE should be 1; it is " + evt.Sequence);
+        }
+
+        [Test, Category("Deserialization")]
+        public void Event8()
+        {
+            var sr = new StringReader(@"BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Computer\, Inc//iCal 1.0//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+CREATED:20070404T211714Z
+DTEND:20070407T010000Z
+DTSTAMP:20070404T211714Z
+DTSTART:20070406T230000Z
+DURATION:PT2H
+RRULE:FREQ=WEEKLY;UNTIL=20070801T070000Z;BYDAY=FR
+SUMMARY:Friday Meetings
+DTSTAMP:20040103T033800Z
+SEQUENCE:1
+UID:fd940618-45e2-4d19-b118-37fd7a8e3906
+END:VEVENT
+BEGIN:VEVENT
+CREATED:20070404T204310Z
+DTEND:20070416T030000Z
+DTSTAMP:20070404T204310Z
+DTSTART:20070414T200000Z
+DURATION:P1DT7H
+RRULE:FREQ=DAILY;COUNT=12;BYDAY=SA,SU
+SUMMARY:Weekend Yea!
+DTSTAMP:20040103T033800Z
+SEQUENCE:1
+UID:ebfbd3e3-cc1e-4a64-98eb-ced2598b3908
+END:VEVENT
+END:VCALENDAR
+");
+            var iCal = SimpleDeserializer.Default.Deserialize(sr).Cast<ICalendar>().Single();
+            Assert.IsTrue(iCal.Events.Count == 2, "There should be 2 events in the parsed calendar");
+            Assert.IsNotNull(iCal.Events["fd940618-45e2-4d19-b118-37fd7a8e3906"], "Event fd940618-45e2-4d19-b118-37fd7a8e3906 should exist in the calendar");
+            Assert.IsNotNull(iCal.Events["ebfbd3e3-cc1e-4a64-98eb-ced2598b3908"], "Event ebfbd3e3-cc1e-4a64-98eb-ced2598b3908 should exist in the calendar");
+        }
+
+        [Test]
+        public void GeographicLocation1_2()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.GeographicLocation1)).Cast<ICalendar>().Single();
+            ProgramTest.TestCal(iCal);
+            var evt = iCal.Events.First();
+
+            Assert.AreEqual(37.386013, evt.GeographicLocation.Latitude, "Latitude should be 37.386013; it is not.");
+            Assert.AreEqual(-122.082932, evt.GeographicLocation.Longitude, "Longitude should be -122.082932; it is not.");
+        }
+
+        [Test, Category("Deserialization")]
+        public void Google1()
+        {
+            var tzId = "Europe/Berlin";
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Google1)).Cast<ICalendar>().Single();
+            var evt = iCal.Events["594oeajmftl3r9qlkb476rpr3c@google.com"];
+            Assert.IsNotNull(evt);
+
+            IDateTime dtStart = new CalDateTime(2006, 12, 18, tzId);
+            IDateTime dtEnd = new CalDateTime(2006, 12, 23, tzId);
+            var occurrences = iCal.GetOccurrences(dtStart, dtEnd).OrderBy(o => o.Period.StartTime).ToList();
+
+            var dateTimes = new[]
+            {
+                new CalDateTime(2006, 12, 18, 7, 0, 0, tzId),
+                new CalDateTime(2006, 12, 19, 7, 0, 0, tzId),
+                new CalDateTime(2006, 12, 20, 7, 0, 0, tzId),
+                new CalDateTime(2006, 12, 21, 7, 0, 0, tzId),
+                new CalDateTime(2006, 12, 22, 7, 0, 0, tzId)
+            };
+
+            for (var i = 0; i < dateTimes.Length; i++)
+                Assert.AreEqual(dateTimes[i], occurrences[i].Period.StartTime, "Event should occur at " + dateTimes[i]);
+
+            Assert.AreEqual(dateTimes.Length, occurrences.Count, "There should be exactly " + dateTimes.Length + " occurrences; there were " + occurrences.Count);
+        }
+
+        /// <summary>
+        /// Tests that valid RDATE properties are parsed correctly.
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void RecurrenceDates1()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.RecurrenceDates1)).Cast<ICalendar>().Single();
+            Assert.AreEqual(1, iCal.Events.Count);
+            Assert.AreEqual(3, iCal.Events.First().RecurrenceDates.Count);
+            
+            Assert.AreEqual((CalDateTime)new DateTime(1997, 7, 14, 12, 30, 0, DateTimeKind.Utc), iCal.Events.First().RecurrenceDates[0][0].StartTime);
+            Assert.AreEqual((CalDateTime)new DateTime(1996, 4, 3, 2, 0, 0, DateTimeKind.Utc), iCal.Events.First().RecurrenceDates[1][0].StartTime);
+            Assert.AreEqual((CalDateTime)new DateTime(1996, 4, 3, 4, 0, 0, DateTimeKind.Utc), iCal.Events.First().RecurrenceDates[1][0].EndTime);
+            Assert.AreEqual(new CalDateTime(1997, 1, 1), iCal.Events.First().RecurrenceDates[2][0].StartTime);
+            Assert.AreEqual(new CalDateTime(1997, 1, 20), iCal.Events.First().RecurrenceDates[2][1].StartTime);
+            Assert.AreEqual(new CalDateTime(1997, 2, 17), iCal.Events.First().RecurrenceDates[2][2].StartTime);
+            Assert.AreEqual(new CalDateTime(1997, 4, 21), iCal.Events.First().RecurrenceDates[2][3].StartTime);
+            Assert.AreEqual(new CalDateTime(1997, 5, 26), iCal.Events.First().RecurrenceDates[2][4].StartTime);
+            Assert.AreEqual(new CalDateTime(1997, 7, 4), iCal.Events.First().RecurrenceDates[2][5].StartTime);
+            Assert.AreEqual(new CalDateTime(1997, 9, 1), iCal.Events.First().RecurrenceDates[2][6].StartTime);
+            Assert.AreEqual(new CalDateTime(1997, 10, 14), iCal.Events.First().RecurrenceDates[2][7].StartTime);
+            Assert.AreEqual(new CalDateTime(1997, 11, 28), iCal.Events.First().RecurrenceDates[2][8].StartTime);
+            Assert.AreEqual(new CalDateTime(1997, 11, 29), iCal.Events.First().RecurrenceDates[2][9].StartTime);
+            Assert.AreEqual(new CalDateTime(1997, 12, 25), iCal.Events.First().RecurrenceDates[2][10].StartTime);
+        }
+
+        /// <summary>
+        /// Tests that valid REQUEST-STATUS properties are parsed correctly.
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void RequestStatus1()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.RequestStatus1)).Cast<ICalendar>().Single();
+            Assert.AreEqual(1, iCal.Events.Count);
+            Assert.AreEqual(4, iCal.Events.First().RequestStatuses.Count);
+
+            var rs = iCal.Events.First().RequestStatuses[0];
+            Assert.AreEqual(2, rs.StatusCode.Primary);
+            Assert.AreEqual(0, rs.StatusCode.Secondary);
+            Assert.AreEqual("Success", rs.Description);
+            Assert.IsNull(rs.ExtraData);
+
+            rs = iCal.Events.First().RequestStatuses[1];
+            Assert.AreEqual(3, rs.StatusCode.Primary);
+            Assert.AreEqual(1, rs.StatusCode.Secondary);
+            Assert.AreEqual("Invalid property value", rs.Description);
+            Assert.AreEqual("DTSTART:96-Apr-01", rs.ExtraData);
+
+            rs = iCal.Events.First().RequestStatuses[2];
+            Assert.AreEqual(2, rs.StatusCode.Primary);
+            Assert.AreEqual(8, rs.StatusCode.Secondary);
+            Assert.AreEqual(" Success, repeating event ignored. Scheduled as a single event.", rs.Description);
+            Assert.AreEqual("RRULE:FREQ=WEEKLY;INTERVAL=2", rs.ExtraData);
+
+            rs = iCal.Events.First().RequestStatuses[3];
+            Assert.AreEqual(4, rs.StatusCode.Primary);
+            Assert.AreEqual(1, rs.StatusCode.Secondary);
+            Assert.AreEqual("Event conflict. Date/time is busy.", rs.Description);
+            Assert.IsNull(rs.ExtraData);
+        }
+
+        /// <summary>
+        /// Tests that string escaping works with Text elements.
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void String2()
+        {
+            var serializer = new StringSerializer();
+            var value = @"test\with\;characters";
+            var unescaped = (string)serializer.Deserialize(new StringReader(value));
+
+            Assert.AreEqual(@"test\with;characters", unescaped, "String unescaping was incorrect.");
+
+            value = @"C:\Path\To\My\New\Information";
+            unescaped = (string)serializer.Deserialize(new StringReader(value));
+            Assert.AreEqual("C:\\Path\\To\\My\new\\Information", unescaped, "String unescaping was incorrect.");
+
+            value = @"\""This\r\nis\Na\, test\""\;\\;,";
+            unescaped = (string)serializer.Deserialize(new StringReader(value));
+
+            Assert.AreEqual("\"This\\r\nis\na, test\";\\;,", unescaped, "String unescaping was incorrect.");
+        }
+
+        [Test, Category("Deserialization")]
+        public void Transparency2()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Transparency2)).Cast<ICalendar>().Single();
+
+            Assert.AreEqual(1, iCal.Events.Count);
+            var evt = iCal.Events.First();
+
+            Assert.AreEqual(TransparencyType.Transparent, evt.Transparency);
+        }
+
+        /// <summary>
+        /// Tests that DateTime values that are out-of-range are still parsed correctly
+        /// and set to the closest representable date/time in .NET.
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void DateTime1()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.DateTime1)).Cast<ICalendar>().Single();
+            Assert.AreEqual(6, iCal.Events.Count);
+
+            var evt = iCal.Events["nc2o66s0u36iesitl2l0b8inn8@google.com"];
+            Assert.IsNotNull(evt);
+
+            // The "Created" date is out-of-bounds.  It should be coerced to the
+            // closest representable date/time.
+            Assert.AreEqual(DateTime.MinValue, evt.Created.Value);
+        }
+
+        [Test, Category("Deserialization")]
+        public void Language4()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Language4)).Cast<ICalendar>().Single();
+            Assert.IsNotNull(iCal);
+        }
+
+        [Test, Category("Deserialization")]
+        public void Outlook2007_LineFolds1()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Outlook2007LineFolds)).Cast<ICalendar>().Single();
+            var events = iCal.GetOccurrences(new CalDateTime(2009, 06, 20), new CalDateTime(2009, 06, 22));
+            Assert.AreEqual(1, events.Count);
+        }
+
+        [Test, Category("Deserialization")]
+        public void Outlook2007_LineFolds2()
+        {
+            var longName = "The Exceptionally Long Named Meeting Room Whose Name Wraps Over Several Lines When Exported From Leading Calendar and Office Software Application Microsoft Office 2007";
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Outlook2007LineFolds)).Cast<ICalendar>().Single();
+            var events = iCal.GetOccurrences<Event>(new CalDateTime(2009, 06, 20), new CalDateTime(2009, 06, 22)).OrderBy(o => o.Period.StartTime).ToList();
+            Assert.AreEqual(longName, ((IEvent)events[0].Source).Location);
+        }
+
+        /// <summary>
+        /// Tests that multiple parameters are allowed in iCalObjects
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void Parameter1()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Parameter1)).Cast<ICalendar>().Single();
+
+            var evt = iCal.Events.First();
+            IList<CalendarParameter> parms = evt.Properties["DTSTART"].Parameters.AllOf("VALUE").ToList();
+            Assert.AreEqual(2, parms.Count);
+            Assert.AreEqual("DATE", parms[0].Values.First());
+            Assert.AreEqual("OTHER", parms[1].Values.First());
+        }
+
+        /// <summary>
+        /// Tests that empty parameters are allowed in iCalObjects
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void Parameter2()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Parameter2)).Cast<ICalendar>().Single();
+            Assert.AreEqual(2, iCal.Events.Count);
+        }
+
+        /// <summary>
+        /// Tests a calendar that should fail to properly parse.
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void Parse1()
+        {
+            try
+            {
+                var content = IcsFiles.Parse1;
+                var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(content)).Cast<ICalendar>().Single();
+                Assert.IsNotNull(iCal);
+            }
+            catch (Exception e)
+            {
+                Assert.IsInstanceOf<SerializationException>(e);
+            }
+        }
+
+        /// <summary>
+        /// Tests that multiple properties are allowed in iCalObjects
+        /// </summary>
+        [Test, Category("Deserialization")]
+        public void Property1()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Property1)).Cast<ICalendar>().Single();
+
+            IList<ICalendarProperty> props = iCal.Properties.AllOf("VERSION").ToList();
+            Assert.AreEqual(2, props.Count);
+
+            for (var i = 0; i < props.Count; i++)
+                Assert.AreEqual("2." + i, props[i].Value);
+        }
+    }
+}

--- a/v2/ical.NET/Ical.Net.csproj
+++ b/v2/ical.NET/Ical.Net.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Interfaces\Serialization\ISerializer.cs" />
     <Compile Include="Interfaces\Serialization\IStringSerializer.cs" />
     <Compile Include="Serialization\EncodingStack.cs" />
+    <Compile Include="Serialization\SimpleDeserializer.cs" />
     <Compile Include="Serialization\iCalendar\Factory\DataTypeSerializerFactory.cs" />
     <Compile Include="Serialization\iCalendar\Processors\CompositeProcessor.cs" />
     <Compile Include="Serialization\iCalendar\Serializers\Components\EventSerializer.cs" />

--- a/v2/ical.NET/Serialization/Factory/ComponentFactory.cs
+++ b/v2/ical.NET/Serialization/Factory/ComponentFactory.cs
@@ -30,6 +30,9 @@ namespace Ical.Net.Serialization.Factory
                 case Components.Todo:
                     c = new Todo();
                     break;
+                case Components.Calendar:
+                    c = new Calendar();
+                    break;
                 default:
                     c = new CalendarComponent();
                     break;

--- a/v2/ical.NET/Serialization/SimpleDeserializer.cs
+++ b/v2/ical.NET/Serialization/SimpleDeserializer.cs
@@ -1,0 +1,221 @@
+﻿using Ical.Net.General;
+using Ical.Net.Interfaces.Components;
+using Ical.Net.Interfaces.Serialization;
+using Ical.Net.Interfaces.Serialization.Factory;
+using Ical.Net.Serialization.Factory;
+using Ical.Net.Serialization.iCalendar.Factory;
+using Ical.Net.Serialization.iCalendar.Serializers;
+using Ical.Net.Utility;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Ical.Net.Serialization
+{
+    public class SimpleDeserializer
+    {
+        public SimpleDeserializer(
+            IDataTypeMapper dataTypeMapper,
+            ISerializerFactory serializerFactory,
+            ICalendarComponentFactory componentFactory)
+        {
+            _dataTypeMapper = dataTypeMapper;
+            _serializerFactory = serializerFactory;
+            _componentFactory = componentFactory;
+        }
+
+        public static readonly SimpleDeserializer Default = new SimpleDeserializer(
+            new DataTypeMapper(),
+            new SerializerFactory(),
+            new ComponentFactory());
+
+        private const string _nameGroup = "name";
+        private const string _valueGroup = "value";
+        private const string _paramNameGroup = "paramName";
+        private const string _paramValueGroup = "paramValue";
+
+        private static Regex _contentLineRegex = new Regex(BuildContentLineRegex(), RegexOptions.Compiled);
+
+        private readonly IDataTypeMapper _dataTypeMapper;
+        private readonly ISerializerFactory _serializerFactory;
+        private readonly ICalendarComponentFactory _componentFactory;
+
+        static string BuildContentLineRegex()
+        {
+            // name          = iana-token / x-name
+            // iana-token    = 1*(ALPHA / DIGIT / "-")
+            // x-name        = "X-" [vendorid "-"] 1*(ALPHA / DIGIT / "-")
+            // vendorid      = 3*(ALPHA / DIGIT)
+            // Add underscore to match behavior of bug 2033495
+            var identifier = "[-A-Za-z0-9_]+";
+
+            // param-value   = paramtext / quoted-string
+            // paramtext     = *SAFE-CHAR
+            // quoted-string = DQUOTE *QSAFE-CHAR DQUOTE
+            // QSAFE-CHAR    = WSP / %x21 / %x23-7E / NON-US-ASCII
+            // ; Any character except CONTROL and DQUOTE
+            // SAFE-CHAR     = WSP / %x21 / %x23-2B / %x2D-39 / %x3C-7E
+            //               / NON-US-ASCII
+            // ; Any character except CONTROL, DQUOTE, ";", ":", ","
+            var paramValue = $"((?<{_paramValueGroup}>[^\\x00-\\x08\\x0A-\\x1F\\x7F\";:,]*)|\"(?<{_paramValueGroup}>[^\\x00-\\x08\\x0A-\\x1F\\x7F\"]*)\")";
+
+            // param         = param-name "=" param-value *("," param-value)
+            // param-name    = iana-token / x-name
+            var paramName = $"(?<{_paramNameGroup}>{identifier})";
+            var param = $"{paramName}={paramValue}(,{paramValue})*";
+
+            // contentline   = name *(";" param ) ":" value CRLF
+            var name = $"(?<{_nameGroup}>{identifier})";
+            // value         = *VALUE-CHAR
+            var value = $"(?<{_valueGroup}>[^\\x00-\\x19]*)";
+            var contentLine = $"^{name}(;{param})*:{value}$";
+            return contentLine;
+        }
+
+        public IEnumerable<ICalendarComponent> Deserialize(TextReader reader)
+        {
+            var context = new SerializationContext();
+            var stack = new Stack<ICalendarComponent>();
+            var current = default(ICalendarComponent);
+            foreach (var contentLineString in GetContentLines(reader))
+            {
+                var contentLine = ParseContentLine(context, contentLineString);
+                if (string.Equals(contentLine.Name, "BEGIN", StringComparison.OrdinalIgnoreCase))
+                {
+                    stack.Push(current);
+                    current = _componentFactory.Build((string)contentLine.Value);
+                    SerializationUtil.OnDeserializing(current);
+                }
+                else
+                {
+                    if (current == null)
+                    {
+                        throw new SerializationException($"Expected 'BEGIN', found '{contentLine.Name}'");
+                    }
+                    if (string.Equals(contentLine.Name, "END", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (!string.Equals((string)contentLine.Value, current.Name, StringComparison.OrdinalIgnoreCase))
+                        {
+                            throw new SerializationException($"Expected 'END:{current.Name}', found 'END:{contentLine.Value}'");
+                        }
+                        SerializationUtil.OnDeserialized(current);
+                        var finished = current;
+                        current = stack.Pop();
+                        if (current == null)
+                        {
+                            yield return finished;
+                        }
+                        else
+                        {
+                            current.Children.Add(finished);
+                        }
+                    }
+                    else
+                    {
+                        current.Properties.Add(contentLine);
+                    }
+                }
+            }
+            if (current != null)
+            {
+                throw new SerializationException($"Unclosed component {current.Name}");
+            }
+        }
+
+        private CalendarProperty ParseContentLine(SerializationContext context, string input)
+        {
+            var match = _contentLineRegex.Match(input);
+            if (!match.Success)
+            {
+                throw new SerializationException($"Could not parse line: '{input}'");
+            }
+            var name = match.Groups[_nameGroup].Value;
+            var value = match.Groups[_valueGroup].Value;
+            var paramNames = match.Groups[_paramNameGroup].Captures;
+            var paramValues = match.Groups[_paramValueGroup].Captures;
+
+            var property = new CalendarProperty(name.ToUpperInvariant());
+            context.Push(property);
+            SetPropertyParameters(property, paramNames, paramValues);
+            SetPropertyValue(context, property, value);
+            context.Pop();
+            return property;
+        }
+
+        private static void SetPropertyParameters(CalendarProperty property, CaptureCollection paramNames, CaptureCollection paramValues)
+        {
+            var paramValueIndex = 0;
+            for (var paramNameIndex = 0; paramNameIndex < paramNames.Count; paramNameIndex++)
+            {
+                var paramName = paramNames[paramNameIndex].Value;
+                var parameter = new CalendarParameter(paramName);
+                var nextParamIndex = paramNameIndex + 1 < paramNames.Count ? paramNames[paramNameIndex + 1].Index : int.MaxValue;
+                while (paramValueIndex < paramValues.Count && paramValues[paramValueIndex].Index < nextParamIndex)
+                {
+                    var paramValue = paramValues[paramValueIndex].Value;
+                    parameter.AddValue(paramValue);
+                    paramValueIndex++;
+                }
+                property.AddParameter(parameter);
+            }
+        }
+
+        private void SetPropertyValue(SerializationContext context, CalendarProperty property, string value)
+        {
+            var type = _dataTypeMapper.GetPropertyMapping(property) ?? typeof(string);
+            var serializer = (SerializerBase)_serializerFactory.Build(type, context);
+            using (var valueReader = new StringReader(value))
+            {
+                var propertyValue = serializer.Deserialize(valueReader);
+                var propertyValues = propertyValue as IEnumerable<string>;
+                if (propertyValues != null)
+                {
+                    foreach (var singlePropertyValue in propertyValues)
+                    {
+                        property.AddValue(singlePropertyValue);
+                    }
+                }
+                else
+                {
+                    property.AddValue(propertyValue);
+                }
+            }
+        }
+
+        private static IEnumerable<string> GetContentLines(TextReader reader)
+        {
+            var currentLine = new StringBuilder();
+            while (true)
+            {
+                var nextLine = reader.ReadLine();
+                if (nextLine == null)
+                {
+                    break;
+                }
+                if (nextLine.Length > 0)
+                {
+                    if ((nextLine[0] == ' ' || nextLine[0] == '\t'))
+                    {
+                        currentLine.Append(nextLine, 1, nextLine.Length - 1);
+                    }
+                    else
+                    {
+                        if (currentLine.Length > 0)
+                        {
+                            yield return currentLine.ToString();
+                        }
+                        currentLine.Clear();
+                        currentLine.Append(nextLine);
+                    }
+                }
+            }
+            if (currentLine.Length > 0)
+            {
+                yield return currentLine.ToString();
+            }
+        }
+    }
+}

--- a/v2/ical.NET/Serialization/iCalendar/Factory/DataTypeSerializerFactory.cs
+++ b/v2/ical.NET/Serialization/iCalendar/Factory/DataTypeSerializerFactory.cs
@@ -26,70 +26,66 @@ namespace Ical.Net.Serialization.iCalendar.Factory
 
                 if (typeof (IAttachment).IsAssignableFrom(objectType))
                 {
-                    s = new AttachmentSerializer();
+                    s = new AttachmentSerializer(ctx);
                 }
                 else if (typeof (IAttendee).IsAssignableFrom(objectType))
                 {
-                    s = new AttendeeSerializer();
+                    s = new AttendeeSerializer(ctx);
                 }
                 else if (typeof (IDateTime).IsAssignableFrom(objectType))
                 {
-                    s = new DateTimeSerializer();
+                    s = new DateTimeSerializer(ctx);
                 }
                 else if (typeof (IFreeBusyEntry).IsAssignableFrom(objectType))
                 {
-                    s = new FreeBusyEntrySerializer();
+                    s = new FreeBusyEntrySerializer(ctx);
                 }
                 else if (typeof (IGeographicLocation).IsAssignableFrom(objectType))
                 {
-                    s = new GeographicLocationSerializer();
+                    s = new GeographicLocationSerializer(ctx);
                 }
                 else if (typeof (IOrganizer).IsAssignableFrom(objectType))
                 {
-                    s = new OrganizerSerializer();
+                    s = new OrganizerSerializer(ctx);
                 }
                 else if (typeof (IPeriod).IsAssignableFrom(objectType))
                 {
-                    s = new PeriodSerializer();
+                    s = new PeriodSerializer(ctx);
                 }
                 else if (typeof (IPeriodList).IsAssignableFrom(objectType))
                 {
-                    s = new PeriodListSerializer();
+                    s = new PeriodListSerializer(ctx);
                 }
                 else if (typeof (IRecurrencePattern).IsAssignableFrom(objectType))
                 {
-                    s = new RecurrencePatternSerializer();
+                    s = new RecurrencePatternSerializer(ctx);
                 }
                 else if (typeof (IRequestStatus).IsAssignableFrom(objectType))
                 {
-                    s = new RequestStatusSerializer();
+                    s = new RequestStatusSerializer(ctx);
                 }
                 else if (typeof (IStatusCode).IsAssignableFrom(objectType))
                 {
-                    s = new StatusCodeSerializer();
+                    s = new StatusCodeSerializer(ctx);
                 }
                 else if (typeof (ITrigger).IsAssignableFrom(objectType))
                 {
-                    s = new TriggerSerializer();
+                    s = new TriggerSerializer(ctx);
                 }
                 else if (typeof (IUtcOffset).IsAssignableFrom(objectType))
                 {
-                    s = new UtcOffsetSerializer();
+                    s = new UtcOffsetSerializer(ctx);
                 }
                 else if (typeof (IWeekDay).IsAssignableFrom(objectType))
                 {
-                    s = new WeekDaySerializer();
+                    s = new WeekDaySerializer(ctx);
                 }
                 // Default to a string serializer, which simply calls
                 // ToString() on the value to serialize it.
                 else
                 {
-                    s = new StringSerializer();
+                    s = new StringSerializer(ctx);
                 }
-
-                // Set the serialization context
-                s.SerializationContext = ctx;
-
                 return s;
             }
             return null;

--- a/v2/ical.NET/Serialization/iCalendar/Factory/SerializerFactory.cs
+++ b/v2/ical.NET/Serialization/iCalendar/Factory/SerializerFactory.cs
@@ -39,48 +39,48 @@ namespace Ical.Net.Serialization.iCalendar.Factory
 
                 if (typeof (ICalendar).IsAssignableFrom(objectType))
                 {
-                    s = new CalendarSerializer();
+                    s = new CalendarSerializer(ctx);
                 }
                 else if (typeof (ICalendarComponent).IsAssignableFrom(objectType))
                 {
                     s = typeof (IEvent).IsAssignableFrom(objectType)
-                        ? new EventSerializer()
-                        : new ComponentSerializer();
+                        ? new EventSerializer(ctx)
+                        : new ComponentSerializer(ctx);
                 }
                 else if (typeof (ICalendarProperty).IsAssignableFrom(objectType))
                 {
-                    s = new PropertySerializer();
+                    s = new PropertySerializer(ctx);
                 }
                 else if (typeof (CalendarParameter).IsAssignableFrom(objectType))
                 {
-                    s = new ParameterSerializer();
+                    s = new ParameterSerializer(ctx);
                 }
                 else if (typeof (string).IsAssignableFrom(objectType))
                 {
-                    s = new StringSerializer();
+                    s = new StringSerializer(ctx);
                 }
 #if NET_4
                 else if (objectType.IsEnum)
                 {
-                    s = new EnumSerializer(objectType);
+                    s = new EnumSerializer(objectType, ctx);
                 }
 #else
                 else if (objectType.GetTypeInfo().IsEnum)
                 {
-                    s = new EnumSerializer(objectType);
+                    s = new EnumSerializer(objectType, ctx);
                 }
 #endif
                 else if (typeof (TimeSpan).IsAssignableFrom(objectType))
                 {
-                    s = new TimeSpanSerializer();
+                    s = new TimeSpanSerializer(ctx);
                 }
                 else if (typeof (int).IsAssignableFrom(objectType))
                 {
-                    s = new IntegerSerializer();
+                    s = new IntegerSerializer(ctx);
                 }
                 else if (typeof (Uri).IsAssignableFrom(objectType))
                 {
-                    s = new UriSerializer();
+                    s = new UriSerializer(ctx);
                 }
                 else if (typeof (ICalendarDataType).IsAssignableFrom(objectType))
                 {
@@ -90,13 +90,7 @@ namespace Ical.Net.Serialization.iCalendar.Factory
                 // ToString() on the value to serialize it.
                 else
                 {
-                    s = new StringSerializer();
-                }
-
-                // Set the serialization context
-                if (s != null)
-                {
-                    s.SerializationContext = ctx;
+                    s = new StringSerializer(ctx);
                 }
 
                 return s;

--- a/v2/ical.NET/Serialization/iCalendar/Serializers/Components/EventSerializer.cs
+++ b/v2/ical.NET/Serialization/iCalendar/Serializers/Components/EventSerializer.cs
@@ -1,10 +1,15 @@
 ﻿using System;
 using Ical.Net.Interfaces.Components;
+using Ical.Net.Interfaces.Serialization;
 
 namespace Ical.Net.Serialization.iCalendar.Serializers.Components
 {
     public class EventSerializer : ComponentSerializer
     {
+        public EventSerializer() { }
+
+        public EventSerializer(ISerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (Event);
 
         public override string SerializeToString(object obj)

--- a/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/AttachmentSerializer.cs
+++ b/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/AttachmentSerializer.cs
@@ -8,6 +8,10 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class AttachmentSerializer : EncodableDataTypeSerializer
     {
+        public AttachmentSerializer() { }
+
+        public AttachmentSerializer(ISerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (Attachment);
 
         public override string SerializeToString(object obj)

--- a/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/AttendeeSerializer.cs
+++ b/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/AttendeeSerializer.cs
@@ -3,11 +3,16 @@ using System.IO;
 using Ical.Net.DataTypes;
 using Ical.Net.Interfaces.DataTypes;
 using Ical.Net.Serialization.iCalendar.Serializers.Other;
+using Ical.Net.Interfaces.Serialization;
 
 namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class AttendeeSerializer : StringSerializer
     {
+        public AttendeeSerializer() { }
+
+        public AttendeeSerializer(ISerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (Attendee);
 
         public override string SerializeToString(object obj)

--- a/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/DateTimeSerializer.cs
+++ b/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/DateTimeSerializer.cs
@@ -4,11 +4,16 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Ical.Net.DataTypes;
 using Ical.Net.Interfaces.DataTypes;
+using Ical.Net.Interfaces.Serialization;
 
 namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class DateTimeSerializer : EncodableDataTypeSerializer
     {
+        public DateTimeSerializer() { }
+
+        public DateTimeSerializer(ISerializationContext ctx) : base(ctx) { }
+
         private DateTime CoerceDateTime(int year, int month, int day, int hour, int minute, int second, DateTimeKind kind)
         {
             var dt = DateTime.MinValue;

--- a/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/FreeBusyEntrySerializer.cs
+++ b/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/FreeBusyEntrySerializer.cs
@@ -2,11 +2,16 @@
 using System.IO;
 using Ical.Net.DataTypes;
 using Ical.Net.Interfaces.DataTypes;
+using Ical.Net.Interfaces.Serialization;
 
 namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class FreeBusyEntrySerializer : PeriodSerializer
     {
+        public FreeBusyEntrySerializer() { }
+
+        public FreeBusyEntrySerializer(ISerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (FreeBusyEntry);
 
         public override string SerializeToString(object obj)

--- a/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/GeographicLocationSerializer.cs
+++ b/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/GeographicLocationSerializer.cs
@@ -3,11 +3,16 @@ using System.IO;
 using Ical.Net.DataTypes;
 using Ical.Net.Interfaces.DataTypes;
 using System.Globalization;
+using Ical.Net.Interfaces.Serialization;
 
 namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class GeographicLocationSerializer : EncodableDataTypeSerializer
     {
+        public GeographicLocationSerializer() { }
+
+        public GeographicLocationSerializer(ISerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (GeographicLocation);
 
         public override string SerializeToString(object obj)

--- a/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/OrganizerSerializer.cs
+++ b/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/OrganizerSerializer.cs
@@ -3,11 +3,16 @@ using System.IO;
 using Ical.Net.DataTypes;
 using Ical.Net.Interfaces.DataTypes;
 using Ical.Net.Serialization.iCalendar.Serializers.Other;
+using Ical.Net.Interfaces.Serialization;
 
 namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class OrganizerSerializer : StringSerializer
     {
+        public OrganizerSerializer() { }
+
+        public OrganizerSerializer(ISerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (Organizer);
 
         public override string SerializeToString(object obj)

--- a/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/PeriodListSerializer.cs
+++ b/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/PeriodListSerializer.cs
@@ -10,6 +10,10 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class PeriodListSerializer : EncodableDataTypeSerializer
     {
+        public PeriodListSerializer() { }
+
+        public PeriodListSerializer(ISerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (PeriodList);
 
         public override string SerializeToString(object obj)

--- a/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/PeriodSerializer.cs
+++ b/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/PeriodSerializer.cs
@@ -10,6 +10,10 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class PeriodSerializer : EncodableDataTypeSerializer
     {
+        public PeriodSerializer() { }
+
+        public PeriodSerializer(ISerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (Period);
 
         public override string SerializeToString(object obj)

--- a/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/RecurrencePatternSerializer.cs
+++ b/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/RecurrencePatternSerializer.cs
@@ -12,6 +12,10 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class RecurrencePatternSerializer : EncodableDataTypeSerializer
     {
+        public RecurrencePatternSerializer() { }
+
+        public RecurrencePatternSerializer(ISerializationContext ctx) : base(ctx) { }
+
         public static DayOfWeek GetDayOfWeek(string value)
         {
             switch (value.ToUpper())

--- a/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/RequestStatusSerializer.cs
+++ b/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/RequestStatusSerializer.cs
@@ -12,6 +12,10 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class RequestStatusSerializer : StringSerializer
     {
+        public RequestStatusSerializer() { }
+
+        public RequestStatusSerializer(ISerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (RequestStatus);
 
         public override string SerializeToString(object obj)

--- a/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/StatusCodeSerializer.cs
+++ b/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/StatusCodeSerializer.cs
@@ -4,11 +4,16 @@ using System.Text.RegularExpressions;
 using Ical.Net.DataTypes;
 using Ical.Net.Interfaces.DataTypes;
 using Ical.Net.Serialization.iCalendar.Serializers.Other;
+using Ical.Net.Interfaces.Serialization;
 
 namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class StatusCodeSerializer : StringSerializer
     {
+        public StatusCodeSerializer() { }
+
+        public StatusCodeSerializer(ISerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (StatusCode);
 
         public override string SerializeToString(object obj)

--- a/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/TriggerSerializer.cs
+++ b/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/TriggerSerializer.cs
@@ -10,6 +10,10 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class TriggerSerializer : StringSerializer
     {
+        public TriggerSerializer() { }
+
+        public TriggerSerializer(ISerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (Trigger);
 
         public override string SerializeToString(object obj)

--- a/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/UTCOffsetSerializer.cs
+++ b/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/UTCOffsetSerializer.cs
@@ -4,11 +4,16 @@ using System.IO;
 using System.Text.RegularExpressions;
 using Ical.Net.DataTypes;
 using Ical.Net.Interfaces.DataTypes;
+using Ical.Net.Interfaces.Serialization;
 
 namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class UtcOffsetSerializer : EncodableDataTypeSerializer
     {
+        public UtcOffsetSerializer() { }
+
+        public UtcOffsetSerializer(ISerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (UtcOffset);
 
         public override string SerializeToString(object obj)

--- a/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/WeekDaySerializer.cs
+++ b/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/WeekDaySerializer.cs
@@ -3,11 +3,16 @@ using System.IO;
 using System.Text.RegularExpressions;
 using Ical.Net.DataTypes;
 using Ical.Net.Interfaces.DataTypes;
+using Ical.Net.Interfaces.Serialization;
 
 namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
 {
     public class WeekDaySerializer : EncodableDataTypeSerializer
     {
+        public WeekDaySerializer() { }
+
+        public WeekDaySerializer(ISerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (WeekDay);
 
         public override string SerializeToString(object obj)

--- a/v2/ical.NET/Serialization/iCalendar/Serializers/Other/EnumSerializer.cs
+++ b/v2/ical.NET/Serialization/iCalendar/Serializers/Other/EnumSerializer.cs
@@ -3,6 +3,7 @@ using System.IO;
 using Ical.Net.DataTypes;
 using Ical.Net.Interfaces.General;
 using Ical.Net.Serialization.iCalendar.Serializers.DataTypes;
+using Ical.Net.Interfaces.Serialization;
 
 namespace Ical.Net.Serialization.iCalendar.Serializers.Other
 {
@@ -11,6 +12,11 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.Other
         private readonly Type _mEnumType;
 
         public EnumSerializer(Type enumType)
+        {
+            _mEnumType = enumType;
+        }
+
+        public EnumSerializer(Type enumType, ISerializationContext ctx) : base(ctx)
         {
             _mEnumType = enumType;
         }

--- a/v2/ical.NET/Serialization/iCalendar/Serializers/Other/IntegerSerializer.cs
+++ b/v2/ical.NET/Serialization/iCalendar/Serializers/Other/IntegerSerializer.cs
@@ -3,11 +3,16 @@ using System.IO;
 using Ical.Net.DataTypes;
 using Ical.Net.Interfaces.General;
 using Ical.Net.Serialization.iCalendar.Serializers.DataTypes;
+using Ical.Net.Interfaces.Serialization;
 
 namespace Ical.Net.Serialization.iCalendar.Serializers.Other
 {
     public class IntegerSerializer : EncodableDataTypeSerializer
     {
+        public IntegerSerializer() { }
+
+        public IntegerSerializer(ISerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (int);
 
         public override string SerializeToString(object integer)

--- a/v2/ical.NET/Serialization/iCalendar/Serializers/Other/TimeSpanSerializer.cs
+++ b/v2/ical.NET/Serialization/iCalendar/Serializers/Other/TimeSpanSerializer.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Ical.Net.Interfaces.Serialization;
+using System;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -7,6 +8,10 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.Other
 {
     public class TimeSpanSerializer : SerializerBase
     {
+        public TimeSpanSerializer() { }
+
+        public TimeSpanSerializer(ISerializationContext ctx) : base(ctx) { }
+
         public override Type TargetType => typeof (TimeSpan);
 
         public override string SerializeToString(object obj)


### PR DESCRIPTION
I wrote a small deserializer that is much simpler than the current ANTLR one.  On my machine, it is able to deserialize about twice as quickly as the current one.  

I also changed the `ISerializerFactory` implementations to pass the `SerializationContext` as a constructor parameter when constructing serializers.  This avoids an expensive call to `SerializationContext.Default` that created an object that was then discarded.  