### PR TITLE
Status and Transparency values should render uppercase to match RFC

### DIFF
--- a/v2/ical.NET.UnitTests/SerializationTests.cs
+++ b/v2/ical.NET.UnitTests/SerializationTests.cs
@@ -254,10 +254,10 @@ namespace Ical.Net.UnitTests
                 Location = "here",
                 Summary = "test",
                 DtStart = new CalDateTime(2012, 3, 25, 12, 50, 00),
-                DtEnd = new CalDateTime(2012, 3, 25, 13, 10, 00)
+                DtEnd = new CalDateTime(2012, 3, 25, 13, 10, 00),
                 //not yet testing property below as serialized output currently does not comply with RTFC 2445
-                //Transparency = TransparencyType.Opaque,
-                //Status = EventStatus.Confirmed
+                Transparency = TransparencyType.Opaque,
+                Status = EventStatus.Confirmed
             };
             cal.Events.Add(evt);
 
@@ -280,9 +280,9 @@ namespace Ical.Net.UnitTests
                 {
                     "CLASS:" + evt.Class, "CREATED:" + CalDateString(evt.Created), "DTSTAMP:" + CalDateString(evt.DtStamp),
                     "LAST-MODIFIED:" + CalDateString(evt.LastModified), "SEQUENCE:" + evt.Sequence, "UID:" + evt.Uid, "PRIORITY:" + evt.Priority,
-                    "LOCATION:" + evt.Location, "SUMMARY:" + evt.Summary, "DTSTART:" + CalDateString(evt.DtStart), "DTEND:" + CalDateString(evt.DtEnd)
-                    //"TRANSPARENCY:" + TransparencyType.Opaque.ToString().ToUpperInvariant(),
-                    //"STATUS:" + EventStatus.Confirmed.ToString().ToUpperInvariant()
+                    "LOCATION:" + evt.Location, "SUMMARY:" + evt.Summary, "DTSTART:" + CalDateString(evt.DtStart), "DTEND:" + CalDateString(evt.DtEnd),
+                    "TRANSP:" + TransparencyType.Opaque.ToString().ToUpperInvariant(),
+                    "STATUS:" + EventStatus.Confirmed.ToString().ToUpperInvariant()
                 });
         }
 

--- a/v2/ical.NET.UnitTests/SerializationTests.cs
+++ b/v2/ical.NET.UnitTests/SerializationTests.cs
@@ -341,7 +341,7 @@ namespace Ical.Net.UnitTests
                 })
                 {
                     Assert.IsTrue(vals.ContainsKey(v.Key), $"could not find key '{v.Key}'");
-                    Assert.AreEqual(v.Value, vals[v.Key], $"ATENDEE prop '{v.Key}' differ");
+                    Assert.AreEqual(v.Value, vals[v.Key], $"ATTENDEE prop '{v.Key}' differ");
                 }
             }
         }

--- a/v2/ical.NET/Serialization/iCalendar/Serializers/Other/EnumSerializer.cs
+++ b/v2/ical.NET/Serialization/iCalendar/Serializers/Other/EnumSerializer.cs
@@ -27,7 +27,13 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.Other
         {
             try
             {
+                string value = enumValue.ToString();
+
+                if (TargetType == typeof(EventStatus) || TargetType == typeof(TransparencyType))
+                    value = value.ToUpperInvariant();
+
                 var obj = SerializationContext.Peek() as ICalendarObject;
+
                 if (obj != null)
                 {
                     // Encode the value as needed.
@@ -35,9 +41,10 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.Other
                     {
                         AssociatedObject = obj
                     };
-                    return Encode(dt, enumValue.ToString());
+                    return Encode(dt, value);
                 }
-                return enumValue.ToString();
+
+                return value;
             }
             catch
             {


### PR DESCRIPTION
Resolves #155.

Also fixed test wrong reference to "TRANSPARENCY" vs "TRANSP" as field name.