### PR TITLE
Checking obj2 with MinValue of type obj2, not type obj1.

### DIFF
--- a/net-core/Ical.Net/Serialization/DataTypes/RecurrencePatternSerializer.cs
+++ b/net-core/Ical.Net/Serialization/DataTypes/RecurrencePatternSerializer.cs
@@ -79,9 +79,10 @@ namespace Ical.Net.Serialization.DataTypes
             // that to be unassigned.
 
             var t1 = obj1.GetType();
+            var t2 = obj2.GetType();
 
             var fi1 = t1.GetField("MinValue");
-            var fi2 = t1.GetField("MinValue");
+            var fi2 = t2.GetField("MinValue");
 
             var isMin1 = fi1 != null && obj1.Equals(fi1.GetValue(null));
             var isMin2 = fi2 != null && obj2.Equals(fi2.GetValue(null));


### PR DESCRIPTION
Found this code error while searching for an other bug.

It currently checks the value of obj2 against the MinValue of obj1.

`var fi2 = t1.GetField("MinValue");` doesn't look like it should be that way. I fixed this by checking against a new t2.