### PR TITLE
Define IEquitable on Calendar and Occurence classes

### DIFF
--- a/net-core/Ical.Net/Ical.Net/Calendar.cs
+++ b/net-core/Ical.Net/Ical.Net/Calendar.cs
@@ -17,7 +17,7 @@ using Ical.Net.Utility;
 
 namespace Ical.Net
 {
-    public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, IMergeable
+    public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, IMergeable, IEquatable<Calendar>
     {
         public static CalendarCollection Load(string iCalendarString)
         {
@@ -109,7 +109,7 @@ namespace Ical.Net
             Initialize();
         }
 
-        protected bool Equals(Calendar other)
+        public bool Equals(Calendar other)
         {
             var foo = CollectionHelpers.Equals(UniqueComponents, other.UniqueComponents);
             return string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase)

--- a/net-core/Ical.Net/Ical.Net/DataTypes/Occurrence.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/Occurrence.cs
@@ -3,7 +3,7 @@ using Ical.Net.Interfaces.Evaluation;
 
 namespace Ical.Net.DataTypes
 {
-    public class Occurrence : IComparable<Occurrence>
+    public class Occurrence : IComparable<Occurrence>, IEquatable<Occurrence>
     {
         public Period Period { get; set; }
         public IRecurrable Source { get; set; }


### PR DESCRIPTION
Both Calendar and Occurence classes are already implementing the IEquatable<T> interface. This change simply add the interface at the class definition.