### PR TITLE
Format code on CalendarObject class

### DIFF
--- a/net-core/Ical.Net/Ical.Net/General/CalendarObject.cs
+++ b/net-core/Ical.Net/Ical.Net/General/CalendarObject.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.Serialization;
 using Ical.Net.Collections;
 using Ical.Net.ExtensionMethods;
+using Ical.Net.Interfaces;
 using Ical.Net.Interfaces.General;
 
 namespace Ical.Net.General
@@ -37,7 +38,7 @@ namespace Ical.Net.General
             _children = new CalendarObjectList(this);
             _serviceProvider = new ServiceProvider();
 
-            _children.ItemAdded += Children_ItemAdded;
+            _children.ItemAdded += ChildItemAdded;
         }
 
         [OnDeserializing]
@@ -59,25 +60,20 @@ namespace Ical.Net.General
 
         protected virtual void OnDeserialized(StreamingContext context) {}
 
-        private void Children_ItemAdded(object sender, ObjectEventArgs<ICalendarObject, int> e)
-        {
-            e.First.Parent = this;
-        }
+        private void ChildItemAdded(object sender, ObjectEventArgs<ICalendarObject, int> e) => e.First.Parent = this;
 
         protected bool Equals(CalendarObject other) => string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase);
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != GetType()) return false;
+            if (ReferenceEquals(null, obj)) { return false; }
+            if (ReferenceEquals(this, obj)) { return true; }
+            if (obj.GetType() != GetType()) { return false; }
+
             return Equals((CalendarObject) obj);
         }
 
-        public override int GetHashCode()
-        {
-            return Name?.GetHashCode() ?? 0;
-        }
+        public override int GetHashCode() => Name?.GetHashCode() ?? 0;
 
         public override void CopyFrom(ICopyable c)
         {
@@ -125,7 +121,7 @@ namespace Ical.Net.General
         public virtual string Name { get; set; }
 
         /// <summary>
-        /// Returns the <see cref="Calendar"/> that this DDayiCalObject belongs to.
+        /// Returns the <see cref="ICalendar"/> that this DDayiCalObject belongs to.
         /// </summary>
         public virtual Calendar Calendar
         {
@@ -150,53 +146,26 @@ namespace Ical.Net.General
 
         public virtual int Column { get; set; }
 
-        public virtual object GetService(Type serviceType)
-        {
-            return _serviceProvider.GetService(serviceType);
-        }
+        public virtual object GetService(Type serviceType) => _serviceProvider.GetService(serviceType);
 
-        public virtual object GetService(string name)
-        {
-            return _serviceProvider.GetService(name);
-        }
+        public virtual object GetService(string name) => _serviceProvider.GetService(name);
 
-        public virtual T GetService<T>()
-        {
-            return _serviceProvider.GetService<T>();
-        }
+        public virtual T GetService<T>() => _serviceProvider.GetService<T>();
 
-        public virtual T GetService<T>(string name)
-        {
-            return _serviceProvider.GetService<T>(name);
-        }
+        public virtual T GetService<T>(string name) => _serviceProvider.GetService<T>(name);
 
-        public virtual void SetService(string name, object obj)
-        {
-            _serviceProvider.SetService(name, obj);
-        }
+        public virtual void SetService(string name, object obj) => _serviceProvider.SetService(name, obj);
 
-        public virtual void SetService(object obj)
-        {
-            _serviceProvider.SetService(obj);
-        }
+        public virtual void SetService(object obj) => _serviceProvider.SetService(obj);
 
-        public virtual void RemoveService(Type type)
-        {
-            _serviceProvider.RemoveService(type);
-        }
+        public virtual void RemoveService(Type type) => _serviceProvider.RemoveService(type);
 
-        public virtual void RemoveService(string name)
-        {
-            _serviceProvider.RemoveService(name);
-        }
+        public virtual void RemoveService(string name) => _serviceProvider.RemoveService(name);
 
         public virtual string Group
         {
             get { return Name; }
-            set
-            {
-                Name = value;
-            }
+            set { Name = value; }
         }
     }
 }

--- a/v2/ical.NET/General/CalendarObject.cs
+++ b/v2/ical.NET/General/CalendarObject.cs
@@ -38,7 +38,7 @@ namespace Ical.Net.General
             _children = new CalendarObjectList(this);
             _serviceProvider = new ServiceProvider();
 
