### PR TITLE
Declare dependency on NodaTime in the .nuspec

### DIFF
--- a/net-core/Ical.Net/Ical.Net.nuspec
+++ b/net-core/Ical.Net/Ical.Net.nuspec
@@ -13,6 +13,9 @@
         <releaseNotes>https://github.com/rianjs/ical.net/blob/master/release-notes.md</releaseNotes>
         <iconUrl>https://github.com/rianjs/ical.net/raw/master/nuget_logo_150px.png</iconUrl>
         <tags>iCal Calendar icalendar ics outlook events rfc-5545 rfc-2445 dday</tags>
+        <dependencies>
+            <dependency id="NodaTime" version="2.0.0-beta20170123" />
+        </dependencies>
     </metadata>
     <files>
         <!-- netstandard 1.6 -->


### PR DESCRIPTION
The Ical.Net .csproj file declares that it references NodaTime, but the .nuspec file does
not declare the dependency. As a result, Ical.Net will throw exceptions unless the NodaTime
NuGet package is installed separately. This change declares the NodaTime dependency in the
.nuspec so NuGet will automatically install NodaTime when Ical.Net is installed.