### PR TITLE
Catch case where recurring item has no Start

### DIFF
--- a/net-core/Ical.Net/Ical.Net.nuspec
+++ b/net-core/Ical.Net/Ical.Net.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>Ical.Net</id>
-        <version>3.0.12</version>
+        <version>3.0.13</version>
         <title>Ical.Net</title>
         <authors>Rian Stockbower, Douglas Day, M. David Peterson</authors>
         <owners>Rian Stockbower</owners>

--- a/net-core/Ical.Net/Ical.Net/Utility/RecurrenceUtil.cs
+++ b/net-core/Ical.Net/Ical.Net/Utility/RecurrenceUtil.cs
@@ -21,7 +21,7 @@ namespace Ical.Net.Utility
         public static HashSet<Occurrence> GetOccurrences(IRecurrable recurrable, IDateTime periodStart, IDateTime periodEnd, bool includeReferenceDateInResults)
         {
             var evaluator = recurrable.GetService(typeof (IEvaluator)) as IEvaluator;
-            if (evaluator == null)
+            if (evaluator == null || recurrable.Start == null)
             {
                 return new HashSet<Occurrence>();
             }

--- a/release-notes.md
+++ b/release-notes.md
@@ -3,6 +3,7 @@
 A listing of what each [Nuget package](https://www.nuget.org/packages/Ical.Net) version represents.
 
 ### v3
+* 3.0.13: Fix if DTSTART is not set for VTODO
 * 3.0.12: Several improvements rolled up:
   * `CalendarEvent` now considers Summary and Description for equality and hashing. [PR 309](https://github.com/rianjs/ical.net/pull/309).
   * Protection against `InvalidOperationException`s in some collections usage scenarios [PR 312](https://github.com/rianjs/ical.net/pull/312)
@@ -20,6 +21,7 @@ A listing of what each [Nuget package](https://www.nuget.org/packages/Ical.Net) 
 
 ### v2
 
+* 2.3.4: Fix if DTSTART is not set for VTODO
 * 2.3.3: Several improvements rolled up:
   * `Event` now considers Summary and Description for equality and hashing. [PR 309](https://github.com/rianjs/ical.net/pull/309).
   * Protection against `InvalidOperationException`s in some collections usage scenarios [PR 312](https://github.com/rianjs/ical.net/pull/312)

--- a/v2/Ical.Net.nuspec
+++ b/v2/Ical.Net.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>Ical.Net</id>
-        <version>2.3.3</version>
+        <version>2.3.4</version>
         <title>Ical.Net</title>
         <authors>Rian Stockbower, Douglas Day, M. David Peterson</authors>
         <owners>Rian Stockbower</owners>

--- a/v2/ical.NET/Utility/RecurrenceUtil.cs
+++ b/v2/ical.NET/Utility/RecurrenceUtil.cs
@@ -24,7 +24,7 @@ namespace Ical.Net.Utility
         public static HashSet<Occurrence> GetOccurrences(IRecurrable recurrable, IDateTime periodStart, IDateTime periodEnd, bool includeReferenceDateInResults)
         {
             var evaluator = recurrable.GetService(typeof (IEvaluator)) as IEvaluator;
-            if (evaluator == null)
+            if (evaluator == null || recurrable.Start == null)
             {
                 return new HashSet<Occurrence>();
             }


### PR DESCRIPTION
In my case, the object without a Start was a TODO. The backend is Zimbra. I'm not sure if it is a Bug in Zimbra or if it is actually a valid item but the fix is simple in the library.