### PR TITLE
Keep data structures in sync in GroupedList.Remove() #253

### DIFF
--- a/net-core/Ical.Net/Ical.Net.Collections/GroupedList.cs
+++ b/net-core/Ical.Net/Ical.Net.Collections/GroupedList.cs
@@ -154,6 +154,11 @@ namespace Ical.Net.Collections
                 return false;
             }
 
+            if (!_lists.Remove(_dictionary[group]))
+            {
+                return false;
+            }
+
             return _dictionary.Remove(group);
 
             //var list = _dictionary[group];


### PR DESCRIPTION
`GroupedList.Remove()` only removes the `TGroup` from `_dictionary`, not `_lists`.
This causes a problem during enumeration because the `GroupedValueEnumerator`
is created from the `_lists` object. Depending on the method of enumeration
used, it might enumerate the removed item (meaning it's still in the results
despite the call to `Remove()`) or it might be null in the enumerated list,
either way causing a problem.

Since `GroupedList.EnsureList()` adds to both `_lists` and `_dictionary`, this
change causes `GroupedList.Remove()` to mirror this behavior by removing
from both instead of just `_dictionary`.