### PR TITLE
Update pdb format for framework and VSTS

### DIFF
--- a/net-core/Ical.Net/Ical.Net.csproj
+++ b/net-core/Ical.Net/Ical.Net.csproj
@@ -6,6 +6,8 @@
     <Company />
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\IcalNetStrongnameKey.snk</AssemblyOriginatorKeyFile>
+    <DebugSymbols Condition=" '$(TargetFramework)' == 'net46' ">true</DebugSymbols>
+    <DebugType Condition=" '$(TargetFramework)' == 'net46' ">full</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>bin\Release\Ical.Net.xml</DocumentationFile>


### PR DESCRIPTION
The VSTS didn't like the framework .pdb file, giving an error, similar to this command line test of validity:
---
# "C:\Program Files (x86)\Windows Kits\10\Debuggers\x86\srcsrv\pdbstr.exe" -r -s:ssrc -p:D:\src\packages\Ical.Net\lib\net46\Ical.Net.pdb
error 0xb opening D:\src\packages\Ical.Net\lib\net46\Ical.Net.pdb
---

This is fixed by adding some conditional debug settings in the project file.

Without this fix one must remember to delete the pdb file whenever one updates packages to avoid build errors, which is a nuisance.