### PR TITLE
Add unit tests for RequestStatus class

### DIFF
--- a/net-core/Ical.Net/Ical.Net.UnitTests/DataTypes/RequestStatusTest.cs
+++ b/net-core/Ical.Net/Ical.Net.UnitTests/DataTypes/RequestStatusTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Ical.Net.DataTypes;
 using Ical.Net.Interfaces.General;
 using NUnit.Framework;
@@ -8,15 +9,10 @@ namespace Ical.Net.UnitTests
 {
     public class RequestStatusTest
     {
-        private static IEnumerable<ITestCaseData> ConstructorTestCases()
+        [Test]
+        public void NullStringConstructorThrowsException()
         {
-            var emptyRequestStatus = new RequestStatus();
-            yield return new TestCaseData(emptyRequestStatus, null, null, null)
-                .SetName("Default request status constructor has null properties");
-
-            var invalidSerializedValue = new RequestStatus("ABC");
-            yield return new TestCaseData(invalidSerializedValue, null, null, null)
-                .SetName("Constructor with invalid serialised text has null properties");
+            Assert.Throws<ArgumentNullException>(() => new StatusCode((string)null));
         }
 
         [Test, TestCaseSource(nameof(ConstructorTestCases))]
@@ -27,31 +23,19 @@ namespace Ical.Net.UnitTests
             Assert.AreEqual(incoming.ExtraData, expectedExtraData);
         }
 
+        private static IEnumerable<ITestCaseData> ConstructorTestCases()
+        {
+            var empty = new RequestStatus();
+            yield return new TestCaseData(empty, null, null, null)
+                .SetName("Default request status constructor has null properties");
+
+            var invalidSerializedValue = new RequestStatus("ABC");
+            yield return new TestCaseData(invalidSerializedValue, null, null, null)
+                .SetName("Constructor invoked with invalid serialised text has null properties");
+        }
+
         [Test, Ignore("Understand what 'valid' values RequestStatusSerializer expects")]
         public void InitialObjectState_Constructor_ValidSerialisedValue() { }
-
-        private static IEnumerable<ITestCaseData> ToStringTestCases()
-        {
-            var emptyRequestStatus = new RequestStatus();
-            yield return new TestCaseData(emptyRequestStatus, ";")
-                .SetName("ToString() for empty request status should return semicolon");
-
-            var emptyStringPropertiesRequestStatus = new RequestStatus()
-            {
-                Description = "",
-                ExtraData = ""
-            };
-            yield return new TestCaseData(emptyStringPropertiesRequestStatus, ";")
-                .SetName("ToString() for request status with empty string properties should return semicolon");
-
-            var nonEmptyStringPropertiesRequestStatus = new RequestStatus()
-            {
-                Description = "ABC Description",
-                ExtraData = "ABC ExtraData"
-            };
-            yield return new TestCaseData(nonEmptyStringPropertiesRequestStatus, ";ABC Description;ABC ExtraData")
-                .SetName("ToString() for request status should return semicolon separated values");
-        }
 
         [Test, TestCaseSource(nameof(ToStringTestCases))]
         public void ToStringTests(RequestStatus incoming, string expected)
@@ -59,25 +43,28 @@ namespace Ical.Net.UnitTests
             Assert.AreEqual(expected, incoming.ToString());
         }
 
-        private static IEnumerable<ITestCaseData> EqualsTestCases()
+        private static IEnumerable<ITestCaseData> ToStringTestCases()
         {
-            var requestStatus = new RequestStatus();
-            yield return new TestCaseData(requestStatus, requestStatus, true)
-                .SetName("Equals() same request status should return true");
+            var empty = new RequestStatus();
+            yield return new TestCaseData(empty, null)
+                .SetName("ToString() for empty request status")
+                .Ignore("Unit test is correct. ToString() should return null");
 
-            yield return new TestCaseData(requestStatus, new RequestStatus(), true)
-                .SetName("Equals() for request statuses with equal properties should return true");
-
-            var secondReferenceVariable = requestStatus;
-            yield return new TestCaseData(requestStatus, secondReferenceVariable, true)
-                .SetName("Equals() for two variables referencing the same object should return true");
-
-            var requestStatusWithPropertyValues = new RequestStatus()
+            var emptyStringProperties = new RequestStatus()
             {
-                Description = "ABC Description"
+                Description = "",
+                ExtraData = ""
             };
-            yield return new TestCaseData(requestStatus, requestStatusWithPropertyValues, false)
-                .SetName("Equals() for request statuses with inequal properties should return false");
+            yield return new TestCaseData(emptyStringProperties, ";")
+                .SetName("ToString() for request status with empty string properties");
+
+            var nonEmptyStringProperties = new RequestStatus()
+            {
+                Description = "ABC Description",
+                ExtraData = "ABC ExtraData"
+            };
+            yield return new TestCaseData(nonEmptyStringProperties, ";ABC Description;ABC ExtraData")
+                .SetName("ToString() for request status returns semicolon separated values");
         }
 
         [Test, TestCaseSource(nameof(EqualsTestCases))]
@@ -89,51 +76,74 @@ namespace Ical.Net.UnitTests
         [Test, TestCaseSource(nameof(EqualsTestCases))]
         public void EqualsTests(RequestStatus incoming, object other, bool expected)
         {
-            Assert.AreEqual(expected, incoming.Equals((object)other));
+            Assert.AreEqual(expected, incoming.Equals(other));
+        }
+
+        private static IEnumerable<ITestCaseData> EqualsTestCases()
+        {
+            var requestStatus = new RequestStatus();
+            yield return new TestCaseData(requestStatus, null, false)
+                .SetName("Equals() compares with null");
+
+            yield return new TestCaseData(requestStatus, requestStatus, true)
+                .SetName("Equals() compares with itself");
+
+            yield return new TestCaseData(requestStatus, new RequestStatus(), true)
+                .SetName("Equals() compares request statuses with equal properties");
+
+            var secondReferenceVariable = requestStatus;
+            yield return new TestCaseData(requestStatus, secondReferenceVariable, true)
+                .SetName("Equals() compares two variables referencing the same object");
+
+            var requestStatusWithPropertyValues = new RequestStatus()
+            {
+                Description = "ABC Description"
+            };
+            yield return new TestCaseData(requestStatus, requestStatusWithPropertyValues, false)
+                .SetName("Equals() compares request statuses with different property values");
+        }
+
+        [Test, TestCaseSource(nameof(GetHashCodeTestCases))]
+        public void GetHashCodeTests(RequestStatus incoming, RequestStatus other, bool expected)
+        {
+            Assert.AreEqual(expected, incoming.GetHashCode() == other.GetHashCode());
         }
 
         private static IEnumerable<ITestCaseData> GetHashCodeTestCases()
         {
-            var emptyRequestStatus = new RequestStatus();
-            yield return new TestCaseData(emptyRequestStatus, 0)
+            var empty = new RequestStatus();
+            var emptyOther = new RequestStatus();
+            yield return new TestCaseData(empty, emptyOther, true)
                 .SetName("GetHashCode() for empty request status");
 
-            var emptyPropertiesRequestStatus = new RequestStatus()
+            var emptyProperties = new RequestStatus()
             {
                 Description = "",
                 ExtraData = "",
                 StatusCode = new StatusCode()
             };
-            yield return new TestCaseData(emptyPropertiesRequestStatus, 666477112)
-                .SetName("GetHashCode() for request status with empty properties");
-
-            var normalRequestStatus = new RequestStatus()
+            var emptyPropertiesOther = new RequestStatus()
             {
-                Description = "ABC Description",
-                ExtraData = "ABC ExtraData",
+                Description = "",
+                ExtraData = "",
                 StatusCode = new StatusCode()
             };
-            yield return new TestCaseData(normalRequestStatus, -150101454)
-                .SetName("GetHashCode() for initialised request status");
-        }
+            yield return new TestCaseData(emptyProperties, emptyPropertiesOther, true)
+                .SetName("GetHashCode() for request status with empty properties");
 
