### PR TITLE
netstandard1.3 and net46 #293

### DIFF
--- a/net-core/Ical.Net/Ical.Net.Collections/GroupedList.cs
+++ b/net-core/Ical.Net/Ical.Net.Collections/GroupedList.cs
@@ -153,13 +153,6 @@ namespace Ical.Net.Collections
                 list.RemoveAt(i);
             }
             return true;
-
-            if (!_lists.Remove(_dictionary[group]))
-            {
-                return false;
-            }
-
-            return _dictionary.Remove(group);
         }
 
         public virtual bool Contains(TItem item)

--- a/net-core/Ical.Net/Ical.Net.Collections/Ical.Net.Collections.csproj
+++ b/net-core/Ical.Net/Ical.Net.Collections/Ical.Net.Collections.csproj
@@ -1,6 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <OutputType>library</OutputType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>bin\Release\Ical.Net.Collections.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Linq" Version="4.3.0" />

--- a/net-core/Ical.Net/Ical.Net.Collections/Ical.Net.Collections.csproj
+++ b/net-core/Ical.Net/Ical.Net.Collections/Ical.Net.Collections.csproj
@@ -1,9 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputType>library</OutputType>
+    <TargetFrameworks>netstandard1.3</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>bin\Release\Ical.Net.Collections.xml</DocumentationFile>

--- a/net-core/Ical.Net/Ical.Net.UnitTests/Ical.Net.UnitTests.csproj
+++ b/net-core/Ical.Net/Ical.Net.UnitTests/Ical.Net.UnitTests.csproj
@@ -5,9 +5,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="NUnit" Version="3.6.1" />
+    <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\antlr.runtime\antlr.runtime.csproj" />

--- a/net-core/Ical.Net/Ical.Net.nuspec
+++ b/net-core/Ical.Net/Ical.Net.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>Ical.Net</id>
-        <version>3.0.10-net-core-beta</version>
+        <version>3.0.11-net-core-beta</version>
         <title>Ical.Net</title>
         <authors>Rian Stockbower, Douglas Day, M. David Peterson</authors>
         <owners>Rian Stockbower</owners>
@@ -14,11 +14,11 @@
         <iconUrl>https://github.com/rianjs/ical.net/raw/master/nuget_logo_150px.png</iconUrl>
         <tags>iCal Calendar icalendar ics outlook events rfc-5545 rfc-2445 dday</tags>
         <dependencies>
-            <dependency id="NodaTime" version="2.0.0-beta20170123" />
+            <dependency id="NodaTime" version="2.0.2" />
         </dependencies>
     </metadata>
     <files>
-        <!-- netstandard 1.3 -->
+        <!-- netstandard 1.3, which covers net46 -->
         <file src="Ical.Net\bin\Release\netstandard1.3\Ical.Net.Collections.dll" target="lib\netstandard1.3\Ical.Net.Collections.dll" />
         <file src="Ical.Net\bin\Release\netstandard1.3\Ical.Net.Collections.pdb" target="lib\netstandard1.3\Ical.Net.Collections.pdb" />
         <file src="Ical.Net\bin\Release\netstandard1.3\Ical.Net.Collections.xml" target="lib\netstandard1.3\Ical.Net.Collections.xml" />
@@ -29,15 +29,5 @@
         <file src="Ical.Net\bin\Release\netstandard1.3\antlr.runtime.pdb" target="lib\netstandard1.3\antlr.runtime.pdb" />
         <file src="Ical.Net\bin\Release\netstandard1.3\antlr.runtime.xml" target="lib\netstandard1.3\antlr.runtime.xml" />
         <file src="Ical.Net\bin\Release\netstandard1.3\Ical.Net.deps.json" target="lib\netstandard1.3\Ical.Net.deps.json" />
