### PR TITLE
Infiinte Loop with MaxDate for GetOccurrences

### DIFF
--- a/net-core/Ical.Net.CoreUnitTests/RecurrenceTests.cs
+++ b/net-core/Ical.Net.CoreUnitTests/RecurrenceTests.cs
@@ -2603,9 +2603,6 @@ namespace Ical.Net.CoreUnitTests
             Assert.AreEqual(10, occurrences.Count, "There should be 10 occurrences of this event, one for each month except February and December.");
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
         [Test, Category("Recurrence")]
         public void ReccurencePattern_MaxDate_StopsOnCount()
         {

--- a/net-core/Ical.Net.CoreUnitTests/RecurrenceTests.cs
+++ b/net-core/Ical.Net.CoreUnitTests/RecurrenceTests.cs
@@ -2604,6 +2604,30 @@ namespace Ical.Net.CoreUnitTests
         }
 
         /// <summary>
+        /// 
+        /// </summary>
+        [Test, Category("Recurrence")]
+        public void ReccurencePattern_MaxDate_StopsOnCount()
+        {
+            var evt = new CalendarEvent
+            {
+                Start = new CalDateTime(2018, 1, 1, 12, 0, 0),
+                Duration = TimeSpan.FromHours(1)
+            };
+
+            var pattern = new RecurrencePattern
+            {
+                Frequency = FrequencyType.Daily,
+                Count = 10
+            };
+
+            evt.RecurrenceRules.Add(pattern);
+
+            var occurrences = evt.GetOccurrences(new DateTime(2018, 1, 1), DateTime.MaxValue);
+            Assert.AreEqual(10, occurrences.Count, "There should be 10 occurrences of this event.");
+        }
+
+        /// <summary>
         /// Tests bug #3292737 - Google Repeating Task Until Time  Bug
         /// See https://sourceforge.net/tracker/?func=detail&aid=3292737&group_id=187422&atid=921236
         /// </summary>

--- a/net-core/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
+++ b/net-core/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -259,7 +259,17 @@ namespace Ical.Net.Evaluation
                     break;
                 }
 
+                if (pattern.Until != DateTime.MinValue && candidate != DateTime.MinValue && candidate > pattern.Until)
+                {
+                    break;
+                }
+
                 if (candidate != DateTime.MinValue && candidate > periodEnd)
+                {
+                    break;
+                }
+
+                if (pattern.Count >= 1 && dates.Count >= pattern.Count)
                 {
                     break;
                 }

--- a/net-core/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
+++ b/net-core/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
@@ -259,11 +259,6 @@ namespace Ical.Net.Evaluation
                     break;
                 }
 
-                if (pattern.Until != DateTime.MinValue && candidate != DateTime.MinValue && candidate > pattern.Until)
-                {
-                    break;
-                }
-
                 if (candidate != DateTime.MinValue && candidate > periodEnd)
                 {
                     break;


### PR DESCRIPTION
Fixes bug when GetOccurrences ends on MaxDate and only Count is set, an
error is thrown inside an infinite loop