### PR TITLE
Fixed potential stack overflow when calculating changes to DtStart, DtEnd, etc.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,33 @@
+# .NET Desktop
+# Build and run tests for .NET Desktop or Windows classic desktop solutions.
+# Add steps that publish symbols, save build artifacts, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/apps/windows/dot-net
+
+trigger:
+- master
+
+pool:
+  vmImage: 'windows-latest'
+
+variables:
+  solution: '**/*.sln'
+  buildPlatform: 'Any CPU'
+  buildConfiguration: 'Release'
+
+steps:
+- task: NuGetToolInstaller@1
+
+- task: NuGetCommand@2
+  inputs:
+    restoreSolution: '$(solution)'
+
+- task: VSBuild@1
+  inputs:
+    solution: '$(solution)'
+    platform: '$(buildPlatform)'
+    configuration: '$(buildConfiguration)'
+
+- task: VSTest@2
+  inputs:
+    platform: '$(buildPlatform)'
+    configuration: '$(buildConfiguration)'

--- a/v2/ical.NET/Components/Event.cs
+++ b/v2/ical.NET/Components/Event.cs
@@ -45,7 +45,7 @@ namespace Ical.Net
             set
             {
                 base.DtStart = value;
-                ExtrapolateTimes();
+                ExtrapolateTimes(2);
             }
         }
 
@@ -68,7 +68,7 @@ namespace Ical.Net
                 if (!Equals(DtEnd, value))
                 {
                     Properties.Set("DTEND", value);
-                    ExtrapolateTimes();
+                    ExtrapolateTimes(0);
                 }
             }
         }
@@ -102,7 +102,7 @@ namespace Ical.Net
                 if (!Equals(Duration, value))
                 {
                     Properties.Set("DURATION", value);
-                    ExtrapolateTimes();
+                    ExtrapolateTimes(1);
                 }
             }
         }
@@ -263,20 +263,27 @@ namespace Ical.Net
         {
             base.OnDeserialized(context);
 
-            ExtrapolateTimes();
+            ExtrapolateTimes(-1);
         }
 
-        private void ExtrapolateTimes()
+        private void ExtrapolateTimes(int source)
         {
-            if (DtEnd == null && DtStart != null && Duration != default(TimeSpan))
+            /*
+			 * Source values, a fix introduced to prevent stack overflow exceptions from occuring.
+			 *   -1 = Anybody, stack overflow could maybe still occur in this case?
+			 *    0 = End
+			 *	  1 = Duration
+			 *	  2 = DtStart
+			 */
+            if (DtEnd == null && DtStart != null && Duration != default(TimeSpan) && source != 0)
             {
                 DtEnd = DtStart.Add(Duration);
             }
-            else if (Duration == default(TimeSpan) && DtStart != null && DtEnd != null)
+            else if (Duration == default(TimeSpan) && DtStart != null && DtEnd != null && source != 1)
             {
                 Duration = DtEnd.Subtract(DtStart);
             }
-            else if (DtStart == null && Duration != default(TimeSpan) && DtEnd != null)
+            else if (DtStart == null && Duration != default(TimeSpan) && DtEnd != null && source != 2)
             {
                 DtStart = DtEnd.Subtract(Duration);
             }

--- a/v2/ical.NET/Components/Todo.cs
+++ b/v2/ical.NET/Components/Todo.cs
@@ -36,7 +36,7 @@ namespace Ical.Net
             set
             {
                 base.DtStart = value;
-                ExtrapolateTimes();
+                ExtrapolateTimes(2);
             }
         }
 
@@ -49,7 +49,7 @@ namespace Ical.Net
             set
             {
                 Properties.Set("DUE", value);
-                ExtrapolateTimes();
+                ExtrapolateTimes(0);
             }
         }
 
@@ -72,7 +72,7 @@ namespace Ical.Net
             set
             {
                 Properties.Set("DURATION", value);
-                ExtrapolateTimes();
+                ExtrapolateTimes(1);
             }
         }
 
@@ -198,17 +198,23 @@ namespace Ical.Net
             base.OnDeserializing(context);
         }
 
-        private void ExtrapolateTimes()
+        private void ExtrapolateTimes(int source)
         {
-            if (Due == null && DtStart != null && Duration != default(TimeSpan))
+            /*
+			 * Source values, a fix introduced to prevent StackOverflow exceptions from occuring.
+			 *    0 = Due
+			 *	  1 = Duration
+			 *	  2 = DtStart
+			 */
+            if (Due == null && DtStart != null && Duration != default(TimeSpan) && source != 0)
             {
                 Due = DtStart.Add(Duration);
             }
-            else if (Duration == default(TimeSpan) && DtStart != null && Due != null)
+            else if (Duration == default(TimeSpan) && DtStart != null && Due != null && source != 1)
             {
                 Duration = Due.Subtract(DtStart);
             }
-            else if (DtStart == null && Duration != default(TimeSpan) && Due != null)
+            else if (DtStart == null && Duration != default(TimeSpan) && Due != null && source != 2)
             {
                 DtStart = Due.Subtract(Duration);
             }


### PR DESCRIPTION
These changes here came from our copy of ical.net. Figured it would be good to push these potentially back. We were seeing some production systems getting stack overflows caused by some fields not being provided when creating a calendar event then setting a value. After setting this value ExtrapolateTimes would then start looping when attempting to set *other* DtStart, Duration, DtEnd values.

p.s This is my first pull request, familiar with using open source projects but this is my first time going upstream. If there are any changes or suggestions let me know. 