-        [Test, TestCaseSource(nameof(GetHashCodeTestCases))]
-        public void GetHashCodeTests(RequestStatus incoming, int expected)
-        {
-            Assert.AreEqual(expected, incoming.GetHashCode());
-        }
+            var normal = new RequestStatus()
+            {
+                Description = "ABC Description"
+            };
+            var normalOther = new RequestStatus()
+            {
+                Description = "ABC Description"
+            };
+            yield return new TestCaseData(normal, normalOther, true)
+                .SetName("GetHashCode() for request status");
 
-        private class Copyable : ICopyable
-        {
-            public T Copy<T>() { return default(T); }
-
-            public void CopyFrom(ICopyable obj) { }
-        }
-
-        private static IEnumerable<ITestCaseData> CopyFrom_InvalidTestCases()
-        {
-            yield return new TestCaseData(new RequestStatus(), null).SetName("Request status CopyFrom() null");
-            yield return new TestCaseData(new RequestStatus(), new Copyable()).SetName("Request status CopyFrom() non-IRequestStatus type");
+            yield return new TestCaseData(normal, emptyPropertiesOther, false)
+                .SetName("GetHashCode() compare empty request status and request status with empty properties");
         }
 
         [Test, TestCaseSource(nameof(CopyFrom_InvalidTestCases))]
@@ -144,6 +154,29 @@ namespace Ical.Net.UnitTests
             Assert.IsNull(incoming.StatusCode);
             Assert.IsNull(incoming.Description);
             Assert.IsNull(incoming.ExtraData);
+        }
+
+        private static IEnumerable<ITestCaseData> CopyFrom_InvalidTestCases()
+        {
+            yield return new TestCaseData(new RequestStatus(), null).SetName("Request status CopyFrom() null");
+            yield return new TestCaseData(new RequestStatus(), new Copyable()).SetName("Request status CopyFrom() non-IRequestStatus type");
+        }
+
+        private class Copyable : ICopyable
+        {
+            public T Copy<T>() { return default(T); }
+
+            public void CopyFrom(ICopyable obj) { }
+        }
+
+        [Test, TestCaseSource(nameof(CopyFromTestCases))]
+        public void CopyFromTests(RequestStatus incoming, ICopyable copyable, string expectedDescription, string expectedExtraData)
+        {
+            incoming.CopyFrom(copyable);
+
+            Assert.AreEqual(expectedDescription, incoming.Description);
+            Assert.AreEqual(expectedExtraData, incoming.ExtraData);
+            Assert.IsNotNull(incoming.StatusCode);
         }
 
         private static IEnumerable<ITestCaseData> CopyFromTestCases()
@@ -177,16 +210,6 @@ namespace Ical.Net.UnitTests
                     normalRequestStatus, copySourceWithNullStatusCode,
                     copySourceWithNullStatusCode.Description, copySourceWithNullStatusCode.ExtraData)
                 .SetName("Request status copy from IRequestStatus type with null StatusCode");
-        }
-
-        [Test, TestCaseSource(nameof(CopyFromTestCases))]
-        public void CopyFromTests(RequestStatus incoming, ICopyable copyable, string expectedDescription, string expectedExtraData)
-        {
-            incoming.CopyFrom(copyable);
-
-            Assert.AreEqual(expectedDescription, incoming.Description);
-            Assert.AreEqual(expectedExtraData, incoming.ExtraData);
-            Assert.IsNotNull(incoming.StatusCode);
         }
     }
 }

--- a/net-core/Ical.Net/Ical.Net.UnitTests/DataTypes/RequestStatusTest.cs
+++ b/net-core/Ical.Net/Ical.Net.UnitTests/DataTypes/RequestStatusTest.cs
@@ -1,0 +1,181 @@
+﻿using Ical.Net.DataTypes;
+using Ical.Net.Interfaces.General;
+using NUnit.Framework;
+
+namespace Ical.Net.UnitTests
+{
+    [TestFixture]
+    public class RequestStatusTest
+    {
+        [Test]
+        public void InitialObjectState_Constructor_Default()
+        {
+            var requestStatus = new RequestStatus();
+
+            Assert.IsNull(requestStatus.StatusCode);
+            Assert.IsNull(requestStatus.Description);
+            Assert.IsNull(requestStatus.ExtraData);
+        }
+
+        [Test]
+        public void InitialObjectState_Constructor_InvalidSerialisedValue() 
+        {
+            var requestStatus = new RequestStatus("ABC");
+
+            Assert.IsNull(requestStatus.StatusCode);
+            Assert.IsNull(requestStatus.Description);
+            Assert.IsNull(requestStatus.ExtraData);
+        }
+
+        [Test, Ignore("Understand what 'valid' values RequestStatusSerializer expects")]
+        public void InitialObjectState_Constructor_ValidSerialisedValue() { }
+
+        [Test]
+        public void ToString_ValidInputWithNullStatusCode()
+        {
+            var requestStatusA = new RequestStatus();
+            var requestStatusB = new RequestStatus()
+            {
+                Description = "",
+                ExtraData = ""
+            };
+            var requestStatusC = new RequestStatus() 
+            {
+                Description = "ABC Description",
+                ExtraData = "ABC ExtraData"
+            };
+
+            Assert.AreEqual(";", requestStatusA.ToString());
+            Assert.AreEqual(";", requestStatusB.ToString());
+            Assert.AreEqual(";ABC Description;ABC ExtraData", requestStatusC.ToString());
+        }
+
+        [Test]
+        public void EqualsGeneric() 
+        {
+            var requestStatusA = new RequestStatus();
+            var requestStatusB = new RequestStatus();
+            var requestStatusC = requestStatusA;
+            var requestStatusD = new RequestStatus() 
+            {
+                Description = "ABC Description"
+            };
+
+            Assert.IsTrue(requestStatusA.Equals(requestStatusA));
+            Assert.IsTrue(requestStatusA.Equals(requestStatusB));
+            Assert.IsTrue(requestStatusA.Equals(requestStatusC));
+            Assert.IsFalse(requestStatusA.Equals(requestStatusD));
+        }
+
+        [Test]
+        public void EqualsNonGeneric() 
+        {
+            object requestStatusA = new RequestStatus();
+            object requestStatusB = new RequestStatus();
+            object requestStatusC = requestStatusA;
+            object requestStatusD = new RequestStatus()
+            {
+                Description = "ABC Description"
+            };
+
+            Assert.IsFalse(requestStatusA.Equals(null));
+            Assert.IsFalse(requestStatusA.Equals("Invalid type value"));
+            Assert.IsTrue(requestStatusA.Equals(requestStatusA));
+            Assert.IsTrue(requestStatusA.Equals(requestStatusB));
+            Assert.IsTrue(requestStatusA.Equals(requestStatusC));
+            Assert.IsFalse(requestStatusA.Equals(requestStatusD));
+        }
+
+        [Test]
+        public void GetHashCode_ValidObject()
+        {
+            var requestStatusA = new RequestStatus();
+            var requestStatusB = new RequestStatus() 
+            {
+                Description = "",
+                ExtraData = "",
+                StatusCode = new StatusCode()
+            };
+            var requestStatusC = new RequestStatus() 
+            {
+                Description = "ABC Description",
+                ExtraData = "ABC ExtraData",
+                StatusCode = new StatusCode()
+            };
+
+            Assert.AreEqual(0,  requestStatusA.GetHashCode());
+            Assert.AreEqual(666477112, requestStatusB.GetHashCode());
+            Assert.AreEqual(-150101454, requestStatusC.GetHashCode());
+        }
+
+        [Test]
+        public void CopyFrom_NullInput() 
+        {
+            var requestStatus = new RequestStatus();
+            requestStatus.CopyFrom(null);
+
+            Assert.IsNull(requestStatus.StatusCode);
+            Assert.IsNull(requestStatus.Description);
+            Assert.IsNull(requestStatus.ExtraData);
+        }
+
+        private class Copyable : ICopyable
+        {
+            public T Copy<T>() { return default(T); }
+
+            public void CopyFrom(ICopyable obj) { }
+        }
+
+        [Test]
+        public void CopyFrom_NonIRequestStatusTypeInput() 
+        {
+            var requestStatus = new RequestStatus();
+            requestStatus.CopyFrom(new Copyable());
+
+            Assert.IsNull(requestStatus.StatusCode);
+            Assert.IsNull(requestStatus.Description);
+            Assert.IsNull(requestStatus.ExtraData);
+        }
+
+        [Test]
+        public void CopyFrom_IRequestStatusTypeInput() 
+        {
+            var requestStatus = new RequestStatus();
+            var requestStatusCopyable = new RequestStatus() 
+            {
+                Description = "XYZ Description",
+                ExtraData = "XYZ ExtraData",
+                StatusCode = new StatusCode()
+            };
+
+            requestStatus.CopyFrom(requestStatusCopyable);
+
+            Assert.AreEqual("XYZ Description", requestStatus.Description);
+            Assert.AreEqual("XYZ ExtraData", requestStatus.ExtraData);
+            Assert.IsNotNull(requestStatus.StatusCode);
+        }
+
+        [Test]
+        public void CopyFrom_IRequestStatusTypeInputWithNullStatusCode() 
+        {
+            var requestStatus = new RequestStatus()
+            {
+                Description = "ABC Description",
+                ExtraData = "ABC ExtraData",
+                StatusCode = new StatusCode()
+            };
+            var requestStatusCopyable = new RequestStatus() 
+            {
+                Description = "XYZ Description",
+                ExtraData = "XYZ ExtraData",
+                StatusCode = null
+            };
+
+            requestStatus.CopyFrom(requestStatusCopyable);
+
+            Assert.AreEqual("XYZ Description", requestStatus.Description);
+            Assert.AreEqual("XYZ ExtraData", requestStatus.ExtraData);
+            Assert.IsNotNull(requestStatus.StatusCode);
+        }
+    }
+}

