### PR TITLE
Check if collection is empty before trying to manipulate first element.

### DIFF
--- a/v2/ical.NET.Collections/GroupedValueList.cs
+++ b/v2/ical.NET.Collections/GroupedValueList.cs
@@ -20,11 +20,11 @@ namespace Ical.Net.Collections
         {
             if (ContainsKey(group))
             {
-                var items = AllOf(group);
-                if (items != null)
+                // Add a value to the first matching item in the list
+                var item = AllOf(group).FirstOrDefault();
+                if (item != null)
                 {
-                    // Add a value to the first matching item in the list
-                    items.First().SetValue(values);
+                    item.SetValue(values);
                     return;
                 }
             }


### PR DESCRIPTION
Fixes the InvalidOperationException mentioned in #311.

I assume that it is the correct behaviour, that it simply reappends the product id property.

