### PR TITLE
BUG FIX: Mutation of property can output as an array

### DIFF
--- a/net-core/Ical.Net.CoreUnitTests/SerializationTests.cs
+++ b/net-core/Ical.Net.CoreUnitTests/SerializationTests.cs
@@ -316,6 +316,9 @@ namespace Ical.Net.CoreUnitTests
             evt.Organizer = new Organizer(org);
 
             evt.Attendees.AddRange(_attendees);
+            
+            // However a bug, when a participation value is changed, ultimately re-serialises as an array (PARTSTAT=ACCEPTED,DECLINED)
+            evt.Attendees[0].ParticipationStatus = EventParticipationStatus.Declined;
 
             var serializer = new CalendarSerializer();
             var serializedCalendar = serializer.SerializeToString(cal);
@@ -421,11 +424,11 @@ DTSTART;TZID=Europe/Helsinki:20160707T110000
 DTEND;TZID=Europe/Helsinki:20160707T140000
 SUMMARY:Some summary
 UID:20160627T123608Z-182847102@atlassian.net
-DESCRIPTION:Key points:\n•	Some text (text,
- , text\, text\, TP) some text\;\n•	some tex
- t Some text (Text\, Text)\;\n•	Some tex
+DESCRIPTION:Key points:\nÂ•	Some text (text,
+ , text\, text\, TP) some text\;\nÂ•	some tex
+ t Some text (Text\, Text)\;\nÂ•	Some tex
  t some text\, some text\, text.\;\n\nsome te
- xt some tex‘t some text. 
+ xt some texÂ‘t some text. 
 ORGANIZER;X-CONFLUENCE-USER-KEY=ff801df01547101c6720006;CN=Some
  user;CUTYPE=INDIVIDUAL:mailto:some.mail@domain.com
 CREATED:20160627T123608Z
@@ -440,8 +443,8 @@ END:VEVENT";
             var deserializedEvent = Calendar.Load<CalendarEvent>(ics).Single();
 
             Assert.IsTrue(deserializedEvent.Description.Contains("\t"));
-            Assert.IsTrue(deserializedEvent.Description.Contains("•"));
-            Assert.IsTrue(deserializedEvent.Description.Contains("‘"));
+            Assert.IsTrue(deserializedEvent.Description.Contains("Â•"));
+            Assert.IsTrue(deserializedEvent.Description.Contains("Â‘"));
         }
 
         [Test]

--- a/net-core/Ical.Net/CalendarParameter.cs
+++ b/net-core/Ical.Net/CalendarParameter.cs
@@ -70,6 +70,7 @@ namespace Ical.Net
 
         public virtual void SetValue(string value)
         {
+            _values.Clear();
             _values.Add(value);
         }
 


### PR DESCRIPTION
Bug found where changing a property that was already set either by deserialization or property set.

On serialization, will be output as an array of values.

Corrects the SetValue property and adds test in serialization exercising a property change.