### PR TITLE
V2 fixes for RecurrenceUtil.GetOccurrences and CalDateTime.ToTimeZone

### DIFF
--- a/v2/ical.NET.UnitTests/EqualityAndHashingTests.cs
+++ b/v2/ical.NET.UnitTests/EqualityAndHashingTests.cs
@@ -259,12 +259,12 @@ namespace Ical.Net.UnitTests
             Assert.IsFalse(serialized.Contains("Hello"));
         }
 
-        internal static (byte[] original, byte[] copy) GetAttachments()
+        internal static Tuple<byte[] /*original*/, byte[] /*copy*/> GetAttachments()
         {
             var payload = Encoding.UTF8.GetBytes("This is an attachment!");
             var payloadCopy = new byte[payload.Length];
             Array.Copy(payload, payloadCopy, payload.Length);
-            return (payload, payloadCopy);
+            return Tuple.Create(payload, payloadCopy);
         }
 
         [Test, TestCaseSource(nameof(RecurringComponentAttachment_TestCases))]
@@ -275,7 +275,7 @@ namespace Ical.Net.UnitTests
             Assert.AreNotEqual(noAttachment, withAttachment);
             Assert.AreNotEqual(noAttachment.GetHashCode(), withAttachment.GetHashCode());
 
-            noAttachment.Attachments.Add(new Attachment(attachments.copy));
+            noAttachment.Attachments.Add(new Attachment(attachments.Item2/*copy*/));
 
             Assert.AreEqual(noAttachment, withAttachment);
             Assert.AreEqual(noAttachment.GetHashCode(), withAttachment.GetHashCode());
@@ -287,17 +287,17 @@ namespace Ical.Net.UnitTests
 
             var journalNoAttach = new Journal {Start = new CalDateTime(_nowTime), Summary = "A summary!", Class = "Some class!"};
             var journalWithAttach = new Journal {Start = new CalDateTime(_nowTime), Summary = "A summary!", Class = "Some class!"};
-            journalWithAttach.Attachments.Add(new Attachment(attachments.original));
+            journalWithAttach.Attachments.Add(new Attachment(attachments.Item1/*original*/));
             yield return new TestCaseData(journalNoAttach, journalWithAttach).SetName("Journal recurring component attachment");
 
             var todoNoAttach = new Todo { Start = new CalDateTime(_nowTime), Summary = "A summary!", Class = "Some class!" };
             var todoWithAttach = new Todo { Start = new CalDateTime(_nowTime), Summary = "A summary!", Class = "Some class!"};
-            todoWithAttach.Attachments.Add(new Attachment(attachments.original));
+            todoWithAttach.Attachments.Add(new Attachment(attachments.Item1/*original*/));
             yield return new TestCaseData(todoNoAttach, todoWithAttach).SetName("Todo recurring component attachment");
 
             var eventNoAttach = GetSimpleEvent();
             var eventWithAttach = GetSimpleEvent();
-            eventWithAttach.Attachments.Add(new Attachment(attachments.original));
+            eventWithAttach.Attachments.Add(new Attachment(attachments.Item1/*original*/));
             yield return new TestCaseData(eventNoAttach, eventWithAttach).SetName("Event recurring component attachment");
         }
 

--- a/v2/ical.NET.UnitTests/Ical.Net.UnitTests.csproj
+++ b/v2/ical.NET.UnitTests/Ical.Net.UnitTests.csproj
@@ -59,7 +59,7 @@
   <ItemGroup>
     <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NodaTime.1.3.1\lib\net35-Client\NodaTime.dll</HintPath>
+      <HintPath>..\packages\NodaTime.1.3.6\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.4.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.4.1\lib\net40\nunit.framework.dll</HintPath>

--- a/v2/ical.NET.UnitTests/packages.config
+++ b/v2/ical.NET.UnitTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NodaTime" version="1.3.1" targetFramework="net461" />
+  <package id="NodaTime" version="1.3.6" targetFramework="net461" />
   <package id="NUnit" version="3.4.1" targetFramework="net40" />
   <package id="System.ValueTuple" version="4.3.0" targetFramework="net40" />
 </packages>

