### PR TITLE
BYWEEKNO & BYMONTH fix & ISO 8601 week number fix

### DIFF
--- a/net-core/Ical.Net.CoreUnitTests/RecurrenceTests.cs
+++ b/net-core/Ical.Net.CoreUnitTests/RecurrenceTests.cs
@@ -2578,7 +2578,6 @@ namespace Ical.Net.CoreUnitTests
 
         /// <summary>
         /// Tests bug BYWEEKNO not working
-        /// See https://sourceforge.net/tracker/?func=detail&aid=3119920&group_id=187422&atid=921236
         /// </summary>
         [Test, Category("Recurrence")]
         public void BugByWeekNoNotWorking()
@@ -2595,7 +2594,6 @@ namespace Ical.Net.CoreUnitTests
 
         /// <summary>
         /// Tests bug BYMONTH while FREQ=WEEKLY not working
-        /// See https://sourceforge.net/tracker/?func=detail&aid=3119920&group_id=187422&atid=921236
         /// </summary>
         [Test, Category("Recurrence")]
         public void BugByMonthWhileFreqIsWeekly()
@@ -2615,7 +2613,6 @@ namespace Ical.Net.CoreUnitTests
 
         /// <summary>
         /// Tests bug BYMONTH while FREQ=MONTHLY not working
-        /// See https://sourceforge.net/tracker/?func=detail&aid=3119920&group_id=187422&atid=921236
         /// </summary>
         [Test, Category("Recurrence")]
         public void BugByMonthWhileFreqIsMontly()

--- a/net-core/Ical.Net/CalendarExtensions.cs
+++ b/net-core/Ical.Net/CalendarExtensions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Ical.Net
+{
+    public static class CalendarExtensions
+    {
+        /// <summary>
+        /// https://blogs.msdn.microsoft.com/shawnste/2006/01/24/iso-8601-week-of-year-format-in-microsoft-net/
+        /// </summary>
+        public static int GetIso8601WeekOfYear(this System.Globalization.Calendar calendar, DateTime time, CalendarWeekRule rule, DayOfWeek firstDayOfWeek)
+        {
+            // Seriously cheat.  If its Monday, Tuesday or Wednesday, then it'll
+            // be the same week# as whatever Thursday, Friday or Saturday are,
+            // and we always get those right
+            var day = calendar.GetDayOfWeek(time);
+            if (day >= DayOfWeek.Monday && day <= DayOfWeek.Wednesday)
+            {
+                time = time.AddDays(3);
+            }
+
+            // Return the week of our adjusted day
+            return calendar.GetIso8601WeekOfYear(time, rule, firstDayOfWeek);
+        }
+    }
+}

--- a/net-core/Ical.Net/CalendarExtensions.cs
+++ b/net-core/Ical.Net/CalendarExtensions.cs
@@ -22,7 +22,7 @@ namespace Ical.Net
             }
 
             // Return the week of our adjusted day
-            return calendar.GetIso8601WeekOfYear(time, rule, firstDayOfWeek);
+            return calendar.GetWeekOfYear(time, rule, firstDayOfWeek);
         }
     }
 }

--- a/net-core/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
+++ b/net-core/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
@@ -133,44 +133,44 @@ namespace Ical.Net.Evaluation
                         switch (pattern.Frequency)
                         {
                             case FrequencyType.Secondly:
-                            {
-                                switch (evaluationRestriction)
                                 {
-                                    case RecurrenceRestrictionType.Default:
-                                    case RecurrenceRestrictionType.RestrictSecondly:
-                                        pattern.Frequency = FrequencyType.Minutely;
-                                        break;
-                                    case RecurrenceRestrictionType.RestrictMinutely:
-                                        pattern.Frequency = FrequencyType.Hourly;
-                                        break;
-                                    case RecurrenceRestrictionType.RestrictHourly:
-                                        pattern.Frequency = FrequencyType.Daily;
-                                        break;
+                                    switch (evaluationRestriction)
+                                    {
+                                        case RecurrenceRestrictionType.Default:
+                                        case RecurrenceRestrictionType.RestrictSecondly:
+                                            pattern.Frequency = FrequencyType.Minutely;
+                                            break;
+                                        case RecurrenceRestrictionType.RestrictMinutely:
+                                            pattern.Frequency = FrequencyType.Hourly;
+                                            break;
+                                        case RecurrenceRestrictionType.RestrictHourly:
+                                            pattern.Frequency = FrequencyType.Daily;
+                                            break;
+                                    }
                                 }
-                            }
                                 break;
                             case FrequencyType.Minutely:
-                            {
-                                switch (evaluationRestriction)
                                 {
-                                    case RecurrenceRestrictionType.RestrictMinutely:
-                                        pattern.Frequency = FrequencyType.Hourly;
-                                        break;
-                                    case RecurrenceRestrictionType.RestrictHourly:
-                                        pattern.Frequency = FrequencyType.Daily;
-                                        break;
+                                    switch (evaluationRestriction)
+                                    {
+                                        case RecurrenceRestrictionType.RestrictMinutely:
+                                            pattern.Frequency = FrequencyType.Hourly;
+                                            break;
+                                        case RecurrenceRestrictionType.RestrictHourly:
+                                            pattern.Frequency = FrequencyType.Daily;
+                                            break;
+                                    }
                                 }
-                            }
                                 break;
                             case FrequencyType.Hourly:
-                            {
-                                switch (evaluationRestriction)
                                 {
-                                    case RecurrenceRestrictionType.RestrictHourly:
-                                        pattern.Frequency = FrequencyType.Daily;
-                                        break;
+                                    switch (evaluationRestriction)
+                                    {
+                                        case RecurrenceRestrictionType.RestrictHourly:
+                                            pattern.Frequency = FrequencyType.Daily;
+                                            break;
+                                    }
                                 }
-                            }
                                 break;
                         }
                         break;