--- a/net-core/Ical.Net/Ical.Net.UnitTests/DataTypes/RequestStatusTest.cs
+++ b/net-core/Ical.Net/Ical.Net.UnitTests/DataTypes/RequestStatusTest.cs
@@ -1,122 +1,126 @@
-﻿using Ical.Net.DataTypes;
+﻿using System.Collections.Generic;
+using Ical.Net.DataTypes;
 using Ical.Net.Interfaces.General;
 using NUnit.Framework;
+using NUnit.Framework.Interfaces;
 
 namespace Ical.Net.UnitTests
 {
-    [TestFixture]
     public class RequestStatusTest
     {
-        [Test]
-        public void InitialObjectState_Constructor_Default()
+        private static IEnumerable<ITestCaseData> ConstructorTestCases()
         {
-            var requestStatus = new RequestStatus();
+            var emptyRequestStatus = new RequestStatus();
+            yield return new TestCaseData(emptyRequestStatus, null, null, null)
+                .SetName("Default request status constructor has null properties");
 
-            Assert.IsNull(requestStatus.StatusCode);
-            Assert.IsNull(requestStatus.Description);
-            Assert.IsNull(requestStatus.ExtraData);
+            var invalidSerializedValue = new RequestStatus("ABC");
+            yield return new TestCaseData(invalidSerializedValue, null, null, null)
+                .SetName("Constructor with invalid serialised text has null properties");
         }
 
-        [Test]
-        public void InitialObjectState_Constructor_InvalidSerialisedValue() 
+        [Test, TestCaseSource(nameof(ConstructorTestCases))]
+        public void ConstructorTests(RequestStatus incoming, string expectedDescription, string expectedStatusCode, string expectedExtraData)
         {
-            var requestStatus = new RequestStatus("ABC");
-
-            Assert.IsNull(requestStatus.StatusCode);
-            Assert.IsNull(requestStatus.Description);
-            Assert.IsNull(requestStatus.ExtraData);
+            Assert.AreEqual(incoming.StatusCode, expectedStatusCode);
+            Assert.AreEqual(incoming.Description, expectedDescription);
+            Assert.AreEqual(incoming.ExtraData, expectedExtraData);
         }
 
         [Test, Ignore("Understand what 'valid' values RequestStatusSerializer expects")]
         public void InitialObjectState_Constructor_ValidSerialisedValue() { }
 
-        [Test]
-        public void ToString_ValidInputWithNullStatusCode()
+        private static IEnumerable<ITestCaseData> ToStringTestCases()
         {
-            var requestStatusA = new RequestStatus();
-            var requestStatusB = new RequestStatus()
+            var emptyRequestStatus = new RequestStatus();
+            yield return new TestCaseData(emptyRequestStatus, ";")
+                .SetName("ToString() for empty request status should return semicolon");
+
+            var emptyStringPropertiesRequestStatus = new RequestStatus()
             {
                 Description = "",
                 ExtraData = ""
             };
-            var requestStatusC = new RequestStatus() 
+            yield return new TestCaseData(emptyStringPropertiesRequestStatus, ";")
+                .SetName("ToString() for request status with empty string properties should return semicolon");
+
+            var nonEmptyStringPropertiesRequestStatus = new RequestStatus()
             {
                 Description = "ABC Description",
                 ExtraData = "ABC ExtraData"
             };
-
-            Assert.AreEqual(";", requestStatusA.ToString());
-            Assert.AreEqual(";", requestStatusB.ToString());
-            Assert.AreEqual(";ABC Description;ABC ExtraData", requestStatusC.ToString());
+            yield return new TestCaseData(nonEmptyStringPropertiesRequestStatus, ";ABC Description;ABC ExtraData")
+                .SetName("ToString() for request status should return semicolon separated values");
         }
 
-        [Test]
-        public void EqualsGeneric() 
+        [Test, TestCaseSource(nameof(ToStringTestCases))]
+        public void ToStringTests(RequestStatus incoming, string expected)
         {
-            var requestStatusA = new RequestStatus();
-            var requestStatusB = new RequestStatus();
-            var requestStatusC = requestStatusA;
-            var requestStatusD = new RequestStatus() 
+            Assert.AreEqual(expected, incoming.ToString());
+        }
+
+        private static IEnumerable<ITestCaseData> EqualsTestCases()
+        {
+            var requestStatus = new RequestStatus();
+            yield return new TestCaseData(requestStatus, requestStatus, true)
+                .SetName("Equals() same request status should return true");
+
+            yield return new TestCaseData(requestStatus, new RequestStatus(), true)
+                .SetName("Equals() for request statuses with equal properties should return true");
+
+            var secondReferenceVariable = requestStatus;
+            yield return new TestCaseData(requestStatus, secondReferenceVariable, true)
+                .SetName("Equals() for two variables referencing the same object should return true");
+
+            var requestStatusWithPropertyValues = new RequestStatus()
             {
                 Description = "ABC Description"
             };
-
-            Assert.IsTrue(requestStatusA.Equals(requestStatusA));
-            Assert.IsTrue(requestStatusA.Equals(requestStatusB));
-            Assert.IsTrue(requestStatusA.Equals(requestStatusC));
-            Assert.IsFalse(requestStatusA.Equals(requestStatusD));
+            yield return new TestCaseData(requestStatus, requestStatusWithPropertyValues, false)
+                .SetName("Equals() for request statuses with inequal properties should return false");
         }
 
-        [Test]
-        public void EqualsNonGeneric() 
+        [Test, TestCaseSource(nameof(EqualsTestCases))]
+        public void EqualsGenericTests(RequestStatus incoming, RequestStatus other, bool expected)
         {
-            object requestStatusA = new RequestStatus();
-            object requestStatusB = new RequestStatus();
-            object requestStatusC = requestStatusA;
-            object requestStatusD = new RequestStatus()
-            {
-                Description = "ABC Description"
-            };
-
-            Assert.IsFalse(requestStatusA.Equals(null));
-            Assert.IsFalse(requestStatusA.Equals("Invalid type value"));
-            Assert.IsTrue(requestStatusA.Equals(requestStatusA));
-            Assert.IsTrue(requestStatusA.Equals(requestStatusB));
-            Assert.IsTrue(requestStatusA.Equals(requestStatusC));
-            Assert.IsFalse(requestStatusA.Equals(requestStatusD));
+            Assert.AreEqual(expected, incoming.Equals(other));
         }
 
-        [Test]
-        public void GetHashCode_ValidObject()
+        [Test, TestCaseSource(nameof(EqualsTestCases))]
+        public void EqualsTests(RequestStatus incoming, object other, bool expected)
         {
-            var requestStatusA = new RequestStatus();
-            var requestStatusB = new RequestStatus() 
+            Assert.AreEqual(expected, incoming.Equals((object)other));
+        }
+
+        private static IEnumerable<ITestCaseData> GetHashCodeTestCases()
+        {
+            var emptyRequestStatus = new RequestStatus();
+            yield return new TestCaseData(emptyRequestStatus, 0)
+                .SetName("GetHashCode() for empty request status");
+
+            var emptyPropertiesRequestStatus = new RequestStatus()
             {
                 Description = "",
                 ExtraData = "",
                 StatusCode = new StatusCode()
             };
-            var requestStatusC = new RequestStatus() 
+            yield return new TestCaseData(emptyPropertiesRequestStatus, 666477112)
+                .SetName("GetHashCode() for request status with empty properties");
+
+            var normalRequestStatus = new RequestStatus()
             {
                 Description = "ABC Description",
                 ExtraData = "ABC ExtraData",
                 StatusCode = new StatusCode()
             };
-
-            Assert.AreEqual(0,  requestStatusA.GetHashCode());
-            Assert.AreEqual(666477112, requestStatusB.GetHashCode());
-            Assert.AreEqual(-150101454, requestStatusC.GetHashCode());
+            yield return new TestCaseData(normalRequestStatus, -150101454)
+                .SetName("GetHashCode() for initialised request status");
         }
 
-        [Test]
-        public void CopyFrom_NullInput() 
+        [Test, TestCaseSource(nameof(GetHashCodeTestCases))]
+        public void GetHashCodeTests(RequestStatus incoming, int expected)
         {
-            var requestStatus = new RequestStatus();
-            requestStatus.CopyFrom(null);
-
-            Assert.IsNull(requestStatus.StatusCode);
-            Assert.IsNull(requestStatus.Description);
-            Assert.IsNull(requestStatus.ExtraData);
+            Assert.AreEqual(expected, incoming.GetHashCode());
         }
 
         private class Copyable : ICopyable
@@ -126,56 +130,63 @@ namespace Ical.Net.UnitTests
             public void CopyFrom(ICopyable obj) { }
         }
 
-        [Test]
-        public void CopyFrom_NonIRequestStatusTypeInput() 
+        private static IEnumerable<ITestCaseData> CopyFrom_InvalidTestCases()
         {
-            var requestStatus = new RequestStatus();
-            requestStatus.CopyFrom(new Copyable());
-
-            Assert.IsNull(requestStatus.StatusCode);
-            Assert.IsNull(requestStatus.Description);
-            Assert.IsNull(requestStatus.ExtraData);
+            yield return new TestCaseData(new RequestStatus(), null).SetName("Request status CopyFrom() null");
+            yield return new TestCaseData(new RequestStatus(), new Copyable()).SetName("Request status CopyFrom() non-IRequestStatus type");
         }
 
-        [Test]
-        public void CopyFrom_IRequestStatusTypeInput() 
+        [Test, TestCaseSource(nameof(CopyFrom_InvalidTestCases))]
+        public void CopyFromTests(RequestStatus incoming, ICopyable copyable)
         {
-            var requestStatus = new RequestStatus();
-            var requestStatusCopyable = new RequestStatus() 
+            incoming.CopyFrom(copyable);
+
+            Assert.IsNull(incoming.StatusCode);
+            Assert.IsNull(incoming.Description);
+            Assert.IsNull(incoming.ExtraData);
+        }
+
+        private static IEnumerable<ITestCaseData> CopyFromTestCases()
+        {
+            var emptyRequestStatus = new RequestStatus();
+            var copySource = new RequestStatus()
             {
                 Description = "XYZ Description",
                 ExtraData = "XYZ ExtraData",
                 StatusCode = new StatusCode()
             };
+            yield return new TestCaseData(emptyRequestStatus, copySource, copySource.Description, copySource.ExtraData)
+                .SetName("Empty request status copy from IRequestStatus type");
 
-            requestStatus.CopyFrom(requestStatusCopyable);
-
-            Assert.AreEqual("XYZ Description", requestStatus.Description);
-            Assert.AreEqual("XYZ ExtraData", requestStatus.ExtraData);
-            Assert.IsNotNull(requestStatus.StatusCode);
-        }
-
-        [Test]
-        public void CopyFrom_IRequestStatusTypeInputWithNullStatusCode() 
-        {
-            var requestStatus = new RequestStatus()
+            var normalRequestStatus = new RequestStatus()
             {
                 Description = "ABC Description",
                 ExtraData = "ABC ExtraData",
                 StatusCode = new StatusCode()
             };
-            var requestStatusCopyable = new RequestStatus() 
+            yield return new TestCaseData(normalRequestStatus, copySource, copySource.Description, copySource.ExtraData)
+                .SetName("Request status copy from IRequestStatus type");
+
+            var copySourceWithNullStatusCode = new RequestStatus()
             {
                 Description = "XYZ Description",
                 ExtraData = "XYZ ExtraData",
                 StatusCode = null
             };
+            yield return new TestCaseData(
+                    normalRequestStatus, copySourceWithNullStatusCode,
+                    copySourceWithNullStatusCode.Description, copySourceWithNullStatusCode.ExtraData)
+                .SetName("Request status copy from IRequestStatus type with null StatusCode");
+        }
 
-            requestStatus.CopyFrom(requestStatusCopyable);
+        [Test, TestCaseSource(nameof(CopyFromTestCases))]
+        public void CopyFromTests(RequestStatus incoming, ICopyable copyable, string expectedDescription, string expectedExtraData)
+        {
+            incoming.CopyFrom(copyable);
 
-            Assert.AreEqual("XYZ Description", requestStatus.Description);
-            Assert.AreEqual("XYZ ExtraData", requestStatus.ExtraData);
-            Assert.IsNotNull(requestStatus.StatusCode);
+            Assert.AreEqual(expectedDescription, incoming.Description);
+            Assert.AreEqual(expectedExtraData, incoming.ExtraData);
+            Assert.IsNotNull(incoming.StatusCode);
         }
     }
 }