--- a/v2/ical.NET/Components/VTimeZone.cs
+++ b/v2/ical.NET/Components/VTimeZone.cs
@@ -323,7 +323,10 @@ namespace Ical.Net
 
         public Uri Url
         {
-            get => _url ?? (_url = Properties.Get<Uri>("TZURL"));
+            get
+            {
+                return _url ?? (_url = Properties.Get<Uri>("TZURL"));
+            }
             set
             {
                 _url = value;
@@ -334,7 +337,10 @@ namespace Ical.Net
         private string _location;
         public string Location
         {
-            get => _location ?? (_location = Properties.Get<string>("X-LIC-LOCATION"));
+            get
+            {
+                return _location ?? (_location = Properties.Get<string>("X-LIC-LOCATION"));
+            }
             set
             {
                 _location = value;

--- a/v2/ical.NET/DataTypes/Period.cs
+++ b/v2/ical.NET/DataTypes/Period.cs
@@ -125,9 +125,12 @@ namespace Ical.Net.DataTypes
         private IDateTime _startTime;
         public virtual IDateTime StartTime
         {
-            get => _startTime.HasTime
-                ? _startTime
-                : new CalDateTime(new DateTime(_startTime.Value.Year, _startTime.Value.Month, _startTime.Value.Day, 0,0,0), _startTime.TzId);
+            get
+            {
+                return _startTime.HasTime
+                    ? _startTime
+                    : new CalDateTime(new DateTime(_startTime.Value.Year, _startTime.Value.Month, _startTime.Value.Day, 0, 0, 0), _startTime.TzId);
+            }
             set
             {
                 if (Equals(_startTime, value))

--- a/v2/ical.NET/DataTypes/PeriodList.cs
+++ b/v2/ical.NET/DataTypes/PeriodList.cs
@@ -110,8 +110,8 @@ namespace Ical.Net.DataTypes
 
         public IPeriod this[int index]
         {
-            get => Periods[index];
-            set => Periods[index] = value;
+            get { return Periods[index]; }
+            set { Periods[index] = value; }
         }
 
         public bool Remove(IPeriod item) => Periods.Remove(item);

--- a/v2/ical.NET/Evaluation/RecurrencePatternEvaluator.cs
+++ b/v2/ical.NET/Evaluation/RecurrencePatternEvaluator.cs
@@ -70,7 +70,7 @@ namespace Ical.Net.Evaluation
             // Convert the UNTIL value to one that matches the same time information as the reference date
             if (r.Until != DateTime.MinValue)
             {
-                r.Until = DateUtil.MatchTimeZone(referenceDate, new CalDateTime(r.Until)).Value;
+                r.Until = DateUtil.GetSimpleDateTimeData(DateUtil.MatchTimeZone(referenceDate, new CalDateTime(r.Until, r.Until.Kind == DateTimeKind.Utc ? "UTC" : referenceDate.TzId)));
             }
 
             if (r.Frequency > FrequencyType.Secondly && r.BySecond.Count == 0 && referenceDate.HasTime
@@ -279,10 +279,7 @@ namespace Ical.Net.Evaluation
                 {
                     noCandidateIncrementCount = 0;
 
-                    // sort candidates for identifying when UNTIL date is exceeded..
-                    candidates.Sort();
-
-                    foreach (var t in candidates.Where(t => t >= originalDate))
+                    foreach (var t in candidates.OrderBy(c => c).Where(t => t >= originalDate))
                     {
                         candidate = t;
 
@@ -301,8 +298,7 @@ namespace Ical.Net.Evaluation
                         }
                         else if (pattern.Until == DateTime.MinValue || candidate <= pattern.Until)
                         {
-                            var utcCandidate = DateUtil.FromTimeZoneToTimeZone(candidate, DateUtil.GetZone(seed.TzId), DateTimeZone.Utc).ToDateTimeUtc();
-                            if (!dates.Contains(candidate) && (pattern.Until == DateTime.MinValue || utcCandidate <= pattern.Until))
+                            if (!dates.Contains(candidate))
                             {
                                 dates.Add(candidate);
                             }
@@ -321,7 +317,6 @@ namespace Ical.Net.Evaluation
                 IncrementDate(ref seedCopy, pattern, pattern.Interval);
             }
 
-            // sort final list..
             return dates;
         }
 

--- a/v2/ical.NET/Evaluation/TimeZoneInfoEvaluator.cs
+++ b/v2/ical.NET/Evaluation/TimeZoneInfoEvaluator.cs
@@ -14,8 +14,8 @@ namespace Ical.Net.Evaluation
 
         protected ITimeZoneInfo TimeZoneInfo
         {
-            get => Recurrable as ITimeZoneInfo;
-            set => Recurrable = value;
+            get { return Recurrable as ITimeZoneInfo; }
+            set { Recurrable = value; }
         }
 
         #endregion

--- a/v2/ical.NET/Ical.Net.csproj
+++ b/v2/ical.NET/Ical.Net.csproj
@@ -60,7 +60,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
-      <HintPath>..\packages\NodaTime.1.3.1\lib\net35-Client\NodaTime.dll</HintPath>
+      <HintPath>..\packages\NodaTime.1.3.6\lib\net35-Client\NodaTime.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/DateTimeSerializer.cs
+++ b/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/DateTimeSerializer.cs
@@ -45,7 +45,7 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
         {
             var dt = obj as IDateTime;
 
-                      // RFC 5545 3.3.5: 
+            // RFC 5545 3.3.5:
             // The date with UTC time, or absolute time, is identified by a LATIN
             // CAPITAL LETTER Z suffix character, the UTC designator, appended to
             // the time value. The "TZID" property parameter MUST NOT be applied to DATE-TIME
@@ -134,6 +134,7 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
                 if (match.Groups[9].Success)
                 {
                     dt.IsUniversalTime = true;
+                    dt.TzId = "UTC";
                 }
 
                 dt.Value = CoerceDateTime(year, month, date, hour, minute, second, DateTimeKind.Utc);

--- a/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/RecurrencePatternSerializer.cs
+++ b/v2/ical.NET/Serialization/iCalendar/Serializers/DataTypes/RecurrencePatternSerializer.cs
@@ -254,7 +254,7 @@ namespace Ical.Net.Serialization.iCalendar.Serializers.DataTypes
                                 var dt = serializer?.Deserialize(new StringReader(keyValue)) as IDateTime;
                                 if (dt != null)
                                 {
-                                    r.Until = dt.Value;
+                                    r.Until = Utility.DateUtil.GetSimpleDateTimeData(dt);
                                 }
                             }
                                 break;

--- a/v2/ical.NET/Utility/RecurrenceUtil.cs
+++ b/v2/ical.NET/Utility/RecurrenceUtil.cs
@@ -35,8 +35,16 @@ namespace Ical.Net.Utility
 
             // Change the time zone of periodStart/periodEnd as needed 
             // so they can be used during the evaluation process.
-            periodStart = DateUtil.MatchTimeZone(start, periodStart);
-            periodEnd = DateUtil.MatchTimeZone(start, periodEnd);
+            if (string.IsNullOrEmpty(periodStart.TzId) && !periodStart.IsUniversalTime)
+            {
+                periodStart.TzId = start.TzId;
+                periodEnd.TzId = start.TzId;
+            }
+            else
+            {
+                periodStart = DateUtil.MatchTimeZone(start, periodStart);
+                periodEnd = DateUtil.MatchTimeZone(start, periodEnd);
+            }
 
             var periods = evaluator.Evaluate(start, DateUtil.GetSimpleDateTimeData(periodStart), DateUtil.GetSimpleDateTimeData(periodEnd), includeReferenceDateInResults);
 

--- a/v2/ical.NET/packages.config
+++ b/v2/ical.NET/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NodaTime" version="1.3.1" targetFramework="net40" />
+  <package id="NodaTime" version="1.3.6" targetFramework="net40" />
   <package id="System.Runtime.Serialization.Primitives" version="4.3.0" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
This pull request is intended to resolve several Ical.Net v2 issues:
* CalDateTime.ToTimeZone produces UTC time instead of target time zone (bug #330)
* Fix issues with UNTIL recurrence rule that caused RecurrenceUtil.GetOccurrences not returning the last occurrence from the series in v2.
* Update NodaTime to v1.3.6

@rianjs, even though Ical.Net v2 is no longer officially supported, I would be grateful if you could review and merge this pull request and then release new version 2.3.6 if there are no objections. We still use .NET 4.0 and can't migrate to new Ical.Net v4.

Thanks.