@@ -179,35 +179,35 @@ namespace Ical.Net.Evaluation
                         switch (pattern.Frequency)
                         {
                             case FrequencyType.Secondly:
-                            {
-                                switch (evaluationRestriction)
                                 {
-                                    case RecurrenceRestrictionType.Default:
-                                    case RecurrenceRestrictionType.RestrictSecondly:
-                                    case RecurrenceRestrictionType.RestrictMinutely:
-                                    case RecurrenceRestrictionType.RestrictHourly:
-                                        throw new ArgumentException();
+                                    switch (evaluationRestriction)
+                                    {
+                                        case RecurrenceRestrictionType.Default:
+                                        case RecurrenceRestrictionType.RestrictSecondly:
+                                        case RecurrenceRestrictionType.RestrictMinutely:
+                                        case RecurrenceRestrictionType.RestrictHourly:
+                                            throw new ArgumentException();
+                                    }
                                 }
-                            }
                                 break;
                             case FrequencyType.Minutely:
-                            {
-                                switch (evaluationRestriction)
                                 {
-                                    case RecurrenceRestrictionType.RestrictMinutely:
-                                    case RecurrenceRestrictionType.RestrictHourly:
-                                        throw new ArgumentException();
+                                    switch (evaluationRestriction)
+                                    {
+                                        case RecurrenceRestrictionType.RestrictMinutely:
+                                        case RecurrenceRestrictionType.RestrictHourly:
+                                            throw new ArgumentException();
+                                    }
                                 }
-                            }
                                 break;
                             case FrequencyType.Hourly:
-                            {
-                                switch (evaluationRestriction)
                                 {
-                                    case RecurrenceRestrictionType.RestrictHourly:
-                                        throw new ArgumentException();
+                                    switch (evaluationRestriction)
+                                    {
+                                        case RecurrenceRestrictionType.RestrictHourly:
+                                            throw new ArgumentException();
+                                    }
                                 }
-                            }
                                 break;
                         }
                         break;
@@ -318,7 +318,7 @@ namespace Ical.Net.Evaluation
 
         private List<DateTime> GetCandidates(DateTime date, RecurrencePattern pattern, bool?[] expandBehaviors)
         {
-            var dates = new List<DateTime> {date};
+            var dates = new List<DateTime> { date };
             dates = GetMonthVariants(dates, pattern, expandBehaviors[0]);
             dates = GetWeekNoVariants(dates, pattern, expandBehaviors[1]);
             dates = GetYearDayVariants(dates, pattern, expandBehaviors[2]);
@@ -410,7 +410,7 @@ namespace Ical.Net.Evaluation
                 foreach (var weekNo in pattern.ByWeekNo)
                 {
                     // Determine our current week number
-                    var currWeekNo = Calendar.GetWeekOfYear(date, CalendarWeekRule.FirstFourDayWeek, pattern.FirstDayOfWeek);
+                    var currWeekNo = Calendar.GetIso8601WeekOfYear(date, CalendarWeekRule.FirstFourDayWeek, pattern.FirstDayOfWeek);
                     while (currWeekNo > weekNo)
                     {
                         // If currWeekNo > weekNo, then we're likely at the start of a year
@@ -418,7 +418,7 @@ namespace Ical.Net.Evaluation
                         // we should be back to week 1, where we can easily make the calculation
                         // to move to weekNo.
                         date = date.AddDays(7);
-                        currWeekNo = Calendar.GetWeekOfYear(date, CalendarWeekRule.FirstFourDayWeek, pattern.FirstDayOfWeek);
+                        currWeekNo = Calendar.GetIso8601WeekOfYear(date, CalendarWeekRule.FirstFourDayWeek, pattern.FirstDayOfWeek);
                     }
 
                     // Move ahead to the correct week of the year
@@ -485,7 +485,7 @@ namespace Ical.Net.Evaluation
                 }
 
                 dates.RemoveAt(i);
-                Next:
+            Next:
                 ;
             }
 