--- a/net-core/Ical.Net/Ical.Net.UnitTests/Ical.Net.UnitTests.csproj
+++ b/net-core/Ical.Net/Ical.Net.UnitTests/Ical.Net.UnitTests.csproj
@@ -13,4 +13,7 @@
     <ProjectReference Include="..\Ical.Net.Collections\Ical.Net.Collections.csproj" />
     <ProjectReference Include="..\Ical.Net\Ical.Net.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="DataTypes\" />
+  </ItemGroup>
 </Project>

--- a/net-core/Ical.Net/Ical.Net/DataTypes/RequestStatus.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/RequestStatus.cs
@@ -53,7 +53,7 @@ namespace Ical.Net.DataTypes
                 StatusCode = rs.StatusCode;
             }
             Description = rs.Description;
-            rs.ExtraData = rs.ExtraData;
+            ExtraData = rs.ExtraData;
         }
 
         public override string ToString()

--- a/v2/ical.NET.UnitTests/DataTypes/RequestStatusTest.cs
+++ b/v2/ical.NET.UnitTests/DataTypes/RequestStatusTest.cs
@@ -1,123 +1,127 @@
-﻿using Ical.Net.DataTypes;
+﻿using System.Collections.Generic;
+using Ical.Net.DataTypes;
 using Ical.Net.Interfaces.General;
 using NUnit.Framework;
