### PR TITLE
Checking for int.MinValue separately.

### DIFF
--- a/net-core/Ical.Net/Serialization/DataTypes/RecurrencePatternSerializer.cs
+++ b/net-core/Ical.Net/Serialization/DataTypes/RecurrencePatternSerializer.cs
@@ -75,6 +75,14 @@ namespace Ical.Net.Serialization.DataTypes
             {
                 return;
             }
+
+            // For some reason GetField("MinValue") sometimes returns 'null' when the obj is an int
+            // Casting the object to an int and directly checking for MinValue works though.
+            if (obj1 is int c && c == int.MinValue)
+            {
+                return;
+            }
+
             // If the object is MinValue instead of its default, consider
             // that to be unassigned.
 


### PR DESCRIPTION
We use this library with Xamarin. When updating Visual Studio this library broke, but only when building for a release package. When debugging everything worked fine. 

After adding extra logging we found that `t1.GetField("MinValue")` resulting in `null` and thus `isMin1` was false. When setting an EndDate it complained that "Both COUNT and UNTIL cannot be supplied together; they are mutually exclusive."

As `CheckMutuallyExclusive` is only used once and count is always obj1 I just added a check for int.MinValue if obj1 is an int.

I cannot find why this behaviour changed. I also don't know whether it is the xamarin compiler, the .net framework or the c# language. (We forced c# to 7.0, so the last one shouldn't be the problem.) 

For now this fixes our problem, but I can understand it when you don't really like the solution and I'm willing to discuss a better solution.