### PR TITLE
Associate attachments with their events when VALUE is BINARY.

### DIFF
--- a/net-core/Ical.Net.CoreUnitTests/SerializationTests.cs
+++ b/net-core/Ical.Net.CoreUnitTests/SerializationTests.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
@@ -485,6 +486,31 @@ END:VEVENT";
 
             var expectedVersion = $"VERSION:{LibraryMetadata.Version}";
             Assert.IsTrue(serialized.Contains(expectedVersion, StringComparison.Ordinal));
+        }
+
+        [Test]
+        public void AttachmentFormatType()
+        {
+            var cal1 = new Calendar
+            {
+                Events =
+                {
+                    new CalendarEvent
+                    {
+                        Attachments =
+                        {
+                            new Attachment(Encoding.UTF8.GetBytes("{}"))
+                            {
+                                FormatType = "application/json",
+                            },
+                        },
+                    },
+                },
+            };
+            var serializer = new CalendarSerializer();
+            var serializedCalendar = serializer.SerializeToString(cal1);
+            var cal2 = Calendar.Load(serializedCalendar);
+            Assert.AreEqual("application/json", cal2.Events.Single().Attachments.Single().FormatType);
         }
     }
 }

--- a/net-core/Ical.Net.nuspec
+++ b/net-core/Ical.Net.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>Ical.Net</id>
-        <version>4.1.8</version>
+        <version>4.1.9</version>
         <title>Ical.Net</title>
         <authors>Rian Stockbower, Douglas Day</authors>
         <owners>Rian Stockbower</owners>

--- a/net-core/Ical.Net/Serialization/DataTypes/AttachmentSerializer.cs
+++ b/net-core/Ical.Net/Serialization/DataTypes/AttachmentSerializer.cs
@@ -62,7 +62,11 @@ namespace Ical.Net.Serialization.DataTypes
                 {
                     // If the VALUE type is specifically set to BINARY,
                     // then set the Data property instead.                    
-                    return new Attachment(data) {ValueEncoding = a.ValueEncoding};
+                    return new Attachment(data)
+                    {
+                        ValueEncoding = a.ValueEncoding,
+                        AssociatedObject = a.AssociatedObject,
+                    };
                 }
 
                 // The default VALUE type for attachments is URI.  So, let's

--- a/release-notes.md
+++ b/release-notes.md
@@ -3,6 +3,7 @@
 A listing of what each [Nuget package](https://www.nuget.org/packages/Ical.Net) version represents.
 
 ### v4
+* 4.1.9 - (2018-07-18) - Associate attachments with their events when VALUE is BINARY. Without the association, parameters such as FMTTYPE would be lost. [PR 411](https://github.com/rianjs/ical.net/pull/411)
 * 4.1.8 - (2018-06-12) - `PRODID` and `VERSION` are unconditionally set when serializing a calendar so as not to mislead consumers about where the serialized output came from. Previous behavior would use the values that came from deserialization. #403
 * 4.1.6 - (2018-06-01) - Target `net46` instead of `net45`. It seems that [`System.Reflection.TypeExtensions`](https://www.nuget.org/packages/System.Reflection.TypeExtensions/), doesn't support framework versions below 4.6. Bummer.
 * 4.1.5 - (2018-05-28)


### PR DESCRIPTION
Without the association, parameters such as FMTTYPE would be lost.