+using NUnit.Framework.Interfaces;
 
 namespace Ical.Net.UnitTests
 {
-    [TestFixture]
     public class RequestStatusTest
     {
-        [Test]
-        public void InitialObjectState_Constructor_Default()
+        private static IEnumerable<ITestCaseData> ConstructorTestCases() 
         {
-            var requestStatus = new RequestStatus();
+            var emptyRequestStatus = new RequestStatus();
+            yield return new TestCaseData(emptyRequestStatus, null, null, null)
+                .SetName("Default request status constructor has null properties");
 
-            Assert.IsNull(requestStatus.StatusCode);
-            Assert.IsNull(requestStatus.Description);
-            Assert.IsNull(requestStatus.ExtraData);
+            var invalidSerializedValue = new RequestStatus("ABC");
+            yield return new TestCaseData(invalidSerializedValue, null, null, null)
+                .SetName("Constructor with invalid serialised text has null properties");
         }
 
-        [Test]
-        public void InitialObjectState_Constructor_InvalidSerialisedValue() 
+        [Test, TestCaseSource(nameof(ConstructorTestCases))]
+        public void ConstructorTests(RequestStatus incoming, string expectedDescription, string expectedStatusCode, string expectedExtraData) 
         {
-            var requestStatus = new RequestStatus("ABC");
-
-            Assert.IsNull(requestStatus.StatusCode);
-            Assert.IsNull(requestStatus.Description);
-            Assert.IsNull(requestStatus.ExtraData);
+            Assert.AreEqual(incoming.StatusCode, expectedStatusCode);
+            Assert.AreEqual(incoming.Description, expectedDescription);
+            Assert.AreEqual(incoming.ExtraData, expectedExtraData);
         }
 
         [Test, Ignore("Understand what 'valid' values RequestStatusSerializer expects")]
         public void InitialObjectState_Constructor_ValidSerialisedValue() { }
 
-        [Test]
-        public void ToString_ValidInputWithNullStatusCode()
+        private static IEnumerable<ITestCaseData> ToStringTestCases() 
         {
-            var requestStatusA = new RequestStatus();
-            var requestStatusB = new RequestStatus()
+            var emptyRequestStatus = new RequestStatus();
+            yield return new TestCaseData(emptyRequestStatus, ";")
+                .SetName("ToString() for empty request status should return semicolon");
+
+            var emptyStringPropertiesRequestStatus = new RequestStatus()
             {
                 Description = "",
                 ExtraData = ""
             };
-            var requestStatusC = new RequestStatus() 
+            yield return new TestCaseData(emptyStringPropertiesRequestStatus, ";")
+                .SetName("ToString() for request status with empty string properties should return semicolon");
+
+            var nonEmptyStringPropertiesRequestStatus = new RequestStatus() 
             {
                 Description = "ABC Description",
                 ExtraData = "ABC ExtraData"
             };
-
-            Assert.AreEqual(";", requestStatusA.ToString());
-            Assert.AreEqual(";", requestStatusB.ToString());
-            Assert.AreEqual(";ABC Description;ABC ExtraData", requestStatusC.ToString());
+            yield return new TestCaseData(nonEmptyStringPropertiesRequestStatus, ";ABC Description;ABC ExtraData")
+                .SetName("ToString() for request status should return semicolon separated values");
         }
 
-        [Test]
-        public void EqualsGeneric() 
+        [Test, TestCaseSource(nameof(ToStringTestCases))]
+        public void ToStringTests(RequestStatus incoming, string expected) 
         {
-            var requestStatusA = new RequestStatus();
-            var requestStatusB = new RequestStatus();
-            var requestStatusC = requestStatusA;
-            var requestStatusD = new RequestStatus() 
+            Assert.AreEqual(expected, incoming.ToString());
+        }
+
+        private static IEnumerable<ITestCaseData> EqualsTestCases() 
+        {
+            var requestStatus = new RequestStatus();
+            yield return new TestCaseData(requestStatus, requestStatus, true)
+                .SetName("Equals() same request status should return true");
+
+            yield return new TestCaseData(requestStatus, new RequestStatus(), true)
+                .SetName("Equals() for request statuses with equal properties should return true");
+
+            var secondReferenceVariable = requestStatus;
+            yield return new TestCaseData(requestStatus, secondReferenceVariable, true)
+                .SetName("Equals() for two variables referencing the same object should return true");
+
+            var requestStatusWithPropertyValues = new RequestStatus() 
             {
                 Description = "ABC Description"
             };
-
-            Assert.IsTrue(requestStatusA.Equals(requestStatusA));
-            Assert.IsTrue(requestStatusA.Equals(requestStatusB));
-            Assert.IsTrue(requestStatusA.Equals(requestStatusC));
-            Assert.IsFalse(requestStatusA.Equals(requestStatusD));
+            yield return new TestCaseData(requestStatus, requestStatusWithPropertyValues, false)
+                .SetName("Equals() for request statuses with inequal properties should return false");
         }
 
-        [Test]
-        public void EqualsNonGeneric() 
+        [Test, TestCaseSource(nameof(EqualsTestCases))]
+        public void EqualsGenericTests(RequestStatus incoming, RequestStatus other, bool expected) 
         {
-            object requestStatusA = new RequestStatus();
-            object requestStatusB = new RequestStatus();
-            object requestStatusC = requestStatusA;
-            object requestStatusD = new RequestStatus()
-            {
-                Description = "ABC Description"
-            };
-
-            Assert.IsFalse(requestStatusA.Equals(null));
-            Assert.IsFalse(requestStatusA.Equals("Invalid type value"));
-            Assert.IsTrue(requestStatusA.Equals(requestStatusA));
-            Assert.IsTrue(requestStatusA.Equals(requestStatusB));
-            Assert.IsTrue(requestStatusA.Equals(requestStatusC));
-            Assert.IsFalse(requestStatusA.Equals(requestStatusD));
+            Assert.AreEqual(expected, incoming.Equals(other));
         }
 
-        [Test]
-        public void GetHashCode_ValidObject()
+        [Test, TestCaseSource(nameof(EqualsTestCases))]
+        public void EqualsTests(RequestStatus incoming, object other, bool expected) 
         {
-            var requestStatusA = new RequestStatus();
-            var requestStatusB = new RequestStatus() 
+            Assert.AreEqual(expected, incoming.Equals((object) other));
+        }
+
+        private static IEnumerable<ITestCaseData> GetHashCodeTestCases() 
+        {
+            var emptyRequestStatus = new RequestStatus();
+            yield return new TestCaseData(emptyRequestStatus, 0)
+                .SetName("GetHashCode() for empty request status");
+
+            var emptyPropertiesRequestStatus = new RequestStatus() 
             {
                 Description = "",
                 ExtraData = "",
                 StatusCode = new StatusCode()
             };
-            var requestStatusC = new RequestStatus() 
+            yield return new TestCaseData(emptyPropertiesRequestStatus, 666477112)
+                .SetName("GetHashCode() for request status with empty properties");
+
+            var normalRequestStatus = new RequestStatus() 
             {
                 Description = "ABC Description",
                 ExtraData = "ABC ExtraData",
                 StatusCode = new StatusCode()
             };
-
-            Assert.AreEqual(0,  requestStatusA.GetHashCode());
-            Assert.AreEqual(666477112, requestStatusB.GetHashCode());
-            Assert.AreEqual(-150101454, requestStatusC.GetHashCode());
+            yield return new TestCaseData(normalRequestStatus, -150101454)
+                .SetName("GetHashCode() for initialised request status");
         }
 
-        [Test]
-        public void CopyFrom_NullInput() 
+        [Test, TestCaseSource(nameof(GetHashCodeTestCases))]
+        public void GetHashCodeTests(RequestStatus incoming, int expected) 
         {
-            var requestStatus = new RequestStatus();
-            requestStatus.CopyFrom(null);
-
-            Assert.IsNull(requestStatus.StatusCode);
-            Assert.IsNull(requestStatus.Description);
-            Assert.IsNull(requestStatus.ExtraData);
-        }
+            Assert.AreEqual(expected, incoming.GetHashCode());
+        }      
 
         private class Copyable : ICopyable
         {
@@ -126,56 +130,63 @@ namespace Ical.Net.UnitTests
             public void CopyFrom(ICopyable obj) { }
         }
 
-        [Test]
-        public void CopyFrom_NonIRequestStatusTypeInput() 
+        private static IEnumerable<ITestCaseData> CopyFrom_InvalidTestCases() 
         {
-            var requestStatus = new RequestStatus();
-            requestStatus.CopyFrom(new Copyable());
-
-            Assert.IsNull(requestStatus.StatusCode);
-            Assert.IsNull(requestStatus.Description);
-            Assert.IsNull(requestStatus.ExtraData);
+            yield return new TestCaseData(new RequestStatus(), null).SetName("Request status CopyFrom() null");
+            yield return new TestCaseData(new RequestStatus(), new Copyable()).SetName("Request status CopyFrom() non-IRequestStatus type");
         }
 
-        [Test]
-        public void CopyFrom_IRequestStatusTypeInput() 
+        [Test, TestCaseSource(nameof(CopyFrom_InvalidTestCases))]
+        public void CopyFromTests(RequestStatus incoming, ICopyable copyable) 
         {
-            var requestStatus = new RequestStatus();
-            var requestStatusCopyable = new RequestStatus() 
+            incoming.CopyFrom(copyable);
+
+            Assert.IsNull(incoming.StatusCode);
+            Assert.IsNull(incoming.Description);
+            Assert.IsNull(incoming.ExtraData);
+        }
+
+        private static IEnumerable<ITestCaseData> CopyFromTestCases() 
+        {
+            var emptyRequestStatus = new RequestStatus();
+            var copySource = new RequestStatus() 
             {
                 Description = "XYZ Description",
                 ExtraData = "XYZ ExtraData",
                 StatusCode = new StatusCode()
             };
+            yield return new TestCaseData(emptyRequestStatus, copySource, copySource.Description, copySource.ExtraData)
+                .SetName("Empty request status copy from IRequestStatus type");
 
-            requestStatus.CopyFrom(requestStatusCopyable);
-
-            Assert.AreEqual("XYZ Description", requestStatus.Description);
-            Assert.AreEqual("XYZ ExtraData", requestStatus.ExtraData);
-            Assert.IsNotNull(requestStatus.StatusCode);
-        }
-
-        [Test]
-        public void CopyFrom_IRequestStatusTypeInputWithNullStatusCode() 
-        {
-            var requestStatus = new RequestStatus()
+            var normalRequestStatus = new RequestStatus() 
             {
                 Description = "ABC Description",
                 ExtraData = "ABC ExtraData",
                 StatusCode = new StatusCode()
             };
-            var requestStatusCopyable = new RequestStatus() 
+            yield return new TestCaseData(normalRequestStatus, copySource, copySource.Description, copySource.ExtraData)
+                .SetName("Request status copy from IRequestStatus type");
+
+            var copySourceWithNullStatusCode = new RequestStatus() 
             {
                 Description = "XYZ Description",
                 ExtraData = "XYZ ExtraData",
                 StatusCode = null
             };
+            yield return new TestCaseData(
+                    normalRequestStatus, copySourceWithNullStatusCode, 
+                    copySourceWithNullStatusCode.Description, copySourceWithNullStatusCode.ExtraData)
+                .SetName("Request status copy from IRequestStatus type with null StatusCode");
+        }
 
-            requestStatus.CopyFrom(requestStatusCopyable);
+        [Test, TestCaseSource(nameof(CopyFromTestCases))]
+        public void CopyFromTests(RequestStatus incoming, ICopyable copyable, string expectedDescription, string expectedExtraData) 
+        {
+            incoming.CopyFrom(copyable);
 
-            Assert.AreEqual("XYZ Description", requestStatus.Description);
-            Assert.AreEqual("XYZ ExtraData", requestStatus.ExtraData);
-            Assert.IsNotNull(requestStatus.StatusCode);
+            Assert.AreEqual(expectedDescription, incoming.Description);
+            Assert.AreEqual(expectedExtraData, incoming.ExtraData);
+            Assert.IsNotNull(incoming.StatusCode);
         }
     }
 }

