### PR TITLE
Fix for #378 - handle timezones which do not observe DST

### DIFF
--- a/net-core/Ical.Net/CalendarComponents/VTimeZone.cs
+++ b/net-core/Ical.Net/CalendarComponents/VTimeZone.cs
@@ -44,7 +44,7 @@ namespace Ical.Net.CalendarComponents
             // Only include historical data if asked to do so.  Otherwise,
             // use only the most recent adjustment rules available.
             var intervals = vTimeZone._nodaZone.GetZoneIntervals(earliest, Instant.FromDateTimeOffset(DateTimeOffset.Now))
-                .Where(z => z.HasStart && z.Start != Instant.MinValue && z.HasEnd)
+                .Where(z => z.HasStart && z.Start != Instant.MinValue)
                 .ToList();
 
             var matchingDaylightIntervals = new List<ZoneInterval>();
@@ -75,7 +75,7 @@ namespace Ical.Net.CalendarComponents
                 vTimeZone.AddChild(latestStandardTimeZoneInfo);
 
                 // check to see if there is no active, future daylight savings (ie, America/Phoenix)
-                if (latestStandardInterval != null && latestStandardInterval.End != Instant.MaxValue)
+                if (latestStandardInterval != null && (latestStandardInterval.HasEnd ? latestStandardInterval.End : Instant.MaxValue) != Instant.MaxValue)
                 {
                     //daylight
                     var daylightIntervals = intervals.Where(x => x.Savings.ToTimeSpan() != new TimeSpan(0)).ToList();
@@ -130,7 +130,7 @@ namespace Ical.Net.CalendarComponents
                 throw new InvalidOperationException("oldestInterval was not found");
             }
 
-            var previousInterval = intervals.SingleOrDefault(x => x.End == oldestInterval.Start);
+            var previousInterval = intervals.SingleOrDefault(x => (x.HasEnd ? x.End : Instant.MaxValue) == oldestInterval.Start);
 
             var delta = new TimeSpan(1, 0, 0);
 


### PR DESCRIPTION
Noda Time doesn't specify End values for the current timezone interval for timezones which do not observe DST.
This causes no current interval to be returned, and the existing code to create at least one standard interval incorrectly - it selects the minimum offset from the timezone on any interval which may not be correct for today.
This fix allows the correct current interval to be returned, rather than relying on fallback code.