### PR TITLE
Fix inverted IsActive property

### DIFF
--- a/net-core/Ical.Net.CoreUnitTests/IcsFiles.cs
+++ b/net-core/Ical.Net.CoreUnitTests/IcsFiles.cs
@@ -68,6 +68,7 @@ namespace Ical.Net.CoreUnitTests
         internal static string Event2 => ReadStream("Ical.Net.CoreUnitTests.Calendars.Serialization.Event2.ics");
         internal static string Event3 => ReadStream("Ical.Net.CoreUnitTests.Calendars.Serialization.Event3.ics");
         internal static string Event4 => ReadStream("Ical.Net.CoreUnitTests.Calendars.Serialization.Event4.ics");
+        internal static string EventStatus => ReadStream("Ical.Net.CoreUnitTests.Calendars.Serialization.EventStatus.ics");
         internal static string GeographicLocation1 => ReadStream("Ical.Net.CoreUnitTests.Calendars.Serialization.GeographicLocation1.ics");
         internal static string Google1 => ReadStream("Ical.Net.CoreUnitTests.Calendars.Serialization.Google1.ics");
         internal static string Hourly1 => ReadStream("Ical.Net.CoreUnitTests.Calendars.Recurrence.Hourly1.ics");

--- a/net-core/Ical.Net.CoreUnitTests/SimpleDeserializationTests.cs
+++ b/net-core/Ical.Net.CoreUnitTests/SimpleDeserializationTests.cs
@@ -422,6 +422,29 @@ END:VCALENDAR
         }
 
         [Test, Category("Deserialization")]
+        public void EventStatus()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.EventStatus)).Cast<Calendar>().Single();
+            Assert.AreEqual(4, iCal.Events.Count);
+
+            Assert.AreEqual("No status", iCal.Events[0].Summary);
+            Assert.IsNull(iCal.Events[0].Status);
+            Assert.IsTrue(iCal.Events[0].IsActive);
+
+            Assert.AreEqual("Confirmed", iCal.Events[1].Summary);
+            Assert.AreEqual("CONFIRMED", iCal.Events[1].Status);
+            Assert.IsTrue(iCal.Events[1].IsActive);
+
+            Assert.AreEqual("Cancelled", iCal.Events[2].Summary);
+            Assert.AreEqual("CANCELLED", iCal.Events[2].Status);
+            Assert.IsFalse(iCal.Events[2].IsActive);
+
+            Assert.AreEqual("Tentative", iCal.Events[3].Summary);
+            Assert.AreEqual("TENTATIVE", iCal.Events[3].Status);
+            Assert.IsTrue(iCal.Events[3].IsActive);
+        }
+
+        [Test, Category("Deserialization")]
         public void Language4()
         {
             var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Language4)).Cast<Calendar>().Single();

--- a/net-core/Ical.Net.FrameworkUnitTests/Ical.Net.FrameworkUnitTests.csproj
+++ b/net-core/Ical.Net.FrameworkUnitTests/Ical.Net.FrameworkUnitTests.csproj
@@ -194,6 +194,7 @@
     <Content Include="Calendars\Serialization\Event2.ics" />
     <Content Include="Calendars\Serialization\Event3.ics" />
     <Content Include="Calendars\Serialization\Event4.ics" />
+    <Content Include="Calendars\Serialization\EventStatus.ics" />
     <Content Include="Calendars\Serialization\GeographicLocation1.ics" />
     <Content Include="Calendars\Serialization\Google1.ics" />
     <Content Include="Calendars\Serialization\Language1.ics" />

--- a/net-core/Ical.Net.FrameworkUnitTests/SimpleDeserializationTests.cs
+++ b/net-core/Ical.Net.FrameworkUnitTests/SimpleDeserializationTests.cs
@@ -422,6 +422,29 @@ END:VCALENDAR
         }
 
         [Test, Category("Deserialization")]
+        public void EventStatus()
+        {
+            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.EventStatus)).Cast<Calendar>().Single();
+            Assert.AreEqual(4, iCal.Events.Count);
+
+            Assert.AreEqual("No status", iCal.Events[0].Summary);
+            Assert.IsNull(iCal.Events[0].Status);
+            Assert.IsTrue(iCal.Events[0].IsActive);
+
+            Assert.AreEqual("Confirmed", iCal.Events[1].Summary);
+            Assert.AreEqual("CONFIRMED", iCal.Events[1].Status);
+            Assert.IsTrue(iCal.Events[1].IsActive);
+
+            Assert.AreEqual("Cancelled", iCal.Events[2].Summary);
+            Assert.AreEqual("CANCELLED", iCal.Events[2].Status);
+            Assert.IsFalse(iCal.Events[2].IsActive);
+
+            Assert.AreEqual("Tentative", iCal.Events[3].Summary);
+            Assert.AreEqual("TENTATIVE", iCal.Events[3].Status);
+            Assert.IsTrue(iCal.Events[3].IsActive);
+        }
+
+        [Test, Category("Deserialization")]
         public void Language4()
         {
             var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Language4)).Cast<Calendar>().Single();

--- a/net-core/Ical.Net/CalendarComponents/CalendarEvent.cs
+++ b/net-core/Ical.Net/CalendarComponents/CalendarEvent.cs
@@ -243,7 +243,7 @@ namespace Ical.Net.CalendarComponents
         /// as an upcoming or occurred event.
         /// </summary>
         /// <returns>True if the event has not been cancelled, False otherwise.</returns>
-        public virtual bool IsActive => string.Equals(Status, EventStatus.Cancelled, EventStatus.Comparison);
+        public virtual bool IsActive => !string.Equals(Status, EventStatus.Cancelled, EventStatus.Comparison);
 
         protected override bool EvaluationIncludesReferenceDate => true;
 


### PR DESCRIPTION
Fixes a bug that was introduced in commit a3c3025 when IsActive was converted to a property.