--- a/v2/ical.NET.UnitTests/DataTypes/RequestStatusTest.cs
+++ b/v2/ical.NET.UnitTests/DataTypes/RequestStatusTest.cs
@@ -1,0 +1,181 @@
+﻿using Ical.Net.DataTypes;
+using Ical.Net.Interfaces.General;
+using NUnit.Framework;
+
+namespace Ical.Net.UnitTests
+{
+    [TestFixture]
+    public class RequestStatusTest
+    {
+        [Test]
+        public void InitialObjectState_Constructor_Default()
+        {
+            var requestStatus = new RequestStatus();
+
+            Assert.IsNull(requestStatus.StatusCode);
+            Assert.IsNull(requestStatus.Description);
+            Assert.IsNull(requestStatus.ExtraData);
+        }
+
+        [Test]
+        public void InitialObjectState_Constructor_InvalidSerialisedValue() 
+        {
+            var requestStatus = new RequestStatus("ABC");
+
+            Assert.IsNull(requestStatus.StatusCode);
+            Assert.IsNull(requestStatus.Description);
+            Assert.IsNull(requestStatus.ExtraData);
+        }
+
+        [Test, Ignore("Understand what 'valid' values RequestStatusSerializer expects")]
+        public void InitialObjectState_Constructor_ValidSerialisedValue() { }
+
+        [Test]
+        public void ToString_ValidInputWithNullStatusCode()
+        {
+            var requestStatusA = new RequestStatus();
+            var requestStatusB = new RequestStatus()
+            {
+                Description = "",
+                ExtraData = ""
+            };
+            var requestStatusC = new RequestStatus() 
+            {
+                Description = "ABC Description",
+                ExtraData = "ABC ExtraData"
+            };
+
+            Assert.AreEqual(";", requestStatusA.ToString());
+            Assert.AreEqual(";", requestStatusB.ToString());
+            Assert.AreEqual(";ABC Description;ABC ExtraData", requestStatusC.ToString());
+        }
+
+        [Test]
+        public void EqualsGeneric() 
+        {
+            var requestStatusA = new RequestStatus();
+            var requestStatusB = new RequestStatus();
+            var requestStatusC = requestStatusA;
+            var requestStatusD = new RequestStatus() 
+            {
+                Description = "ABC Description"
+            };
+
+            Assert.IsTrue(requestStatusA.Equals(requestStatusA));
+            Assert.IsTrue(requestStatusA.Equals(requestStatusB));
+            Assert.IsTrue(requestStatusA.Equals(requestStatusC));
+            Assert.IsFalse(requestStatusA.Equals(requestStatusD));
+        }
+
+        [Test]
+        public void EqualsNonGeneric() 
+        {
+            object requestStatusA = new RequestStatus();
+            object requestStatusB = new RequestStatus();
+            object requestStatusC = requestStatusA;
+            object requestStatusD = new RequestStatus()
+            {
+                Description = "ABC Description"
+            };
+
+            Assert.IsFalse(requestStatusA.Equals(null));
+            Assert.IsFalse(requestStatusA.Equals("Invalid type value"));
+            Assert.IsTrue(requestStatusA.Equals(requestStatusA));
+            Assert.IsTrue(requestStatusA.Equals(requestStatusB));
+            Assert.IsTrue(requestStatusA.Equals(requestStatusC));
+            Assert.IsFalse(requestStatusA.Equals(requestStatusD));
+        }
+
+        [Test]
+        public void GetHashCode_ValidObject()
+        {
+            var requestStatusA = new RequestStatus();
+            var requestStatusB = new RequestStatus() 
+            {
+                Description = "",
+                ExtraData = "",
+                StatusCode = new StatusCode()
+            };
+            var requestStatusC = new RequestStatus() 
+            {
+                Description = "ABC Description",
+                ExtraData = "ABC ExtraData",
+                StatusCode = new StatusCode()
+            };
+
+            Assert.AreEqual(0,  requestStatusA.GetHashCode());
+            Assert.AreEqual(666477112, requestStatusB.GetHashCode());
+            Assert.AreEqual(-150101454, requestStatusC.GetHashCode());
+        }
+
+        [Test]
+        public void CopyFrom_NullInput() 
+        {
+            var requestStatus = new RequestStatus();
+            requestStatus.CopyFrom(null);
+
+            Assert.IsNull(requestStatus.StatusCode);
+            Assert.IsNull(requestStatus.Description);
+            Assert.IsNull(requestStatus.ExtraData);
+        }
+
+        private class Copyable : ICopyable
+        {
+            public T Copy<T>() { return default(T); }
+
+            public void CopyFrom(ICopyable obj) { }
+        }
+
+        [Test]
+        public void CopyFrom_NonIRequestStatusTypeInput() 
+        {
+            var requestStatus = new RequestStatus();
+            requestStatus.CopyFrom(new Copyable());
+
+            Assert.IsNull(requestStatus.StatusCode);
+            Assert.IsNull(requestStatus.Description);
+            Assert.IsNull(requestStatus.ExtraData);
+        }
+
+        [Test]
+        public void CopyFrom_IRequestStatusTypeInput() 
+        {
+            var requestStatus = new RequestStatus();
+            var requestStatusCopyable = new RequestStatus() 
+            {
+                Description = "XYZ Description",
+                ExtraData = "XYZ ExtraData",
+                StatusCode = new StatusCode()
+            };
+
+            requestStatus.CopyFrom(requestStatusCopyable);
+
+            Assert.AreEqual("XYZ Description", requestStatus.Description);
+            Assert.AreEqual("XYZ ExtraData", requestStatus.ExtraData);
+            Assert.IsNotNull(requestStatus.StatusCode);
+        }
+
+        [Test]
+        public void CopyFrom_IRequestStatusTypeInputWithNullStatusCode() 
+        {
+            var requestStatus = new RequestStatus()
+            {
+                Description = "ABC Description",
+                ExtraData = "ABC ExtraData",
+                StatusCode = new StatusCode()
+            };
+            var requestStatusCopyable = new RequestStatus() 
+            {
+                Description = "XYZ Description",
+                ExtraData = "XYZ ExtraData",
+                StatusCode = null
+            };
+
+            requestStatus.CopyFrom(requestStatusCopyable);
+
+            Assert.AreEqual("XYZ Description", requestStatus.Description);
+            Assert.AreEqual("XYZ ExtraData", requestStatus.ExtraData);
+            Assert.IsNotNull(requestStatus.StatusCode);
+        }
+    }
+}

