### PR TITLE
Make NetCore PeriodList implement IsReadOnly

### DIFF
--- a/net-core/Ical.Net/Ical.Net/DataTypes/PeriodList.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/PeriodList.cs
@@ -46,6 +46,8 @@ namespace Ical.Net.DataTypes
                 Add(p);
             }
         }
+        
+        public bool IsReadOnly => Periods.IsReadOnly;
 
         public override string ToString() => new PeriodListSerializer().SerializeToString(this);
 


### PR DESCRIPTION
NetCore PeriodList does not compile as it doesn't implement IsReadOnly property.