### PR TITLE
Reverted TZID parameter in UTC Dates. 

### DIFF
--- a/net-core/Ical.Net/Ical.Net.UnitTests/CalendarEventTest.cs
+++ b/net-core/Ical.Net/Ical.Net.UnitTests/CalendarEventTest.cs
@@ -133,7 +133,6 @@ namespace Ical.Net.UnitTests
             var lines = serialized.Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries).ToList();
             var result = lines.First(s => s.StartsWith("DTSTAMP"));
 
-            //Both of these are correct, since the library no longer asserts that UTC must elide an explicit TZID in favor of the Z suffix on UTC times
             return !result.Contains("TZID=") && result.EndsWith("Z");
         }
 

--- a/net-core/Ical.Net/Ical.Net.UnitTests/CalendarEventTest.cs
+++ b/net-core/Ical.Net/Ical.Net.UnitTests/CalendarEventTest.cs
@@ -134,8 +134,7 @@ namespace Ical.Net.UnitTests
             var result = lines.First(s => s.StartsWith("DTSTAMP"));
 
             //Both of these are correct, since the library no longer asserts that UTC must elide an explicit TZID in favor of the Z suffix on UTC times
-            return !result.Contains("TZID=") && result.EndsWith("Z")
-                || result.Contains("TZID=") && !result.EndsWith("Z");
+            return !result.Contains("TZID=") && result.EndsWith("Z");
         }
 
         public static IEnumerable<ITestCaseData> EnsureAutomaticallySetDtStampIsSerializedAsUtcKind_TestCases()

--- a/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/DateTimeSerializer.cs
+++ b/net-core/Ical.Net/Ical.Net/Serialization/iCalendar/Serializers/DataTypes/DateTimeSerializer.cs
@@ -44,11 +44,16 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
         {
             var dt = obj as IDateTime;
 
-            //Historically, dday.ical substituted TZID=UTC with Z suffixes on DateTimes. However this behavior isn't part of the spec. Some popular libraries
-            //like Telerik's RadSchedule components will only understand the DateTimeKind.Utc if the ical text says TZID=UTC. Anything but that is treated as
-            //DateTimeKind.Unspecified, which is problematic.
+            // RFC 5545 3.3.5: 
+            // The date with UTC time, or absolute time, is identified by a LATIN
+            // CAPITAL LETTER Z suffix character, the UTC designator, appended to
+            // the time value. The "TZID" property parameter MUST NOT be applied to DATE-TIME
+            // properties whose time values are specified in UTC.
+            if (dt.IsUniversalTime)
+            {
+                dt.Parameters.Remove("TZID");
 
-            if (!string.IsNullOrWhiteSpace(dt.TzId))
+            } else if (!string.IsNullOrWhiteSpace(dt.TzId))
             {
                 dt.Parameters.Set("TZID", dt.TzId);
             }

--- a/v2/ical.NET.Collections/Constants.cs
+++ b/v2/ical.NET.Collections/Constants.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace ical.net.collections
+namespace Ical.Net.Collections
 {
     public class ObjectEventArgs<T, TU> :
         EventArgs

--- a/v2/ical.NET.Collections/GroupedValueList.cs
+++ b/v2/ical.NET.Collections/GroupedValueList.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using ical.net.collections.Interfaces;
-using ical.net.collections.Proxies;
+using Ical.Net.Collections.Interfaces;
+using Ical.Net.Collections.Proxies;
 
-namespace ical.net.collections
+namespace Ical.Net.Collections
 {
     public class GroupedValueList<TGroup, TInterface, TItem, TValueType> :
         GroupedList<TGroup, TInterface>

--- a/v2/ical.NET.Collections/Interfaces/IGroupedList.cs
+++ b/v2/ical.NET.Collections/Interfaces/IGroupedList.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace ical.net.collections.Interfaces
+namespace Ical.Net.Collections.Interfaces
 {
     public interface IGroupedList<TGroup, TItem> :
         IGroupedCollection<TGroup, TItem>,

--- a/v2/ical.NET.Collections/Interfaces/IGroupedObject.cs
+++ b/v2/ical.NET.Collections/Interfaces/IGroupedObject.cs
@@ -1,4 +1,4 @@
-namespace ical.net.collections.Interfaces
+namespace Ical.Net.Collections.Interfaces
 {
     public interface IGroupedObject<TGroup>
     {

--- a/v2/ical.NET.Collections/Interfaces/IMultiLinkedList.cs
+++ b/v2/ical.NET.Collections/Interfaces/IMultiLinkedList.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace ical.net.collections.Interfaces
+namespace Ical.Net.Collections.Interfaces
 {
     public interface IMultiLinkedList<TType> :
         IList<TType>

--- a/v2/ical.NET.Collections/Interfaces/IValueObject.cs
+++ b/v2/ical.NET.Collections/Interfaces/IValueObject.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace ical.net.collections.Interfaces
+namespace Ical.Net.Collections.Interfaces
 {
     public interface IValueObject<T>
     {

--- a/v2/ical.NET.UnitTests/EventTest.cs
+++ b/v2/ical.NET.UnitTests/EventTest.cs
@@ -135,9 +135,7 @@ namespace Ical.Net.UnitTests
             var lines = serialized.Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries).ToList();
             var result = lines.First(s => s.StartsWith("DTSTAMP"));
 
-            //Both of these are correct, since the library no longer asserts that UTC must elide an explicit TZID in favor of the Z suffix on UTC times
-            return !result.Contains("TZID=") && result.EndsWith("Z")
-                || result.Contains("TZID=") && !result.EndsWith("Z");
+            return !result.Contains("TZID=") && result.EndsWith("Z");
         }
 
         public static IEnumerable<ITestCaseData> EnsureAutomaticallySetDtStampIsSerializedAsUtcKind_TestCases()

--- a/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/DateTimeSerializer.cs
+++ b/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/DateTimeSerializer.cs
@@ -45,11 +45,16 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
         {
             var dt = obj as IDateTime;
 
-            //Historically, dday.ical substituted TZID=UTC with Z suffixes on DateTimes. However this behavior isn't part of the spec. Some popular libraries
-            //like Telerik's RadSchedule components will only understand the DateTimeKind.Utc if the ical text says TZID=UTC. Anything but that is treated as
-            //DateTimeKind.Unspecified, which is problematic.
+                      // RFC 5545 3.3.5: 
+            // The date with UTC time, or absolute time, is identified by a LATIN
+            // CAPITAL LETTER Z suffix character, the UTC designator, appended to
+            // the time value. The "TZID" property parameter MUST NOT be applied to DATE-TIME
+            // properties whose time values are specified in UTC.
+            if (dt.IsUniversalTime)
+            {
+                dt.Parameters.Remove("TZID");
 
-            if (!string.IsNullOrWhiteSpace(dt.TzId))
+            } else if (!string.IsNullOrWhiteSpace(dt.TzId))
             {
                 dt.Parameters.Set("TZID", dt.TzId);
             }


### PR DESCRIPTION
DateTime Serializer now places a Zulu suffix at the end of the string when dates are UTC.