--- a/v2/ical.NET.UnitTests/DataTypes/RequestStatusTest.cs
+++ b/v2/ical.NET.UnitTests/DataTypes/RequestStatusTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Ical.Net.DataTypes;
 using Ical.Net.Interfaces.General;
 using NUnit.Framework;
@@ -8,136 +9,145 @@ namespace Ical.Net.UnitTests
 {
     public class RequestStatusTest
     {
-        private static IEnumerable<ITestCaseData> ConstructorTestCases() 
+        [Test]
+        public void NullStringConstructorThrowsException()
         {
-            var emptyRequestStatus = new RequestStatus();
-            yield return new TestCaseData(emptyRequestStatus, null, null, null)
-                .SetName("Default request status constructor has null properties");
-
-            var invalidSerializedValue = new RequestStatus("ABC");
-            yield return new TestCaseData(invalidSerializedValue, null, null, null)
-                .SetName("Constructor with invalid serialised text has null properties");
+            Assert.Throws<ArgumentNullException>(() => new StatusCode((string)null));
         }
 
         [Test, TestCaseSource(nameof(ConstructorTestCases))]
-        public void ConstructorTests(RequestStatus incoming, string expectedDescription, string expectedStatusCode, string expectedExtraData) 
+        public void ConstructorTests(RequestStatus incoming, string expectedDescription, string expectedStatusCode, string expectedExtraData)
         {
             Assert.AreEqual(incoming.StatusCode, expectedStatusCode);
             Assert.AreEqual(incoming.Description, expectedDescription);
             Assert.AreEqual(incoming.ExtraData, expectedExtraData);
         }
 
+        private static IEnumerable<ITestCaseData> ConstructorTestCases()
+        {
+            var empty = new RequestStatus();
+            yield return new TestCaseData(empty, null, null, null)
+                .SetName("Default request status constructor has null properties");
+
+            var invalidSerializedValue = new RequestStatus("ABC");
+            yield return new TestCaseData(invalidSerializedValue, null, null, null)
+                .SetName("Constructor invoked with invalid serialised text has null properties");
+        }
+
         [Test, Ignore("Understand what 'valid' values RequestStatusSerializer expects")]
         public void InitialObjectState_Constructor_ValidSerialisedValue() { }
 
-        private static IEnumerable<ITestCaseData> ToStringTestCases() 
-        {
-            var emptyRequestStatus = new RequestStatus();
-            yield return new TestCaseData(emptyRequestStatus, ";")
-                .SetName("ToString() for empty request status should return semicolon");
-
-            var emptyStringPropertiesRequestStatus = new RequestStatus()
-            {
-                Description = "",
-                ExtraData = ""
-            };
-            yield return new TestCaseData(emptyStringPropertiesRequestStatus, ";")
-                .SetName("ToString() for request status with empty string properties should return semicolon");
-
-            var nonEmptyStringPropertiesRequestStatus = new RequestStatus() 
-            {
-                Description = "ABC Description",
-                ExtraData = "ABC ExtraData"
-            };
-            yield return new TestCaseData(nonEmptyStringPropertiesRequestStatus, ";ABC Description;ABC ExtraData")
-                .SetName("ToString() for request status should return semicolon separated values");
-        }
-
         [Test, TestCaseSource(nameof(ToStringTestCases))]
-        public void ToStringTests(RequestStatus incoming, string expected) 
+        public void ToStringTests(RequestStatus incoming, string expected)
         {
             Assert.AreEqual(expected, incoming.ToString());
         }
 
-        private static IEnumerable<ITestCaseData> EqualsTestCases() 
+        private static IEnumerable<ITestCaseData> ToStringTestCases()
         {
-            var requestStatus = new RequestStatus();
-            yield return new TestCaseData(requestStatus, requestStatus, true)
-                .SetName("Equals() same request status should return true");
+            var empty = new RequestStatus();
+            yield return new TestCaseData(empty, null)
+                .SetName("ToString() for empty request status")
+                .Ignore("Unit test is correct. ToString() should return null");
 
-            yield return new TestCaseData(requestStatus, new RequestStatus(), true)
-                .SetName("Equals() for request statuses with equal properties should return true");
-
-            var secondReferenceVariable = requestStatus;
-            yield return new TestCaseData(requestStatus, secondReferenceVariable, true)
-                .SetName("Equals() for two variables referencing the same object should return true");
-
-            var requestStatusWithPropertyValues = new RequestStatus() 
+            var emptyStringProperties = new RequestStatus()
             {
-                Description = "ABC Description"
+                Description = "",
+                ExtraData = ""
             };
-            yield return new TestCaseData(requestStatus, requestStatusWithPropertyValues, false)
-                .SetName("Equals() for request statuses with inequal properties should return false");
+            yield return new TestCaseData(emptyStringProperties, ";")
+                .SetName("ToString() for request status with empty string properties");
+
+            var nonEmptyStringProperties = new RequestStatus()
+            {
+                Description = "ABC Description",
+                ExtraData = "ABC ExtraData"
+            };
+            yield return new TestCaseData(nonEmptyStringProperties, ";ABC Description;ABC ExtraData")
+                .SetName("ToString() for request status returns semicolon separated values");
         }
 
         [Test, TestCaseSource(nameof(EqualsTestCases))]
-        public void EqualsGenericTests(RequestStatus incoming, RequestStatus other, bool expected) 
+        public void EqualsGenericTests(RequestStatus incoming, RequestStatus other, bool expected)
         {
             Assert.AreEqual(expected, incoming.Equals(other));
         }
 
         [Test, TestCaseSource(nameof(EqualsTestCases))]
-        public void EqualsTests(RequestStatus incoming, object other, bool expected) 
+        public void EqualsTests(RequestStatus incoming, object other, bool expected)
         {
-            Assert.AreEqual(expected, incoming.Equals((object) other));
+            Assert.AreEqual(expected, incoming.Equals(other));
         }
 
-        private static IEnumerable<ITestCaseData> GetHashCodeTestCases() 
+        private static IEnumerable<ITestCaseData> EqualsTestCases()
         {
-            var emptyRequestStatus = new RequestStatus();
-            yield return new TestCaseData(emptyRequestStatus, 0)
+            var requestStatus = new RequestStatus();
+            yield return new TestCaseData(requestStatus, null, false)
+                .SetName("Equals() compares with null");
+
+            yield return new TestCaseData(requestStatus, requestStatus, true)
+                .SetName("Equals() compares with itself");
+
+            yield return new TestCaseData(requestStatus, new RequestStatus(), true)
+                .SetName("Equals() compares request statuses with equal properties");
+
+            var secondReferenceVariable = requestStatus;
+            yield return new TestCaseData(requestStatus, secondReferenceVariable, true)
+                .SetName("Equals() compares two variables referencing the same object");
+
+            var requestStatusWithPropertyValues = new RequestStatus()
+            {
+                Description = "ABC Description"
+            };
+            yield return new TestCaseData(requestStatus, requestStatusWithPropertyValues, false)
+                .SetName("Equals() compares request statuses with different property values");
+        }
+
+        [Test, TestCaseSource(nameof(GetHashCodeTestCases))]
+        public void GetHashCodeTests(RequestStatus incoming, RequestStatus other, bool expected)
+        {
+            Assert.AreEqual(expected, incoming.GetHashCode() == other.GetHashCode());
+        }
+
+        private static IEnumerable<ITestCaseData> GetHashCodeTestCases()
+        {
+            var empty = new RequestStatus();
+            var emptyOther = new RequestStatus();
+            yield return new TestCaseData(empty, emptyOther, true)
                 .SetName("GetHashCode() for empty request status");
 
-            var emptyPropertiesRequestStatus = new RequestStatus() 
+            var emptyProperties = new RequestStatus()
             {
                 Description = "",
                 ExtraData = "",
                 StatusCode = new StatusCode()
             };
-            yield return new TestCaseData(emptyPropertiesRequestStatus, 666477112)
-                .SetName("GetHashCode() for request status with empty properties");
-
-            var normalRequestStatus = new RequestStatus() 
+            var emptyPropertiesOther = new RequestStatus()
             {
-                Description = "ABC Description",
-                ExtraData = "ABC ExtraData",
+                Description = "",
+                ExtraData = "",
                 StatusCode = new StatusCode()
             };
-            yield return new TestCaseData(normalRequestStatus, -150101454)
-                .SetName("GetHashCode() for initialised request status");
-        }
+            yield return new TestCaseData(emptyProperties, emptyPropertiesOther, true)
+                .SetName("GetHashCode() for request status with empty properties");
 
-        [Test, TestCaseSource(nameof(GetHashCodeTestCases))]
-        public void GetHashCodeTests(RequestStatus incoming, int expected) 
-        {
-            Assert.AreEqual(expected, incoming.GetHashCode());
-        }      
+            var normal = new RequestStatus()
+            {
+                Description = "ABC Description"
+            };
+            var normalOther = new RequestStatus()
+            {
+                Description = "ABC Description"
+            };
+            yield return new TestCaseData(normal, normalOther, true)
+                .SetName("GetHashCode() for request status");
 
-        private class Copyable : ICopyable
-        {
-            public T Copy<T>() { return default(T); }
-
-            public void CopyFrom(ICopyable obj) { }
-        }
-
-        private static IEnumerable<ITestCaseData> CopyFrom_InvalidTestCases() 
-        {
-            yield return new TestCaseData(new RequestStatus(), null).SetName("Request status CopyFrom() null");
-            yield return new TestCaseData(new RequestStatus(), new Copyable()).SetName("Request status CopyFrom() non-IRequestStatus type");
+            yield return new TestCaseData(normal, emptyPropertiesOther, false)
+                .SetName("GetHashCode() compare empty request status and request status with empty properties");
         }
 
         [Test, TestCaseSource(nameof(CopyFrom_InvalidTestCases))]
-        public void CopyFromTests(RequestStatus incoming, ICopyable copyable) 
+        public void CopyFromTests(RequestStatus incoming, ICopyable copyable)
         {
             incoming.CopyFrom(copyable);
 
@@ -146,10 +156,33 @@ namespace Ical.Net.UnitTests
             Assert.IsNull(incoming.ExtraData);
         }
 
-        private static IEnumerable<ITestCaseData> CopyFromTestCases() 
+        private static IEnumerable<ITestCaseData> CopyFrom_InvalidTestCases()
+        {
+            yield return new TestCaseData(new RequestStatus(), null).SetName("Request status CopyFrom() null");
+            yield return new TestCaseData(new RequestStatus(), new Copyable()).SetName("Request status CopyFrom() non-IRequestStatus type");
+        }
+
+        private class Copyable : ICopyable
+        {
+            public T Copy<T>() { return default(T); }
+
+            public void CopyFrom(ICopyable obj) { }
+        }
+
+        [Test, TestCaseSource(nameof(CopyFromTestCases))]
+        public void CopyFromTests(RequestStatus incoming, ICopyable copyable, string expectedDescription, string expectedExtraData)
+        {
+            incoming.CopyFrom(copyable);
+
+            Assert.AreEqual(expectedDescription, incoming.Description);
+            Assert.AreEqual(expectedExtraData, incoming.ExtraData);
+            Assert.IsNotNull(incoming.StatusCode);
+        }
+
+        private static IEnumerable<ITestCaseData> CopyFromTestCases()
         {
             var emptyRequestStatus = new RequestStatus();
-            var copySource = new RequestStatus() 
+            var copySource = new RequestStatus()
             {
                 Description = "XYZ Description",
                 ExtraData = "XYZ ExtraData",
@@ -158,7 +191,7 @@ namespace Ical.Net.UnitTests
             yield return new TestCaseData(emptyRequestStatus, copySource, copySource.Description, copySource.ExtraData)
                 .SetName("Empty request status copy from IRequestStatus type");
 
-            var normalRequestStatus = new RequestStatus() 
+            var normalRequestStatus = new RequestStatus()
             {
                 Description = "ABC Description",
                 ExtraData = "ABC ExtraData",
@@ -167,26 +200,16 @@ namespace Ical.Net.UnitTests
             yield return new TestCaseData(normalRequestStatus, copySource, copySource.Description, copySource.ExtraData)
                 .SetName("Request status copy from IRequestStatus type");
 
-            var copySourceWithNullStatusCode = new RequestStatus() 
+            var copySourceWithNullStatusCode = new RequestStatus()
             {
                 Description = "XYZ Description",
                 ExtraData = "XYZ ExtraData",
                 StatusCode = null
             };
             yield return new TestCaseData(
-                    normalRequestStatus, copySourceWithNullStatusCode, 
+                    normalRequestStatus, copySourceWithNullStatusCode,
                     copySourceWithNullStatusCode.Description, copySourceWithNullStatusCode.ExtraData)
                 .SetName("Request status copy from IRequestStatus type with null StatusCode");
-        }
-
-        [Test, TestCaseSource(nameof(CopyFromTestCases))]
-        public void CopyFromTests(RequestStatus incoming, ICopyable copyable, string expectedDescription, string expectedExtraData) 
-        {
-            incoming.CopyFrom(copyable);
-
-            Assert.AreEqual(expectedDescription, incoming.Description);
-            Assert.AreEqual(expectedExtraData, incoming.ExtraData);
-            Assert.IsNotNull(incoming.StatusCode);
         }
     }
 }

--- a/v2/ical.NET.UnitTests/Ical.Net.UnitTests.csproj
+++ b/v2/ical.NET.UnitTests/Ical.Net.UnitTests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="CollectionHelpersTests.cs" />
     <Compile Include="ComponentTest.cs" />
     <Compile Include="ConcurrentDeserializationTests.cs" />
+    <Compile Include="DataTypes\RequestStatusTest.cs" />
     <Compile Include="DateTimeSerializerTests.cs" />
     <Compile Include="SerializationHelpers.cs" />
     <Compile Include="SimpleDeserializationTests.cs" />
@@ -583,6 +584,7 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/v2/ical.NET/DataTypes/RequestStatus.cs
+++ b/v2/ical.NET/DataTypes/RequestStatus.cs
@@ -54,7 +54,7 @@ namespace Ical.Net.DataTypes
                 StatusCode = rs.StatusCode;
             }
             Description = rs.Description;
-            rs.ExtraData = rs.ExtraData;
+            ExtraData = rs.ExtraData;
         }
 
         public override string ToString()


### PR DESCRIPTION
* Unit tests for RequestStatus class
* Fix: The CopyFrom(ICopyable) method in RequestStatus class never copied the value for the parameter object for ExtraData property.

The changes are affecting both the v2 and .NET Core projects.