@@ -547,7 +547,7 @@ namespace Ical.Net.Evaluation
                     }
                 }
 
-                Next:
+            Next:
                 dates.RemoveAt(i);
             }
 
@@ -601,7 +601,7 @@ namespace Ical.Net.Evaluation
                     }
                 }
                 dates.RemoveAt(i);
-                Next:
+            Next:
                 ;
             }
 
@@ -630,7 +630,7 @@ namespace Ical.Net.Evaluation
             }
             else if (pattern.Frequency == FrequencyType.Weekly || pattern.ByWeekNo.Count > 0)
             {
-                var weekNo = Calendar.GetWeekOfYear(date, CalendarWeekRule.FirstFourDayWeek, pattern.FirstDayOfWeek);
+                var weekNo = Calendar.GetIso8601WeekOfYear(date, CalendarWeekRule.FirstFourDayWeek, pattern.FirstDayOfWeek);
 
                 // construct a list of possible week days..
                 while (date.DayOfWeek != dayOfWeek)
@@ -638,17 +638,22 @@ namespace Ical.Net.Evaluation
                     date = date.AddDays(1);
                 }
 
-                var nextWeekNo = Calendar.GetWeekOfYear(date, CalendarWeekRule.FirstFourDayWeek, pattern.FirstDayOfWeek);
-                var currentWeekNo = Calendar.GetWeekOfYear(date, CalendarWeekRule.FirstFourDayWeek, pattern.FirstDayOfWeek);
+                var nextWeekNo = Calendar.GetIso8601WeekOfYear(date, CalendarWeekRule.FirstFourDayWeek, pattern.FirstDayOfWeek);
+                var currentWeekNo = Calendar.GetIso8601WeekOfYear(date, CalendarWeekRule.FirstFourDayWeek, pattern.FirstDayOfWeek);
 
                 //When we manage weekly recurring pattern and we have boundary case:
                 //Weekdays: Dec 31, Jan 1, Feb 1, Mar 1, Apr 1, May 1, June 1, Dec 31 - It's the 53th week of the year, but all another are 1st week number.
                 //So we need an EXRULE for this situation, but only for weekly events
                 while (currentWeekNo == weekNo || (nextWeekNo < weekNo && currentWeekNo == nextWeekNo && pattern.Frequency == FrequencyType.Weekly))
                 {
-                    days.Add(date);
+                    if ((pattern.ByWeekNo.Count == 0 || pattern.ByWeekNo.Contains(currentWeekNo)) &&
+                        (pattern.ByMonth.Count == 0 || pattern.ByMonth.Contains(date.Month)))
+                    {
+                        days.Add(date);
+                    }
+
                     date = date.AddDays(7);
-                    currentWeekNo = Calendar.GetWeekOfYear(date, CalendarWeekRule.FirstFourDayWeek, pattern.FirstDayOfWeek);
+                    currentWeekNo = Calendar.GetIso8601WeekOfYear(date, CalendarWeekRule.FirstFourDayWeek,pattern.FirstDayOfWeek);
                 }
             }
             else if (pattern.Frequency == FrequencyType.Monthly || pattern.ByMonth.Count > 0)
@@ -664,7 +669,13 @@ namespace Ical.Net.Evaluation
 
                 while (date.Month == month)
                 {
-                    days.Add(date);
+                    var currentWeekNo = Calendar.GetIso8601WeekOfYear(date, CalendarWeekRule.FirstFourDayWeek, pattern.FirstDayOfWeek);
+
+                    if ((pattern.ByWeekNo.Count == 0 || pattern.ByWeekNo.Contains(currentWeekNo)) &&
+                        (pattern.ByMonth.Count == 0 || pattern.ByMonth.Contains(date.Month)))
+                    {
+                        days.Add(date);
+                    }
                     date = date.AddDays(7);
                 }
             }
@@ -761,7 +772,7 @@ namespace Ical.Net.Evaluation
                 }
                 // Remove unmatched dates
                 dates.RemoveAt(i);
-                Next:
+            Next:
                 ;
             }
             return dates;
@@ -811,7 +822,7 @@ namespace Ical.Net.Evaluation
                 }
                 // Remove unmatched dates
                 dates.RemoveAt(i);
-                Next:
+            Next:
                 ;
             }
             return dates;
@@ -861,7 +872,7 @@ namespace Ical.Net.Evaluation
                 }
                 // Remove unmatched dates
                 dates.RemoveAt(i);
-                Next:
+            Next:
                 ;
             }
             return dates;


### PR DESCRIPTION
BYWEEKNO was not working completely (week numbers was not considered when generating dates)
BYMONTH was not working completely (month numbers was not considered when generating dates)

...see tests for more details

Week numbers was retrieved from .NET's Calendar which behaves differently than ISO 8601 (see https://blogs.msdn.microsoft.com/shawnste/2006/01/24/iso-8601-week-of-year-format-in-microsoft-net/). iCalendar RFC says that ISO 8601 should be used.