### PR TITLE
Ignore timezone if two periods are compared for equality

### DIFF
--- a/net-core/Ical.Net/Ical.Net/DataTypes/Period.cs
+++ b/net-core/Ical.Net/Ical.Net/DataTypes/Period.cs
@@ -60,7 +60,7 @@ namespace Ical.Net.DataTypes
             Duration = p.Duration;
         }
 
-        protected bool Equals(Period other) => Equals(StartTime, other.StartTime) && Equals(EndTime, other.EndTime) && Duration.Equals(other.Duration);
+        protected bool Equals(Period other) => IsSameInstant(StartTime, other.StartTime) && IsSameInstant(EndTime, other.EndTime) && Duration.Equals(other.Duration);
 
         public override bool Equals(object obj)
         {
@@ -69,12 +69,21 @@ namespace Ical.Net.DataTypes
             return obj.GetType() == GetType() && Equals((Period) obj);
         }
 
+        public static bool IsSameInstant(IDateTime a, IDateTime b)
+        {
+            if (a == null || b == null)
+            {
+                return a == b;
+            }
+            return Equals(a.AsUtc, b.AsUtc);
+        }
+
         public override int GetHashCode()
         {
             unchecked
             {
-                var hashCode = StartTime?.GetHashCode() ?? 0;
-                hashCode = (hashCode * 397) ^ (EndTime?.GetHashCode() ?? 0);
+                var hashCode = StartTime?.AsUtc.GetHashCode() ?? 0;
+                hashCode = (hashCode * 397) ^ (EndTime?.AsUtc.GetHashCode() ?? 0);
                 hashCode = (hashCode * 397) ^ Duration.GetHashCode();
                 return hashCode;
             }


### PR DESCRIPTION
This solves the case where exception dates are ignored due to different time zone than the recurring event.

This PR is a follow up to https://github.com/rianjs/ical.net/pull/307.

On IDateTime there were cases where it was required to honour the timezone in equals.
Therefore, this PR changes the Equals on "Period" which also solves the issue. Are there also cases where the Timezone for a Period is relevant in case of comparing them? I currently cant think of one and therefore think this could be a nice fix for my issue.

What is your opinion on that?

If its ok, I will also update the v2-version and do the package updates.