### PR TITLE
Define IEquatable when already implemented

### DIFF
--- a/net-core/Ical.Net/Ical.Net.nuspec
+++ b/net-core/Ical.Net/Ical.Net.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>Ical.Net</id>
-        <version>3.0.3-net-core-alpha</version>
+        <version>3.0.4-net-core-alpha</version>
         <title>Ical.Net</title>
         <authors>Rian Stockbower, Douglas Day, M. David Peterson</authors>
         <owners>Rian Stockbower</owners>

--- a/net-core/Ical.Net/Ical.Net/Calendar.cs
+++ b/net-core/Ical.Net/Ical.Net/Calendar.cs
@@ -17,7 +17,7 @@ using Ical.Net.Utility;
 
 namespace Ical.Net
 {
-    public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, IMergeable
+    public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, IMergeable, IEquatable<Calendar>
     {
         public static CalendarCollection Load(string iCalendarString)
         {
@@ -109,7 +109,7 @@ namespace Ical.Net
             Initialize();
         }
 
-        protected bool Equals(Calendar other)
+        public bool Equals(Calendar other)
         {
             var foo = CollectionHelpers.Equals(UniqueComponents, other.UniqueComponents);
             return string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase)

--- a/net-core/Ical.Net/Ical.Net/CalendarCollection.cs
+++ b/net-core/Ical.Net/Ical.Net/CalendarCollection.cs
@@ -11,7 +11,7 @@ namespace Ical.Net
     /// <summary>
     /// A list of iCalendars.
     /// </summary>
-    public class CalendarCollection : List<Calendar>
+    public class CalendarCollection : List<Calendar>, IEquatable<CalendarCollection>
     {
         public void ClearEvaluation()
         {
@@ -124,7 +124,7 @@ namespace Ical.Net
 
         public override int GetHashCode() => CollectionHelpers.GetHashCode(this);
 
-        protected bool Equals(CalendarCollection obj) => CollectionHelpers.Equals(this, obj);
+        public bool Equals(CalendarCollection other) => CollectionHelpers.Equals(this, other);
 
         public override bool Equals(object obj)
         {

--- a/net-core/Ical.Net/Ical.Net/Components/CalendarEvent.cs
+++ b/net-core/Ical.Net/Ical.Net/Components/CalendarEvent.cs
@@ -24,7 +24,7 @@ namespace Ical.Net
     ///         <item>Create a TextCollection DataType for 'text' items separated by commas</item>
     ///     </list>
     /// </note>
-    public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<CalendarEvent>
+    public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<CalendarEvent>, IEquatable<CalendarEvent>
     {
         internal const string ComponentName = "VEVENT";
 
@@ -282,7 +282,7 @@ namespace Ical.Net
             }
         }
 
-        protected bool Equals(CalendarEvent other)
+        public bool Equals(CalendarEvent other)
         {
             var resourcesSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             resourcesSet.UnionWith(Resources);

--- a/net-core/Ical.Net/Ical.Net/Components/CalendarEvent.cs
+++ b/net-core/Ical.Net/Ical.Net/Components/CalendarEvent.cs
@@ -333,19 +333,19 @@ namespace Ical.Net
 
         public int CompareTo(CalendarEvent other)
         {
-            if (DtStart.Equals(other.DtStart))
+            if (ReferenceEquals(other, null))
             {
-                return 0;
-            }
-            if (DtStart.LessThan(other.DtStart))
-            {
-                return -1;
+                return 1;
             }
             if (DtStart.GreaterThan(other.DtStart))
             {
                 return 1;
             }
-            throw new Exception("An error occurred while comparing two CalDateTimes.");
+            if (DtStart.Equals(other.DtStart))
+            {
+                return 0;
+            }
+            return -1;
         }
     }
 }

--- a/net-core/Ical.Net/Ical.Net/Components/UniqueComponent.cs
+++ b/net-core/Ical.Net/Ical.Net/Components/UniqueComponent.cs
@@ -11,7 +11,7 @@ namespace Ical.Net
     /// Represents a unique component, a component with a unique UID,
     /// which can be used to uniquely identify the component.    
     /// </summary>
-    public class UniqueComponent : CalendarComponent, IUniqueComponent, IComparable<UniqueComponent>
+    public class UniqueComponent : CalendarComponent, IUniqueComponent, IComparable<UniqueComponent>, IEquatable<UniqueComponent>
     {
         // TODO: Add AddRelationship() public method.
         // This method will add the UID of a related component
@@ -96,8 +96,28 @@ namespace Ical.Net
         public int CompareTo(UniqueComponent other)
             => string.Compare(Uid, other.Uid, StringComparison.OrdinalIgnoreCase);
 
+        public bool Equals(UniqueComponent other)
+        {
+            // TODO: Casting UniqueComponent to RecurringComponent, i.e. a subclass, creates tight coupling of the two classes. 
+            //      This implementation should be moved to RecurringComponent class instead. 
+
+            if (other is RecurringComponent && other != this)
+            {
+                var r = (RecurringComponent)other;
+                if (Uid != null)
+                {
+                    return Uid.Equals(r.Uid);
+                }
+                return Uid == r.Uid;
+            }
+            return base.Equals(other);
+        }
+
         public override bool Equals(object obj)
         {
+            // TODO: Casting UniqueComponent to RecurringComponent, i.e. a subclass, creates tight coupling of the two classes. 
+            //      This implementation should be moved to RecurringComponent class instead. 
+
             if (obj is RecurringComponent && obj != this)
             {
                 var r = (RecurringComponent) obj;

--- a/net-core/Ical.Net/Ical.Net/Components/VTimeZone.cs
+++ b/net-core/Ical.Net/Ical.Net/Components/VTimeZone.cs
@@ -5,7 +5,7 @@ namespace Ical.Net
     /// <summary>
     /// Represents an RFC 5545 VTIMEZONE component.
     /// </summary>
-    public class VTimeZone : CalendarComponent
+    public class VTimeZone : CalendarComponent, IEquatable<VTimeZone>
     {
         public VTimeZone()
         {
@@ -46,7 +46,7 @@ namespace Ical.Net
             }
         }
 
-        protected bool Equals(VTimeZone other)
+        public bool Equals(VTimeZone other)
         {
             return string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase)
                 && string.Equals(TzId, other.TzId, StringComparison.OrdinalIgnoreCase)

--- a/net-core/Ical.Net/Ical.Net/DataTypes/AlarmOccurrence.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/AlarmOccurrence.cs
@@ -12,7 +12,7 @@ namespace Ical.Net.DataTypes
     /// the alarm occurs, the <see cref="Alarm"/> that fired, and the 
     /// component on which the alarm fired.
     /// </remarks>
-    public class AlarmOccurrence : IComparable<AlarmOccurrence>
+    public class AlarmOccurrence : IComparable<AlarmOccurrence>, IEquatable<AlarmOccurrence>
     {
         public Period Period { get; set; }
 
@@ -45,7 +45,7 @@ namespace Ical.Net.DataTypes
             return Period.CompareTo(other.Period);
         }
 
-        protected bool Equals(AlarmOccurrence other)
+        public bool Equals(AlarmOccurrence other)
         {
             return Equals(Period, other.Period) && Equals(Component, other.Component) && Equals(Alarm, other.Alarm);
         }

--- a/net-core/Ical.Net/Ical.Net/DataTypes/Attachment.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/Attachment.cs
@@ -12,7 +12,7 @@ namespace Ical.Net.DataTypes
     /// 1) A string representing a URI which is typically human-readable, OR
     /// 2) A base64-encoded string that can represent anything
     /// </summary>
-    public class Attachment : EncodableDataType
+    public class Attachment : EncodableDataType, IEquatable<Attachment>
     {
         public virtual Uri Uri { get; set; }
         public virtual byte[] Data { get; }
@@ -72,7 +72,7 @@ namespace Ical.Net.DataTypes
         //ToDo: See if this can be deleted
         public override void CopyFrom(ICopyable obj) { }
 
-        protected bool Equals(Attachment other)
+        public bool Equals(Attachment other)
         {
             var firstPart = Equals(Uri, other.Uri) && ValueEncoding.Equals(other.ValueEncoding);
             return Data == null

--- a/net-core/Ical.Net/Ical.Net/DataTypes/Attendee.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/Attendee.cs
@@ -6,7 +6,7 @@ using Ical.Net.Utility;
 
 namespace Ical.Net.DataTypes
 {
-    public class Attendee : EncodableDataType
+    public class Attendee : EncodableDataType, IEquatable<Attendee>
     {
         private Uri _sentBy;
         /// <summary> SENT-BY, to indicate who is acting on behalf of the ATTENDEE </summary>
@@ -246,7 +246,7 @@ namespace Ical.Net.DataTypes
         //ToDo: See if this can be deleted
         public override void CopyFrom(ICopyable obj) {}
 
-        protected bool Equals(Attendee other)
+        public bool Equals(Attendee other)
         {
             return Equals(SentBy, other.SentBy)
                 && string.Equals(CommonName, other.CommonName, StringComparison.OrdinalIgnoreCase)

--- a/net-core/Ical.Net/Ical.Net/DataTypes/GeographicLocation.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/GeographicLocation.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using Ical.Net.Interfaces.General;
 using Ical.Net.Serialization.iCalendar.Serializers.DataTypes;
@@ -9,7 +10,7 @@ namespace Ical.Net.DataTypes
     /// <see cref="Components.Event"/> or <see cref="Components.Todo"/> item.
     /// </summary>
     [DebuggerDisplay("{Latitude};{Longitude}")]
-    public class GeographicLocation : EncodableDataType
+    public class GeographicLocation : EncodableDataType, IEquatable<GeographicLocation>
     {
         public double Latitude { get; set; }
         public double Longitude { get; set; }
@@ -35,7 +36,7 @@ namespace Ical.Net.DataTypes
             return Latitude.ToString("0.000000") + ";" + Longitude.ToString("0.000000");
         }
 
-        protected bool Equals(GeographicLocation other)
+        public bool Equals(GeographicLocation other)
         {
             return Latitude.Equals(other.Latitude) && Longitude.Equals(other.Longitude);
         }

--- a/net-core/Ical.Net/Ical.Net/DataTypes/Occurrence.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/Occurrence.cs
@@ -3,7 +3,7 @@ using Ical.Net.Interfaces.Evaluation;
 
 namespace Ical.Net.DataTypes
 {
-    public class Occurrence : IComparable<Occurrence>
+    public class Occurrence : IComparable<Occurrence>, IEquatable<Occurrence>
     {
         public Period Period { get; set; }
         public IRecurrable Source { get; set; }

--- a/net-core/Ical.Net/Ical.Net/DataTypes/Organizer.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/Organizer.cs
@@ -10,7 +10,7 @@ namespace Ical.Net.DataTypes
     /// A class that represents the organizer of an event/todo/journal.
     /// </summary>
     [DebuggerDisplay("{Value}")]
-    public class Organizer : EncodableDataType
+    public class Organizer : EncodableDataType, IEquatable<Organizer>
     {
         public virtual Uri SentBy
         {
@@ -60,7 +60,7 @@ namespace Ical.Net.DataTypes
             CopyFrom(serializer.Deserialize(new StringReader(value)) as ICopyable);
         }
 
-        protected bool Equals(Organizer other)
+        public bool Equals(Organizer other)
         {
             return Equals(Value, other.Value);
         }

--- a/net-core/Ical.Net/Ical.Net/DataTypes/Period.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/Period.cs
@@ -180,19 +180,19 @@ namespace Ical.Net.DataTypes
 
         public int CompareTo(Period other)
         {
-            if (StartTime.Equals(other.StartTime))
-            {
-                return 0;
-            }
-            if (StartTime.LessThan(other.StartTime))
-            {
-                return -1;
-            }
-            if (StartTime.GreaterThan(other.StartTime))
+            if (ReferenceEquals(other, null))
             {
                 return 1;
             }
-            throw new Exception("An error occurred while comparing two Periods.");
+            if (StartTime.GreaterThanOrEqual(other.StartTime))
+            {
+                return 1;
+            }
+            if (Equals(other))
+            {
+                return 0;
+            }
+            return -1;
         }
     }
 }

--- a/net-core/Ical.Net/Ical.Net/DataTypes/Period.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/Period.cs
@@ -6,7 +6,7 @@ using Ical.Net.Serialization.iCalendar.Serializers.DataTypes;
 namespace Ical.Net.DataTypes
 {
     /// <summary> Represents an iCalendar period of time. </summary>    
-    public class Period : EncodableDataType, IComparable<Period>
+    public class Period : EncodableDataType, IComparable<Period>, IEquatable<Period>
     {
         public Period() { }
 
@@ -60,7 +60,7 @@ namespace Ical.Net.DataTypes
             Duration = p.Duration;
         }
 
-        protected bool Equals(Period other)
+        public bool Equals(Period other)
         {
             return Equals(StartTime, other.StartTime) && Equals(EndTime, other.EndTime) && Duration.Equals(other.Duration);
         }

--- a/net-core/Ical.Net/Ical.Net/DataTypes/PeriodList.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/PeriodList.cs
@@ -33,7 +33,7 @@ namespace Ical.Net.DataTypes
 
         public bool Equals(PeriodList other)
         {
-            return string.Equals(TzId, other.TzId) && CollectionHelpers.Equals(Periods, other.Periods);
+            return string.Equals(TzId, other.TzId, StringComparison.OrdinalIgnoreCase) && CollectionHelpers.Equals(Periods, other.Periods);
         }
 
         public override bool Equals(object obj)

--- a/net-core/Ical.Net/Ical.Net/DataTypes/PeriodList.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/PeriodList.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -12,7 +13,7 @@ namespace Ical.Net.DataTypes
     /// <summary>
     /// An iCalendar list of recurring dates (or date exclusions)
     /// </summary>
-    public class PeriodList : EncodableDataType, IList<Period>
+    public class PeriodList : EncodableDataType, IList<Period>, IEquatable<PeriodList>
     {
         public string TzId { get; set; }
         public int Count => Periods.Count;
@@ -30,7 +31,7 @@ namespace Ical.Net.DataTypes
             CopyFrom(serializer.Deserialize(new StringReader(value)) as ICopyable);
         }
 
-        protected bool Equals(PeriodList other)
+        public bool Equals(PeriodList other)
         {
             return string.Equals(TzId, other.TzId) && CollectionHelpers.Equals(Periods, other.Periods);
         }
@@ -50,6 +51,7 @@ namespace Ical.Net.DataTypes
                 return ((TzId?.GetHashCode() ?? 0) * 397) ^ CollectionHelpers.GetHashCode(Periods);
             }
         }
+
         public override void CopyFrom(ICopyable obj)
         {
             base.CopyFrom(obj);
@@ -80,6 +82,7 @@ namespace Ical.Net.DataTypes
         public IEnumerator<Period> GetEnumerator() => Periods.GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => Periods.GetEnumerator();
+
         public void Clear()
         {
             Periods.Clear();

--- a/net-core/Ical.Net/Ical.Net/DataTypes/RecurrencePattern.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/RecurrencePattern.cs
@@ -12,7 +12,7 @@ namespace Ical.Net.DataTypes
     /// <summary>
     /// An iCalendar representation of the <c>RRULE</c> property.
     /// </summary>
-    public class RecurrencePattern : EncodableDataType
+    public class RecurrencePattern : EncodableDataType, IEquatable<RecurrencePattern>
     {
         private int _interval = int.MinValue;
         private RecurrenceRestrictionType? _restrictionType;
@@ -112,7 +112,7 @@ namespace Ical.Net.DataTypes
             return serializer.SerializeToString(this);
         }
 
-        protected bool Equals(RecurrencePattern other)
+        public bool Equals(RecurrencePattern other)
         {
             return (Interval == other.Interval)
                 && (RestrictionType == other.RestrictionType)

--- a/net-core/Ical.Net/Ical.Net/DataTypes/RequestStatus.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/RequestStatus.cs
@@ -65,7 +65,8 @@ namespace Ical.Net.DataTypes
 
         public bool Equals(RequestStatus other)
         {
-            return string.Equals(_mDescription, other._mDescription) && string.Equals(_mExtraData, other._mExtraData) &&
+            return string.Equals(_mDescription, other._mDescription, StringComparison.OrdinalIgnoreCase) && 
+                   string.Equals(_mExtraData, other._mExtraData, StringComparison.OrdinalIgnoreCase) &&
                    Equals(_mStatusCode, other._mStatusCode);
         }
 

--- a/net-core/Ical.Net/Ical.Net/DataTypes/RequestStatus.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/RequestStatus.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using Ical.Net.Interfaces.General;
 using Ical.Net.Serialization.iCalendar.Serializers.DataTypes;
@@ -7,7 +8,7 @@ namespace Ical.Net.DataTypes
     /// <summary>
     /// A class that represents the return status of an iCalendar request.
     /// </summary>
-    public class RequestStatus : EncodableDataType
+    public class RequestStatus : EncodableDataType, IEquatable<RequestStatus>
     {
         private string _mDescription;
         private string _mExtraData;
@@ -62,7 +63,7 @@ namespace Ical.Net.DataTypes
             return serializer.SerializeToString(this);
         }
 
-        protected bool Equals(RequestStatus other)
+        public bool Equals(RequestStatus other)
         {
             return string.Equals(_mDescription, other._mDescription) && string.Equals(_mExtraData, other._mExtraData) &&
                    Equals(_mStatusCode, other._mStatusCode);

--- a/net-core/Ical.Net/Ical.Net/DataTypes/StatusCode.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/StatusCode.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using Ical.Net.Interfaces.General;
@@ -9,7 +10,7 @@ namespace Ical.Net.DataTypes
     /// <summary>
     /// An iCalendar status code.
     /// </summary>
-    public class StatusCode : EncodableDataType
+    public class StatusCode : EncodableDataType, IEquatable<StatusCode>
     {
         public int[] Parts { get; private set; }
 
@@ -71,7 +72,7 @@ namespace Ical.Net.DataTypes
 
         public override string ToString() => new StatusCodeSerializer().SerializeToString(this);
 
-        protected bool Equals(StatusCode other) => Parts.SequenceEqual(other.Parts);
+        public bool Equals(StatusCode other) => Parts.SequenceEqual(other.Parts);
 
         public override bool Equals(object obj)
         {

--- a/net-core/Ical.Net/Ical.Net/DataTypes/Trigger.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/Trigger.cs
@@ -10,7 +10,7 @@ namespace Ical.Net.DataTypes
     /// A class that is used to specify exactly when an <see cref="Components.Alarm"/> component will trigger.
     /// Usually this date/time is relative to the component to which the Alarm is associated.
     /// </summary>    
-    public class Trigger : EncodableDataType
+    public class Trigger : EncodableDataType, IEquatable<Trigger>
     {
         private IDateTime _mDateTime;
         private TimeSpan? _mDuration;
@@ -85,7 +85,7 @@ namespace Ical.Net.DataTypes
             }
         }
 
-        protected bool Equals(Trigger other)
+        public bool Equals(Trigger other)
         {
             return Equals(_mDateTime, other._mDateTime) && _mDuration.Equals(other._mDuration) && _mRelated == other._mRelated;
         }

--- a/net-core/Ical.Net/Ical.Net/DataTypes/UTCOffset.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/UTCOffset.cs
@@ -6,7 +6,7 @@ namespace Ical.Net.DataTypes
     /// <summary>
     /// Represents a time offset from UTC (Coordinated Universal Time).
     /// </summary>
-    public class UtcOffset : EncodableDataType
+    public class UtcOffset : EncodableDataType, IEquatable<UtcOffset>
     {
         public TimeSpan Offset { get; }
 
@@ -38,7 +38,7 @@ namespace Ical.Net.DataTypes
 
         public virtual DateTime ToLocal(DateTime dt) => DateTime.SpecifyKind(dt.Add(Offset), DateTimeKind.Local);
 
-        protected bool Equals(UtcOffset other)
+        public bool Equals(UtcOffset other)
         {
             return Offset == other.Offset;
         }

--- a/net-core/Ical.Net/Ical.Net/DataTypes/WeekDay.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/WeekDay.cs
@@ -8,7 +8,7 @@ namespace Ical.Net.DataTypes
     /// <summary>
     /// Represents an RFC 5545 "BYDAY" value.
     /// </summary>
-    public class WeekDay : EncodableDataType, IComparable, IComparable<WeekDay>, IEquatable<WeekDay>
+    public class WeekDay : EncodableDataType, IComparable<WeekDay>, IEquatable<WeekDay>
     {
         public virtual int Offset { get; set; } = int.MinValue;
 
@@ -68,9 +68,9 @@ namespace Ical.Net.DataTypes
 
         public int CompareTo(WeekDay other)
         {
-            if (other == null)
+            if (ReferenceEquals(other, null))
             {
-                throw new ArgumentException();
+                return 1;
             }
             var compare = DayOfWeek.CompareTo(other.DayOfWeek);
             if (compare == 0)
@@ -78,21 +78,6 @@ namespace Ical.Net.DataTypes
                 compare = Offset.CompareTo(other.Offset);
             }
             return compare;
-        }
-
-        public int CompareTo(object obj)
-        {
-            WeekDay bd = null;
-            if (obj is string)
-            {
-                bd = new WeekDay(obj.ToString());
-            }
-            else if (obj is WeekDay)
-            {
-                bd = (WeekDay) obj;
-            }
-
-            return CompareTo(bd);
         }
     }
 }

--- a/net-core/Ical.Net/Ical.Net/DataTypes/WeekDay.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/WeekDay.cs
@@ -8,7 +8,7 @@ namespace Ical.Net.DataTypes
     /// <summary>
     /// Represents an RFC 5545 "BYDAY" value.
     /// </summary>
-    public class WeekDay : EncodableDataType
+    public class WeekDay : EncodableDataType, IEquatable<WeekDay>
     {
         public virtual int Offset { get; set; } = int.MinValue;
 
@@ -36,6 +36,8 @@ namespace Ical.Net.DataTypes
             var serializer = new WeekDaySerializer();
             CopyFrom(serializer.Deserialize(new StringReader(value)) as ICopyable);
         }
+
+        public bool Equals(WeekDay other) => other.Offset == Offset && other.DayOfWeek == DayOfWeek;
 
         public override bool Equals(object obj)
         {

--- a/net-core/Ical.Net/Ical.Net/DataTypes/WeekDay.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/WeekDay.cs
@@ -8,7 +8,7 @@ namespace Ical.Net.DataTypes
     /// <summary>
     /// Represents an RFC 5545 "BYDAY" value.
     /// </summary>
-    public class WeekDay : EncodableDataType, IEquatable<WeekDay>
+    public class WeekDay : EncodableDataType, IComparable, IComparable<WeekDay>, IEquatable<WeekDay>
     {
         public virtual int Offset { get; set; } = int.MinValue;
 
@@ -66,6 +66,20 @@ namespace Ical.Net.DataTypes
             }
         }
 
+        public int CompareTo(WeekDay other)
+        {
+            if (other == null)
+            {
+                throw new ArgumentException();
+            }
+            var compare = DayOfWeek.CompareTo(other.DayOfWeek);
+            if (compare == 0)
+            {
+                compare = Offset.CompareTo(other.Offset);
+            }
+            return compare;
+        }
+
         public int CompareTo(object obj)
         {
             WeekDay bd = null;
@@ -78,16 +92,7 @@ namespace Ical.Net.DataTypes
                 bd = (WeekDay) obj;
             }
 
-            if (bd == null)
-            {
-                throw new ArgumentException();
-            }
-            var compare = DayOfWeek.CompareTo(bd.DayOfWeek);
-            if (compare == 0)
-            {
-                compare = Offset.CompareTo(bd.Offset);
-            }
-            return compare;
+            return CompareTo(bd);
         }
     }
 }

--- a/net-core/Ical.Net/Ical.Net/DataTypes/iCalDateTime.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/iCalDateTime.cs
@@ -14,7 +14,7 @@ namespace Ical.Net.DataTypes
     /// class handles time zone differences, and integrates seamlessly into the iCalendar framework.
     /// </remarks>
     /// </summary>
-    public sealed class CalDateTime : EncodableDataType, IDateTime, IEquatable<IDateTime>
+    public sealed class CalDateTime : EncodableDataType, IComparable<IDateTime>, IDateTime, IEquatable<IDateTime>
     {
         public static CalDateTime Now => new CalDateTime(DateTime.Now);
 

--- a/net-core/Ical.Net/Ical.Net/DataTypes/iCalDateTime.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/iCalDateTime.cs
@@ -14,7 +14,7 @@ namespace Ical.Net.DataTypes
     /// class handles time zone differences, and integrates seamlessly into the iCalendar framework.
     /// </remarks>
     /// </summary>
-    public sealed class CalDateTime : EncodableDataType, IDateTime
+    public sealed class CalDateTime : EncodableDataType, IDateTime, IEquatable<IDateTime>
     {
         public static CalDateTime Now => new CalDateTime(DateTime.Now);
 
@@ -138,6 +138,8 @@ namespace Ical.Net.DataTypes
                 AssociateWith(dt);
             }
         }
+
+        public bool Equals(IDateTime other) => Equals(other.AsUtc, AsUtc);
 
         //ToDo: Time zone equality should include time zone values. Perhaps we should separate the idea of "equal" with "equivalent
         /// <summary>Equality is determined by the unambiguous UTC representation of the time. Time zone string values are ignored.</summary>

--- a/net-core/Ical.Net/Ical.Net/DataTypes/iCalDateTime.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/iCalDateTime.cs
@@ -14,7 +14,7 @@ namespace Ical.Net.DataTypes
     /// class handles time zone differences, and integrates seamlessly into the iCalendar framework.
     /// </remarks>
     /// </summary>
-    public sealed class CalDateTime : EncodableDataType, IComparable<IDateTime>, IDateTime, IEquatable<IDateTime>
+    public sealed class CalDateTime : EncodableDataType, IComparable<IDateTime>, IDateTime, IEquatable<CalDateTime>
     {
         public static CalDateTime Now => new CalDateTime(DateTime.Now);
 
@@ -139,7 +139,7 @@ namespace Ical.Net.DataTypes
             }
         }
 
-        public bool Equals(IDateTime other) => Equals(other.AsUtc, AsUtc);
+        public bool Equals(CalDateTime other) => Equals(other.AsUtc, AsUtc);
 
         //ToDo: Time zone equality should include time zone values. Perhaps we should separate the idea of "equal" with "equivalent
         /// <summary>Equality is determined by the unambiguous UTC representation of the time. Time zone string values are ignored.</summary>
@@ -518,21 +518,21 @@ namespace Ical.Net.DataTypes
             }
         }
 
-        public int CompareTo(IDateTime dt)
+        public int CompareTo(IDateTime other)
         {
-            if (Equals(dt))
-            {
-                return 0;
-            }
-            if (this < dt)
-            {
-                return -1;
-            }
-            if (this > dt)
+            if (ReferenceEquals(other, null))
             {
                 return 1;
             }
-            throw new Exception("An error occurred while comparing two IDateTime values.");
+            if (this > other)
+            {
+                return 1;
+            }
+            if (Equals(other))
+            {
+                return 0;
+            }
+            return -1;
         }
 
         public string ToString(string format)

--- a/net-core/Ical.Net/Ical.Net/General/CalendarObject.cs
+++ b/net-core/Ical.Net/Ical.Net/General/CalendarObject.cs
@@ -9,7 +9,7 @@ namespace Ical.Net.General
     /// <summary>
     /// The base class for all iCalendar objects and components.
     /// </summary>
-    public class CalendarObject : CalendarObjectBase, ICalendarObject
+    public class CalendarObject : CalendarObjectBase, ICalendarObject, IEquatable<CalendarObject>
     {
         private ICalendarObjectList<ICalendarObject> _children;
         private ServiceProvider _serviceProvider;
@@ -64,7 +64,7 @@ namespace Ical.Net.General
             e.First.Parent = this;
         }
 
-        protected bool Equals(CalendarObject other) => string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase);
+        public bool Equals(CalendarObject other) => string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase);
 
         public override bool Equals(object obj)
         {

--- a/release-notes.md
+++ b/release-notes.md
@@ -3,13 +3,13 @@
 A listing of what each [Nuget package](https://www.nuget.org/packages/Ical.Net) version represents.
 
 ### v3
-
+* 3.0.4-net-core-alpha: All calendar components now explicitly implement IEquatable<T>. [PR 262](https://github.com/rianjs/ical.net/pull/262)
 * 3.0.3-net-core-alpha: Bringing in 2.2.34's changes: serializing `EXDATE`s and `RDATE`s now includes time zone information when specified. UTC timestamps are now allowed to be specified either in `Z`-suffixed form (which was mandatory before), OR explicitly with a time zone id (`TZID=UTC`). This allows greater interop with third-party libraries like Telerik's RadSchedule. [#259](https://github.com/rianjs/ical.net/issues/259) `PeriodList` now implements `IList<Period>`.
 * 3.0.2-net-core-alpha: Fix nuspec file to declare NodaTime as dependency
 * 3.0.1-alpha: Initial publishing of .NET Core release
 
 ### v2
-
+* 2.2.35: All calendar components now explicitly implement IEquatable<T>. [PR 262](https://github.com/rianjs/ical.net/pull/262)
 * 2.2.34: Serializing `EXDATE`s and `RDATE`s now includes time zone information when specified. UTC timestamps are now allowed to be specified either in `Z`-suffixed form (which was mandatory before), OR explicitly with a time zone id (`TZID=UTC`). This allows greater interop with third-party libraries like Telerik's RadSchedule. [#259](https://github.com/rianjs/ical.net/issues/259)
 * 2.2.33: Bugfix for [#235](https://github.com/rianjs/ical.net/issues/235) when years have 53 weeks. Contains a new deserializer that's twice as fast as the default ANTLR implementation, and several other (smaller) performance enhancements. _This will become the default deserializer in a future release._ [PR 246](https://github.com/rianjs/ical.net/pull/246), [PR 247](https://github.com/rianjs/ical.net/pull/247)
 * 2.2.31: .NET's UTC offset parsing semantics don't match the RFC (which allows for `hhmmss` UTC offsets), so I extended the offset serializer to account for these differences. ([#102](https://github.com/rianjs/ical.net/issues/102), [#236](https://github.com/rianjs/ical.net/issues/236))

--- a/v2/Ical.Net.nuspec
+++ b/v2/Ical.Net.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>Ical.Net</id>
-        <version>2.2.34</version>
+        <version>2.2.35</version>
         <title>Ical.Net</title>
         <authors>Rian Stockbower, Douglas Day, M. David Peterson</authors>
         <owners>Rian Stockbower</owners>

--- a/v2/ical.NET/Calendar.cs
+++ b/v2/ical.NET/Calendar.cs
@@ -18,7 +18,7 @@ using Ical.Net.Utility;
 
 namespace Ical.Net
 {
-    public class Calendar : CalendarComponent, ICalendar
+    public class Calendar : CalendarComponent, ICalendar, IEquatable<Calendar>
     {
         /// <summary>
         /// Loads an <see cref="Calendar"/> from the file system.
@@ -177,7 +177,7 @@ namespace Ical.Net
             Initialize();
         }
 
-        protected bool Equals(Calendar other)
+        public bool Equals(Calendar other)
         {
             return string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase)
                 && CollectionHelpers.Equals(UniqueComponents, other.UniqueComponents)

--- a/v2/ical.NET/CalendarCollection.cs
+++ b/v2/ical.NET/CalendarCollection.cs
@@ -12,7 +12,7 @@ namespace Ical.Net
     /// <summary>
     /// A list of iCalendars.
     /// </summary>
-    public class CalendarCollection : List<ICalendar>, IICalendarCollection
+    public class CalendarCollection : List<ICalendar>, IICalendarCollection, IEquatable<CalendarCollection>
     {
         public void ClearEvaluation()
         {
@@ -125,7 +125,7 @@ namespace Ical.Net
 
         public override int GetHashCode() => CollectionHelpers.GetHashCode(this);
 
-        protected bool Equals(CalendarCollection obj) => CollectionHelpers.Equals(this, obj);
+        public bool Equals(CalendarCollection other) => CollectionHelpers.Equals(this, other);
 
         public override bool Equals(object obj)
         {

--- a/v2/ical.NET/Components/Event.cs
+++ b/v2/ical.NET/Components/Event.cs
@@ -23,7 +23,7 @@ namespace Ical.Net
     ///         <item>Create a TextCollection DataType for 'text' items separated by commas</item>
     ///     </list>
     /// </note>
-    public class Event : RecurringComponent, IEvent, IComparable<Event>
+    public class Event : RecurringComponent, IEvent, IComparable<Event>, IEquatable<Event>
     {
         internal const string ComponentName = "VEVENT";
 
@@ -281,7 +281,7 @@ namespace Ical.Net
             }
         }
 
-        protected bool Equals(Event other)
+        public bool Equals(Event other)
         {
             var resourcesSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             resourcesSet.UnionWith(Resources);

--- a/v2/ical.NET/Components/Event.cs
+++ b/v2/ical.NET/Components/Event.cs
@@ -332,19 +332,19 @@ namespace Ical.Net
 
         public int CompareTo(Event other)
         {
-            if (DtStart.Equals(other.DtStart))
+            if (ReferenceEquals(other, null)) 
             {
-                return 0;
-            }
-            if (DtStart.LessThan(other.DtStart))
-            {
-                return -1;
+                return 1;
             }
             if (DtStart.GreaterThan(other.DtStart))
             {
                 return 1;
             }
-            throw new Exception("An error occurred while comparing two CalDateTimes.");
+            if (DtStart.Equals(other.DtStart)) 
+            {
+                return 0;
+            }
+            return -1;
         }
     }
 }

--- a/v2/ical.NET/Components/UniqueComponent.cs
+++ b/v2/ical.NET/Components/UniqueComponent.cs
@@ -11,7 +11,7 @@ namespace Ical.Net
     /// Represents a unique component, a component with a unique UID,
     /// which can be used to uniquely identify the component.    
     /// </summary>
-    public class UniqueComponent : CalendarComponent, IUniqueComponent, IComparable<UniqueComponent>
+    public class UniqueComponent : CalendarComponent, IUniqueComponent, IComparable<UniqueComponent>, IEquatable<UniqueComponent>
     {
         // TODO: Add AddRelationship() public method.
         // This method will add the UID of a related component
@@ -95,8 +95,26 @@ namespace Ical.Net
 
         public int CompareTo(UniqueComponent other) => string.Compare(Uid, other.Uid, StringComparison.OrdinalIgnoreCase);
 
+        public bool Equals(UniqueComponent other) 
+        {
+            // TODO: Casting UniqueComponent to RecurringComponent, i.e. a subclass, creates tight coupling of the two classes. 
+            //      This implementation should be moved to RecurringComponent class instead. 
+
+            if (other is RecurringComponent && other != this) {
+                var r = (RecurringComponent)other;
+                if (Uid != null) {
+                    return Uid.Equals(r.Uid);
+                }
+                return Uid == r.Uid;
+            }
+            return base.Equals(other);
+        }
+
         public override bool Equals(object obj)
         {
+            // TODO: Casting UniqueComponent to RecurringComponent, i.e. a subclass, creates tight coupling of the two classes. 
+            //      This implementation should be moved to RecurringComponent class instead. 
+
             if (obj is RecurringComponent && obj != this)
             {
                 var r = (RecurringComponent) obj;

--- a/v2/ical.NET/Components/VTimeZone.cs
+++ b/v2/ical.NET/Components/VTimeZone.cs
@@ -6,7 +6,7 @@ namespace Ical.Net
     /// <summary>
     /// Represents an RFC 5545 VTIMEZONE component.
     /// </summary>
-    public class VTimeZone : CalendarComponent, ITimeZone
+    public class VTimeZone : CalendarComponent, ITimeZone, IEquatable<VTimeZone>
     {
         public static VTimeZone FromLocalTimeZone()
         {
@@ -68,7 +68,7 @@ namespace Ical.Net
             }
         }
 
-        protected bool Equals(VTimeZone other)
+        public bool Equals(VTimeZone other)
         {
             return string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase)
                 && string.Equals(TzId, other.TzId, StringComparison.OrdinalIgnoreCase)

--- a/v2/ical.NET/DataTypes/AlarmOccurrence.cs
+++ b/v2/ical.NET/DataTypes/AlarmOccurrence.cs
@@ -12,7 +12,7 @@ namespace Ical.Net.DataTypes
     /// the alarm occurs, the <see cref="Alarm"/> that fired, and the 
     /// component on which the alarm fired.
     /// </remarks>
-    public class AlarmOccurrence : IComparable<AlarmOccurrence>
+    public class AlarmOccurrence : IComparable<AlarmOccurrence>, IEquatable<AlarmOccurrence>
     {
         public IPeriod Period { get; set; }
 
@@ -45,7 +45,7 @@ namespace Ical.Net.DataTypes
             return Period.CompareTo(other.Period);
         }
 
-        protected bool Equals(AlarmOccurrence other)
+        public bool Equals(AlarmOccurrence other)
         {
             return Equals(Period, other.Period) && Equals(Component, other.Component) && Equals(Alarm, other.Alarm);
         }

--- a/v2/ical.NET/DataTypes/Attachment.cs
+++ b/v2/ical.NET/DataTypes/Attachment.cs
@@ -13,7 +13,7 @@ namespace Ical.Net.DataTypes
     /// 1) A string representing a URI which is typically human-readable, OR
     /// 2) A base64-encoded string that can represent anything
     /// </summary>
-    public class Attachment : EncodableDataType, IAttachment
+    public class Attachment : EncodableDataType, IAttachment, IEquatable<Attachment>
     {
         public virtual Uri Uri { get; set; }
         public virtual byte[] Data { get; set; }
@@ -73,7 +73,7 @@ namespace Ical.Net.DataTypes
         //ToDo: See if this can be deleted
         public override void CopyFrom(ICopyable obj) { }
 
-        protected bool Equals(Attachment other)
+        public bool Equals(Attachment other)
         {
             var firstPart = Equals(Uri, other.Uri) && ValueEncoding.Equals(other.ValueEncoding);
             return Data == null

--- a/v2/ical.NET/DataTypes/Attendee.cs
+++ b/v2/ical.NET/DataTypes/Attendee.cs
@@ -7,7 +7,7 @@ using Ical.Net.Utility;
 
 namespace Ical.Net.DataTypes
 {
-    public class Attendee : EncodableDataType, IAttendee
+    public class Attendee : EncodableDataType, IAttendee, IEquatable<Attendee>
     {
         private Uri _sentBy;
         /// <summary> SENT-BY, to indicate who is acting on behalf of the ATTENDEE </summary>
@@ -247,7 +247,7 @@ namespace Ical.Net.DataTypes
         //ToDo: See if this can be deleted
         public override void CopyFrom(ICopyable obj) {}
 
-        protected bool Equals(Attendee other)
+        public bool Equals(Attendee other)
         {
             return Equals(SentBy, other.SentBy)
                 && string.Equals(CommonName, other.CommonName, StringComparison.OrdinalIgnoreCase)

--- a/v2/ical.NET/DataTypes/GeographicLocation.cs
+++ b/v2/ical.NET/DataTypes/GeographicLocation.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using Ical.Net.Interfaces.DataTypes;
 using Ical.Net.Interfaces.General;
@@ -10,7 +11,7 @@ namespace Ical.Net.DataTypes
     /// <see cref="Components.Event"/> or <see cref="Components.Todo"/> item.
     /// </summary>
     [DebuggerDisplay("{Latitude};{Longitude}")]
-    public class GeographicLocation : EncodableDataType, IGeographicLocation
+    public class GeographicLocation : EncodableDataType, IGeographicLocation, IEquatable<GeographicLocation>
     {
         public double Latitude { get; set; }
         public double Longitude { get; set; }
@@ -36,7 +37,7 @@ namespace Ical.Net.DataTypes
             return Latitude.ToString("0.000000") + ";" + Longitude.ToString("0.000000");
         }
 
-        protected bool Equals(GeographicLocation other)
+        public bool Equals(GeographicLocation other)
         {
             return Latitude.Equals(other.Latitude) && Longitude.Equals(other.Longitude);
         }

--- a/v2/ical.NET/DataTypes/Occurrence.cs
+++ b/v2/ical.NET/DataTypes/Occurrence.cs
@@ -4,7 +4,7 @@ using Ical.Net.Interfaces.Evaluation;
 
 namespace Ical.Net.DataTypes
 {
-    public class Occurrence : IComparable<Occurrence>
+    public class Occurrence : IComparable<Occurrence>, IEquatable<Occurrence>
     {
         public IPeriod Period { get; set; }
         public IRecurrable Source { get; set; }

--- a/v2/ical.NET/DataTypes/Organizer.cs
+++ b/v2/ical.NET/DataTypes/Organizer.cs
@@ -11,7 +11,7 @@ namespace Ical.Net.DataTypes
     /// A class that represents the organizer of an event/todo/journal.
     /// </summary>
     [DebuggerDisplay("{Value}")]
-    public class Organizer : EncodableDataType, IOrganizer
+    public class Organizer : EncodableDataType, IOrganizer, IEquatable<Organizer>
     {
         public virtual Uri SentBy
         {
@@ -61,7 +61,7 @@ namespace Ical.Net.DataTypes
             CopyFrom(serializer.Deserialize(new StringReader(value)) as ICopyable);
         }
 
-        protected bool Equals(Organizer other)
+        public bool Equals(Organizer other)
         {
             return Equals(Value, other.Value);
         }

--- a/v2/ical.NET/DataTypes/Period.cs
+++ b/v2/ical.NET/DataTypes/Period.cs
@@ -84,22 +84,7 @@ namespace Ical.Net.DataTypes
             }
         }
 
-        public int CompareTo(Period other)
-        {
-            if (StartTime.Equals(other.StartTime))
-            {
-                return 0;
-            }
-            if (StartTime.LessThan(other.StartTime))
-            {
-                return -1;
-            }
-            if (StartTime.GreaterThan(other.StartTime))
-            {
-                return 1;
-            }
-            throw new Exception("An error occurred while comparing two Periods.");
-        }
+        public int CompareTo(Period other) => CompareTo((IPeriod)other);
 
         public override string ToString()
         {
@@ -195,25 +180,21 @@ namespace Ical.Net.DataTypes
                 && ((period.StartTime != null && Contains(period.StartTime)) || (period.EndTime != null && Contains(period.EndTime)));
         }
 
-        public int CompareTo(IPeriod p)
+        public int CompareTo(IPeriod other)
         {
-            if (p == null)
-            {
-                throw new ArgumentNullException(nameof(p));
-            }
-            if (Equals(p))
-            {
-                return 0;
-            }
-            if (StartTime.LessThan(p.StartTime))
-            {
-                return -1;
-            }
-            if (StartTime.GreaterThanOrEqual(p.StartTime))
+            if (ReferenceEquals(other, null))
             {
                 return 1;
             }
-            throw new Exception("An error occurred while comparing Period values.");
+            if (StartTime.GreaterThanOrEqual(other.StartTime))
+            {
+                return 1;
+            }
+            if (Equals(other)) 
+            {
+                return 0;
+            }
+            return -1;
         }
     }
 }

--- a/v2/ical.NET/DataTypes/Period.cs
+++ b/v2/ical.NET/DataTypes/Period.cs
@@ -6,7 +6,7 @@ using Ical.Net.Serialization.iCalendar.Serializers.DataTypes;
 namespace Ical.Net.DataTypes
 {
     /// <summary> Represents an iCalendar period of time. </summary>    
-    public class Period : EncodableDataType, IPeriod, IComparable<Period>
+    public class Period : EncodableDataType, IPeriod, IComparable<Period>, IEquatable<Period>
     {
         public Period() { }
 
@@ -60,7 +60,7 @@ namespace Ical.Net.DataTypes
             Duration = p.Duration;
         }
 
-        protected bool Equals(Period other)
+        public bool Equals(Period other)
         {
             return Equals(StartTime, other.StartTime) && Equals(EndTime, other.EndTime) && Duration.Equals(other.Duration);
         }

--- a/v2/ical.NET/DataTypes/PeriodList.cs
+++ b/v2/ical.NET/DataTypes/PeriodList.cs
@@ -33,7 +33,7 @@ namespace Ical.Net.DataTypes
 
         public bool Equals(PeriodList other)
         {
-            return string.Equals(TzId, other.TzId) && CollectionHelpers.Equals(Periods, other.Periods);
+            return string.Equals(TzId, other.TzId, StringComparison.OrdinalIgnoreCase) && CollectionHelpers.Equals(Periods, other.Periods);
         }
 
         public override bool Equals(object obj)

--- a/v2/ical.NET/DataTypes/PeriodList.cs
+++ b/v2/ical.NET/DataTypes/PeriodList.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -12,7 +13,7 @@ namespace Ical.Net.DataTypes
     /// <summary>
     /// An iCalendar list of recurring dates (or date exclusions)
     /// </summary>
-    public class PeriodList : EncodableDataType, IPeriodList
+    public class PeriodList : EncodableDataType, IPeriodList, IEquatable<PeriodList>
     {
         public string TzId { get; set; }
         public int Count => Periods.Count;
@@ -30,7 +31,7 @@ namespace Ical.Net.DataTypes
             CopyFrom(serializer.Deserialize(new StringReader(value)) as ICopyable);
         }
 
-        protected bool Equals(PeriodList other)
+        public bool Equals(PeriodList other)
         {
             return string.Equals(TzId, other.TzId) && CollectionHelpers.Equals(Periods, other.Periods);
         }

--- a/v2/ical.NET/DataTypes/RecurrencePattern.cs
+++ b/v2/ical.NET/DataTypes/RecurrencePattern.cs
@@ -13,7 +13,7 @@ namespace Ical.Net.DataTypes
     /// <summary>
     /// An iCalendar representation of the <c>RRULE</c> property.
     /// </summary>
-    public class RecurrencePattern : EncodableDataType, IRecurrencePattern
+    public class RecurrencePattern : EncodableDataType, IRecurrencePattern, IEquatable<RecurrencePattern>
     {
         private int _interval = int.MinValue;
         private RecurrenceRestrictionType? _restrictionType;
@@ -113,7 +113,7 @@ namespace Ical.Net.DataTypes
             return serializer.SerializeToString(this);
         }
 
-        protected bool Equals(RecurrencePattern other)
+        public bool Equals(RecurrencePattern other)
         {
             return (Interval == other.Interval)
                 && (RestrictionType == other.RestrictionType)

--- a/v2/ical.NET/DataTypes/RequestStatus.cs
+++ b/v2/ical.NET/DataTypes/RequestStatus.cs
@@ -66,7 +66,8 @@ namespace Ical.Net.DataTypes
 
         public bool Equals(RequestStatus other)
         {
-            return string.Equals(_mDescription, other._mDescription) && string.Equals(_mExtraData, other._mExtraData) &&
+            return string.Equals(_mDescription, other._mDescription, StringComparison.OrdinalIgnoreCase) && 
+                   string.Equals(_mExtraData, other._mExtraData, StringComparison.OrdinalIgnoreCase) &&
                    Equals(_mStatusCode, other._mStatusCode);
         }
 

--- a/v2/ical.NET/DataTypes/RequestStatus.cs
+++ b/v2/ical.NET/DataTypes/RequestStatus.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using Ical.Net.Interfaces.DataTypes;
 using Ical.Net.Interfaces.General;
@@ -8,7 +9,7 @@ namespace Ical.Net.DataTypes
     /// <summary>
     /// A class that represents the return status of an iCalendar request.
     /// </summary>
-    public class RequestStatus : EncodableDataType, IRequestStatus
+    public class RequestStatus : EncodableDataType, IRequestStatus, IEquatable<RequestStatus>
     {
         private string _mDescription;
         private string _mExtraData;
@@ -63,7 +64,7 @@ namespace Ical.Net.DataTypes
             return serializer.SerializeToString(this);
         }
 
-        protected bool Equals(RequestStatus other)
+        public bool Equals(RequestStatus other)
         {
             return string.Equals(_mDescription, other._mDescription) && string.Equals(_mExtraData, other._mExtraData) &&
                    Equals(_mStatusCode, other._mStatusCode);

--- a/v2/ical.NET/DataTypes/StatusCode.cs
+++ b/v2/ical.NET/DataTypes/StatusCode.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using Ical.Net.Interfaces.DataTypes;
@@ -10,7 +11,7 @@ namespace Ical.Net.DataTypes
     /// <summary>
     /// An iCalendar status code.
     /// </summary>
-    public class StatusCode : EncodableDataType, IStatusCode
+    public class StatusCode : EncodableDataType, IStatusCode, IEquatable<StatusCode>
     {
         public int[] Parts { get; private set; }
 
@@ -72,7 +73,7 @@ namespace Ical.Net.DataTypes
 
         public override string ToString() => new StatusCodeSerializer().SerializeToString(this);
 
-        protected bool Equals(StatusCode other) => Parts.SequenceEqual(other.Parts);
+        public bool Equals(StatusCode other) => Parts.SequenceEqual(other.Parts);
 
         public override bool Equals(object obj)
         {

--- a/v2/ical.NET/DataTypes/Trigger.cs
+++ b/v2/ical.NET/DataTypes/Trigger.cs
@@ -10,7 +10,7 @@ namespace Ical.Net.DataTypes
     /// A class that is used to specify exactly when an <see cref="Components.Alarm"/> component will trigger.
     /// Usually this date/time is relative to the component to which the Alarm is associated.
     /// </summary>    
-    public class Trigger : EncodableDataType, ITrigger
+    public class Trigger : EncodableDataType, ITrigger, IEquatable<Trigger>
     {
         private IDateTime _mDateTime;
         private TimeSpan? _mDuration;
@@ -85,7 +85,7 @@ namespace Ical.Net.DataTypes
             }
         }
 
-        protected bool Equals(Trigger other)
+        public bool Equals(Trigger other)
         {
             return Equals(_mDateTime, other._mDateTime) && _mDuration.Equals(other._mDuration) && _mRelated == other._mRelated;
         }

--- a/v2/ical.NET/DataTypes/UTCOffset.cs
+++ b/v2/ical.NET/DataTypes/UTCOffset.cs
@@ -7,7 +7,7 @@ namespace Ical.Net.DataTypes
     /// <summary>
     /// Represents a time offset from UTC (Coordinated Universal Time).
     /// </summary>
-    public class UtcOffset : EncodableDataType, IUtcOffset
+    public class UtcOffset : EncodableDataType, IUtcOffset, IEquatable<UtcOffset>
     {
         public TimeSpan Offset { get; }
 
@@ -39,7 +39,7 @@ namespace Ical.Net.DataTypes
 
         public virtual DateTime ToLocal(DateTime dt) => DateTime.SpecifyKind(dt.Add(Offset), DateTimeKind.Local);
 
-        protected bool Equals(UtcOffset other)
+        public bool Equals(UtcOffset other)
         {
             return Offset == other.Offset;
         }

--- a/v2/ical.NET/DataTypes/WeekDay.cs
+++ b/v2/ical.NET/DataTypes/WeekDay.cs
@@ -9,7 +9,7 @@ namespace Ical.Net.DataTypes
     /// <summary>
     /// Represents an RFC 5545 "BYDAY" value.
     /// </summary>
-    public class WeekDay : EncodableDataType, IWeekDay, IEquatable<WeekDay>
+    public class WeekDay : EncodableDataType, IWeekDay, IComparable, IComparable<IWeekDay>, IEquatable<WeekDay>
     {
         public virtual int Offset { get; set; } = int.MinValue;
 
@@ -65,30 +65,29 @@ namespace Ical.Net.DataTypes
                 Offset = bd.Offset;
                 DayOfWeek = bd.DayOfWeek;
             }
-        }
+        }      
 
-        public int CompareTo(object obj)
-        {
-            IWeekDay bd = null;
-            if (obj is string)
-            {
-                bd = new WeekDay(obj.ToString());
-            }
-            else if (obj is IWeekDay)
-            {
-                bd = (IWeekDay) obj;
-            }
-
-            if (bd == null)
-            {
+        public int CompareTo(IWeekDay other) {
+            if (other == null) {
                 throw new ArgumentException();
             }
-            var compare = DayOfWeek.CompareTo(bd.DayOfWeek);
-            if (compare == 0)
-            {
-                compare = Offset.CompareTo(bd.Offset);
+            var compare = DayOfWeek.CompareTo(other.DayOfWeek);
+            if (compare == 0) {
+                compare = Offset.CompareTo(other.Offset);
             }
             return compare;
+        }
+
+        public int CompareTo(object obj) {
+            IWeekDay bd = null;
+            if (obj is string) {
+                bd = new WeekDay(obj.ToString());
+            }
+            else if (obj is IWeekDay) {
+                bd = (IWeekDay)obj;
+            }
+
+            return CompareTo(bd);
         }
     }
 }

--- a/v2/ical.NET/DataTypes/WeekDay.cs
+++ b/v2/ical.NET/DataTypes/WeekDay.cs
@@ -9,7 +9,7 @@ namespace Ical.Net.DataTypes
     /// <summary>
     /// Represents an RFC 5545 "BYDAY" value.
     /// </summary>
-    public class WeekDay : EncodableDataType, IWeekDay, IComparable, IComparable<IWeekDay>, IEquatable<WeekDay>
+    public class WeekDay : EncodableDataType, IWeekDay, IComparable<WeekDay>, IEquatable<WeekDay>
     {
         public virtual int Offset { get; set; } = int.MinValue;
 
@@ -67,27 +67,18 @@ namespace Ical.Net.DataTypes
             }
         }      
 
-        public int CompareTo(IWeekDay other) {
-            if (other == null) {
-                throw new ArgumentException();
+        public int CompareTo(WeekDay other) 
+        {
+            if (ReferenceEquals(other, null)) 
+            {
+                return 1;
             }
             var compare = DayOfWeek.CompareTo(other.DayOfWeek);
-            if (compare == 0) {
+            if (compare == 0) 
+            {
                 compare = Offset.CompareTo(other.Offset);
             }
             return compare;
-        }
-
-        public int CompareTo(object obj) {
-            IWeekDay bd = null;
-            if (obj is string) {
-                bd = new WeekDay(obj.ToString());
-            }
-            else if (obj is IWeekDay) {
-                bd = (IWeekDay)obj;
-            }
-
-            return CompareTo(bd);
         }
     }
 }

--- a/v2/ical.NET/DataTypes/WeekDay.cs
+++ b/v2/ical.NET/DataTypes/WeekDay.cs
@@ -9,7 +9,7 @@ namespace Ical.Net.DataTypes
     /// <summary>
     /// Represents an RFC 5545 "BYDAY" value.
     /// </summary>
-    public class WeekDay : EncodableDataType, IWeekDay
+    public class WeekDay : EncodableDataType, IWeekDay, IEquatable<WeekDay>
     {
         public virtual int Offset { get; set; } = int.MinValue;
 
@@ -37,6 +37,8 @@ namespace Ical.Net.DataTypes
             var serializer = new WeekDaySerializer();
             CopyFrom(serializer.Deserialize(new StringReader(value)) as ICopyable);
         }
+
+        public bool Equals(WeekDay other) => other.Offset == Offset && other.DayOfWeek == DayOfWeek;
 
         public override bool Equals(object obj)
         {

--- a/v2/ical.NET/DataTypes/iCalDateTime.cs
+++ b/v2/ical.NET/DataTypes/iCalDateTime.cs
@@ -15,7 +15,7 @@ namespace Ical.Net.DataTypes
     /// class handles time zone differences, and integrates seamlessly into the iCalendar framework.
     /// </remarks>
     /// </summary>
-    public sealed class CalDateTime : EncodableDataType, IDateTime, IEquatable<IDateTime>
+    public sealed class CalDateTime : EncodableDataType, IComparable<IDateTime>, IDateTime, IEquatable<IDateTime>
     {
         public static CalDateTime Now => new CalDateTime(DateTime.Now);
 
@@ -59,6 +59,7 @@ namespace Ical.Net.DataTypes
         }
 
         public CalDateTime(int year, int month, int day) : this(year, month, day, 0, 0, 0) {}
+
         public CalDateTime(int year, int month, int day, string tzId) : this(year, month, day, 0, 0, 0, tzId) {}
 
         public CalDateTime(string value)

--- a/v2/ical.NET/DataTypes/iCalDateTime.cs
+++ b/v2/ical.NET/DataTypes/iCalDateTime.cs
@@ -15,7 +15,7 @@ namespace Ical.Net.DataTypes
     /// class handles time zone differences, and integrates seamlessly into the iCalendar framework.
     /// </remarks>
     /// </summary>
-    public sealed class CalDateTime : EncodableDataType, IComparable<IDateTime>, IDateTime, IEquatable<IDateTime>
+    public sealed class CalDateTime : EncodableDataType, IDateTime, IEquatable<CalDateTime>
     {
         public static CalDateTime Now => new CalDateTime(DateTime.Now);
 
@@ -141,7 +141,7 @@ namespace Ical.Net.DataTypes
             }
         }
 
-        public bool Equals(IDateTime other) => Equals(other.AsUtc, AsUtc);
+        public bool Equals(CalDateTime other) => Equals(other.AsUtc, AsUtc);
 
         //ToDo: Time zone equality should include time zone values. Perhaps we should separate the idea of "equal" with "equivalent
         /// <summary>Equality is determined by the unambiguous UTC representation of the time. Time zone string values are ignored.</summary>
@@ -520,21 +520,21 @@ namespace Ical.Net.DataTypes
             }
         }
 
-        public int CompareTo(IDateTime dt)
+        public int CompareTo(IDateTime other)
         {
-            if (Equals(dt))
-            {
-                return 0;
-            }
-            if (this < dt)
-            {
-                return -1;
-            }
-            if (this > dt)
+            if (ReferenceEquals(other, null)) 
             {
                 return 1;
             }
-            throw new Exception("An error occurred while comparing two IDateTime values.");
+            if (this > other)
+            {
+                return 1;
+            }
+            if (Equals(other)) 
+            {
+                return 0;
+            }
+            return -1;
         }
 
         public string ToString(string format)

--- a/v2/ical.NET/DataTypes/iCalDateTime.cs
+++ b/v2/ical.NET/DataTypes/iCalDateTime.cs
@@ -15,7 +15,7 @@ namespace Ical.Net.DataTypes
     /// class handles time zone differences, and integrates seamlessly into the iCalendar framework.
     /// </remarks>
     /// </summary>
-    public sealed class CalDateTime : EncodableDataType, IDateTime
+    public sealed class CalDateTime : EncodableDataType, IDateTime, IEquatable<IDateTime>
     {
         public static CalDateTime Now => new CalDateTime(DateTime.Now);
 
@@ -139,6 +139,8 @@ namespace Ical.Net.DataTypes
                 AssociateWith(dt);
             }
         }
+
+        public bool Equals(IDateTime other) => Equals(other.AsUtc, AsUtc);
 
         //ToDo: Time zone equality should include time zone values. Perhaps we should separate the idea of "equal" with "equivalent
         /// <summary>Equality is determined by the unambiguous UTC representation of the time. Time zone string values are ignored.</summary>

--- a/v2/ical.NET/General/CalendarObject.cs
+++ b/v2/ical.NET/General/CalendarObject.cs
@@ -10,7 +10,7 @@ namespace Ical.Net.General
     /// <summary>
     /// The base class for all iCalendar objects and components.
     /// </summary>
-    public class CalendarObject : CalendarObjectBase, ICalendarObject
+    public class CalendarObject : CalendarObjectBase, ICalendarObject, IEquatable<CalendarObject>
     {
         private ICalendarObjectList<ICalendarObject> _children;
         private ServiceProvider _serviceProvider;
@@ -65,7 +65,7 @@ namespace Ical.Net.General
             e.First.Parent = this;
         }
 
-        protected bool Equals(CalendarObject other) => string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase);
+        public bool Equals(CalendarObject other) => string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase);
 
         public override bool Equals(object obj)
         {

--- a/v2/ical.NET/Interfaces/DataTypes/IWeekDay.cs
+++ b/v2/ical.NET/Interfaces/DataTypes/IWeekDay.cs
@@ -2,7 +2,7 @@
 
 namespace Ical.Net.Interfaces.DataTypes
 {
-    public interface IWeekDay : IEncodableDataType, IComparable
+    public interface IWeekDay : IEncodableDataType
     {
         int Offset { get; set; }
         DayOfWeek DayOfWeek { get; set; }


### PR DESCRIPTION
All the classes amended have had implemented the IEquatable<T> interface already. This change simply add the interface at the class definition. 