-            _children.ItemAdded += _Children_ItemAdded;
+            _children.ItemAdded += ChildItemAdded;
         }
 
         [OnDeserializing]
@@ -60,25 +60,20 @@ namespace Ical.Net.General
 
         protected virtual void OnDeserialized(StreamingContext context) {}
 
-        private void _Children_ItemAdded(object sender, ObjectEventArgs<ICalendarObject, int> e)
-        {
-            e.First.Parent = this;
-        }
+        private void ChildItemAdded(object sender, ObjectEventArgs<ICalendarObject, int> e) => e.First.Parent = this;
 
         protected bool Equals(CalendarObject other) => string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase);
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != GetType()) return false;
+            if (ReferenceEquals(null, obj)) { return false; }
+            if (ReferenceEquals(this, obj)) { return true; }
+            if (obj.GetType() != GetType()) { return false; }
+
             return Equals((CalendarObject) obj);
         }
 
-        public override int GetHashCode()
-        {
-            return Name?.GetHashCode() ?? 0;
-        }
+        public override int GetHashCode() => Name?.GetHashCode() ?? 0;
 
         public override void CopyFrom(ICopyable c)
         {
@@ -147,6 +142,7 @@ namespace Ical.Net.General
             protected set { }
         }
 
+        [Obsolete("Use Calendar property instead. Marked obsolete on version on version 2.x and it will be removed in a future version.")]
         public virtual ICalendar ICalendar
         {
             get { return Calendar; }
@@ -157,53 +153,26 @@ namespace Ical.Net.General
 
         public virtual int Column { get; set; }
 
-        public virtual object GetService(Type serviceType)
-        {
-            return _serviceProvider.GetService(serviceType);
-        }
+        public virtual object GetService(Type serviceType) => _serviceProvider.GetService(serviceType);
 
-        public virtual object GetService(string name)
-        {
-            return _serviceProvider.GetService(name);
-        }
+        public virtual object GetService(string name) => _serviceProvider.GetService(name);
 
-        public virtual T GetService<T>()
-        {
-            return _serviceProvider.GetService<T>();
-        }
+        public virtual T GetService<T>() => _serviceProvider.GetService<T>();
 
-        public virtual T GetService<T>(string name)
-        {
-            return _serviceProvider.GetService<T>(name);
-        }
+        public virtual T GetService<T>(string name) => _serviceProvider.GetService<T>(name);
 
-        public virtual void SetService(string name, object obj)
-        {
-            _serviceProvider.SetService(name, obj);
-        }
+        public virtual void SetService(string name, object obj) => _serviceProvider.SetService(name, obj);
 
-        public virtual void SetService(object obj)
-        {
-            _serviceProvider.SetService(obj);
-        }
+        public virtual void SetService(object obj) => _serviceProvider.SetService(obj);
 
-        public virtual void RemoveService(Type type)
-        {
-            _serviceProvider.RemoveService(type);
-        }
+        public virtual void RemoveService(Type type) => _serviceProvider.RemoveService(type);
 
-        public virtual void RemoveService(string name)
-        {
-            _serviceProvider.RemoveService(name);
-        }
+        public virtual void RemoveService(string name) => _serviceProvider.RemoveService(name);
 
         public virtual string Group
         {
             get { return Name; }
-            set
-            {
-                Name = value;
-            }
+            set { Name = value; }
         }
     }
 }

--- a/v2/ical.NET/Interfaces/General/ICalendarObject.cs
+++ b/v2/ical.NET/Interfaces/General/ICalendarObject.cs
@@ -1,4 +1,5 @@
-﻿using Ical.Net.Collections.Interfaces;
+﻿using System;
+using Ical.Net.Collections.Interfaces;
 
 namespace Ical.Net.Interfaces.General
 {
@@ -27,6 +28,7 @@ namespace Ical.Net.Interfaces.General
         /// </summary>
         ICalendar Calendar { get; }
 
+        [Obsolete("Use Calendar property instead. Marked obsolete on version on version 2.x and it will be removed in a future version.")]
         ICalendar ICalendar { get; }
 
         /// <summary>


### PR DESCRIPTION
* Formatting changes to improve code readability.
* Mark ICalendar property on ICalendarObject (interface) and CalendarObject (class) as obsolete (on v2 project).