-        <!-- net46 -->
-        <file src="Ical.Net\bin\Release\net46\Ical.Net.Collections.dll" target="lib\net46\Ical.Net.Collections.dll" />
-        <file src="Ical.Net\bin\Release\net46\Ical.Net.Collections.pdb" target="lib\net46\Ical.Net.Collections.pdb" />
-        <file src="Ical.Net\bin\Release\net46\Ical.Net.Collections.xml" target="lib\net46\Ical.Net.Collections.xml" />
-        <file src="Ical.Net\bin\Release\net46\Ical.Net.dll" target="lib\net46\Ical.Net.dll" />
-        <file src="Ical.Net\bin\Release\net46\Ical.Net.pdb" target="lib\net46\Ical.Net.pdb" />
-        <file src="Ical.Net\bin\Release\net46\Ical.Net.xml" target="lib\net46\Ical.Net.xml" />
-        <file src="Ical.Net\bin\Release\net46\antlr.runtime.dll" target="lib\net46\antlr.runtime.dll" />
-        <file src="Ical.Net\bin\Release\net46\antlr.runtime.pdb" target="lib\net46\antlr.runtime.pdb" />
-        <file src="Ical.Net\bin\Release\net46\antlr.runtime.xml" target="lib\net46\antlr.runtime.xml" />
     </files>
 </package>

--- a/net-core/Ical.Net/Ical.Net.nuspec
+++ b/net-core/Ical.Net/Ical.Net.nuspec
@@ -18,13 +18,26 @@
         </dependencies>
     </metadata>
     <files>
-        <!-- netstandard 1.6 -->
-        <file src="Ical.Net\bin\Release\netstandard1.6\Ical.Net.Collections.dll" target="lib\netstandard1.6\Ical.Net.Collections.dll" />
-        <file src="Ical.Net\bin\Release\netstandard1.6\Ical.Net.Collections.pdb" target="lib\netstandard1.6\Ical.Net.Collections.pdb" />
-        <file src="Ical.Net\bin\Release\netstandard1.6\Ical.Net.dll" target="lib\netstandard1.6\Ical.Net.dll" />
-        <file src="Ical.Net\bin\Release\netstandard1.6\Ical.Net.pdb" target="lib\netstandard1.6\Ical.Net.pdb" />
-        <file src="Ical.Net\bin\Release\netstandard1.6\antlr.runtime.dll" target="lib\netstandard1.6\antlr.runtime.dll" />
-        <file src="Ical.Net\bin\Release\netstandard1.6\antlr.runtime.pdb" target="lib\netstandard1.6\antlr.runtime.pdb" />
-        <file src="Ical.Net\bin\Release\netstandard1.6\Ical.Net.deps.json" target="lib\netstandard1.6\Ical.Net.deps.json" />
+        <!-- netstandard 1.3 -->
+        <file src="Ical.Net\bin\Release\netstandard1.3\Ical.Net.Collections.dll" target="lib\netstandard1.3\Ical.Net.Collections.dll" />
+        <file src="Ical.Net\bin\Release\netstandard1.3\Ical.Net.Collections.pdb" target="lib\netstandard1.3\Ical.Net.Collections.pdb" />
+        <file src="Ical.Net\bin\Release\netstandard1.3\Ical.Net.Collections.xml" target="lib\netstandard1.3\Ical.Net.Collections.xml" />
+        <file src="Ical.Net\bin\Release\netstandard1.3\Ical.Net.dll" target="lib\netstandard1.3\Ical.Net.dll" />
+        <file src="Ical.Net\bin\Release\netstandard1.3\Ical.Net.pdb" target="lib\netstandard1.3\Ical.Net.pdb" />
+        <file src="Ical.Net\bin\Release\netstandard1.3\Ical.Net.xml" target="lib\netstandard1.3\Ical.Net.xml" />
+        <file src="Ical.Net\bin\Release\netstandard1.3\antlr.runtime.dll" target="lib\netstandard1.3\antlr.runtime.dll" />
+        <file src="Ical.Net\bin\Release\netstandard1.3\antlr.runtime.pdb" target="lib\netstandard1.3\antlr.runtime.pdb" />
+        <file src="Ical.Net\bin\Release\netstandard1.3\antlr.runtime.xml" target="lib\netstandard1.3\antlr.runtime.xml" />
+        <file src="Ical.Net\bin\Release\netstandard1.3\Ical.Net.deps.json" target="lib\netstandard1.3\Ical.Net.deps.json" />
+        <!-- net46 -->
+        <file src="Ical.Net\bin\Release\net46\Ical.Net.Collections.dll" target="lib\net46\Ical.Net.Collections.dll" />
+        <file src="Ical.Net\bin\Release\net46\Ical.Net.Collections.pdb" target="lib\net46\Ical.Net.Collections.pdb" />
+        <file src="Ical.Net\bin\Release\net46\Ical.Net.Collections.xml" target="lib\net46\Ical.Net.Collections.xml" />
+        <file src="Ical.Net\bin\Release\net46\Ical.Net.dll" target="lib\net46\Ical.Net.dll" />
+        <file src="Ical.Net\bin\Release\net46\Ical.Net.pdb" target="lib\net46\Ical.Net.pdb" />
+        <file src="Ical.Net\bin\Release\net46\Ical.Net.xml" target="lib\net46\Ical.Net.xml" />
+        <file src="Ical.Net\bin\Release\net46\antlr.runtime.dll" target="lib\net46\antlr.runtime.dll" />
+        <file src="Ical.Net\bin\Release\net46\antlr.runtime.pdb" target="lib\net46\antlr.runtime.pdb" />
+        <file src="Ical.Net\bin\Release\net46\antlr.runtime.xml" target="lib\net46\antlr.runtime.xml" />
     </files>
 </package>

--- a/net-core/Ical.Net/Ical.Net/Ical.Net.csproj
+++ b/net-core/Ical.Net/Ical.Net/Ical.Net.csproj
@@ -1,12 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OutputType>library</OutputType>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>bin\Release\Ical.Net.xml</DocumentationFile>
+  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NodaTime" Version="2.0.0-beta20170123" />
+    <PackageReference Include="NodaTime" Version="2.0.2" />
     <PackageReference Include="System.Linq.Parallel" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
   </ItemGroup>

--- a/net-core/Ical.Net/Ical.Net/Ical.Net.csproj
+++ b/net-core/Ical.Net/Ical.Net/Ical.Net.csproj
@@ -1,9 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputType>library</OutputType>
+    <TargetFrameworks>netstandard1.3</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>bin\Release\Ical.Net.xml</DocumentationFile>

--- a/net-core/Ical.Net/antlr.runtime/antlr.runtime.csproj
+++ b/net-core/Ical.Net/antlr.runtime/antlr.runtime.csproj
@@ -1,8 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OutputType>library</OutputType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>bin\Release\antlr.runtime.xml</DocumentationFile>
   </PropertyGroup>
 </Project>

--- a/net-core/Ical.Net/antlr.runtime/antlr.runtime.csproj
+++ b/net-core/Ical.Net/antlr.runtime/antlr.runtime.csproj
@@ -1,9 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputType>library</OutputType>
+    <TargetFrameworks>netstandard1.3</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>bin\Release\antlr.runtime.xml</DocumentationFile>

--- a/release-notes.md
+++ b/release-notes.md
@@ -4,6 +4,7 @@ A listing of what each [Nuget package](https://www.nuget.org/packages/Ical.Net) 
 
 ### v3
 
+* 3.0.11-net-core-beta: Targeting netstandard1.3 and net46
 * 3.0.10-net-core-beta: Reverts a change made in 3.0.3 which allowed UTC timestamps to specify `TZID=UTC` instead of being suffixed with `Z`. The spec requires `Z` suffixes, and broke many applications, including Outlook. [#263](https://github.com/rianjs/ical.net/issues/263)
 * 3.0.9-net-core-beta: Bugfixes: `PeriodList` now fully implements `IList<Period>`. Keep data structures in sync in GroupedList.Remove() [#253](https://github.com/rianjs/ical.net/issues/253). Fix for StackOverflow exception [#257](https://github.com/rianjs/ical.net/issues/257). UnitTests can now be run in VS test runner!
 * 3.0.8-net-core-alpha: Bugfix: Better CalDateTime equality and hashing, because time zones matter. [#275](https://github.com/rianjs/ical.net/issues/275)


### PR DESCRIPTION
Per the API surface area, net46 and netstandard1.3 overlap. This is a change from netstandard1.6 which I thought was a little aggressive.

https://docs.microsoft.com/en-us/dotnet/standard/library

I also updated some dependencies (NodaTime, etc.), and I did remove one section of unreachable code.