### PR TITLE
Fixed potential stack overflow when calculating changes to DtStart, DtEnd, etc.

### DIFF
--- a/net-core/Ical.Net/CalendarComponents/CalendarEvent.cs
+++ b/net-core/Ical.Net/CalendarComponents/CalendarEvent.cs
@@ -43,7 +43,7 @@ namespace Ical.Net.CalendarComponents
             set
             {
                 base.DtStart = value;
-                ExtrapolateTimes();
+                ExtrapolateTimes(2);
             }
         }
 
@@ -66,7 +66,7 @@ namespace Ical.Net.CalendarComponents
                 if (!Equals(DtEnd, value))
                 {
                     Properties.Set("DTEND", value);
-                    ExtrapolateTimes();
+                    ExtrapolateTimes(0);
                 }
             }
         }
@@ -100,7 +100,7 @@ namespace Ical.Net.CalendarComponents
                 if (!Equals(Duration, value))
                 {
                     Properties.Set("DURATION", value);
-                    ExtrapolateTimes();
+                    ExtrapolateTimes(1);
                 }
             }
         }
@@ -258,20 +258,27 @@ namespace Ical.Net.CalendarComponents
         {
             base.OnDeserialized(context);
 
-            ExtrapolateTimes();
+            ExtrapolateTimes(-1);
         }
 
-        private void ExtrapolateTimes()
+        private void ExtrapolateTimes(int source)
         {
-            if (DtEnd == null && DtStart != null && Duration != default(TimeSpan))
+            /*
+			 * Source values, a fix introduced to prevent stack overflow exceptions from occuring.
+			 *   -1 = Anybody, stack overflow could maybe still occur in this case?
+			 *    0 = End
+			 *	  1 = Duration
+			 *	  2 = DtStart
+			 */
+            if (DtEnd == null && DtStart != null && Duration != default(TimeSpan) && source != 0)
             {
                 DtEnd = DtStart.Add(Duration);
             }
-            else if (Duration == default(TimeSpan) && DtStart != null && DtEnd != null)
+            else if (Duration == default(TimeSpan) && DtStart != null && DtEnd != null && source != 1)
             {
                 Duration = DtEnd.Subtract(DtStart);
             }
-            else if (DtStart == null && Duration != default(TimeSpan) && DtEnd != null)
+            else if (DtStart == null && Duration != default(TimeSpan) && DtEnd != null && source != 2)
             {
                 DtStart = DtEnd.Subtract(Duration);
             }

--- a/net-core/Ical.Net/CalendarComponents/Todo.cs
+++ b/net-core/Ical.Net/CalendarComponents/Todo.cs
@@ -34,7 +34,7 @@ namespace Ical.Net.CalendarComponents
             set
             {
                 base.DtStart = value;
-                ExtrapolateTimes();
+                ExtrapolateTimes(2);
             }
         }
 
@@ -47,7 +47,7 @@ namespace Ical.Net.CalendarComponents
             set
             {
                 Properties.Set("DUE", value);
-                ExtrapolateTimes();
+                ExtrapolateTimes(0);
             }
         }
 
@@ -70,7 +70,7 @@ namespace Ical.Net.CalendarComponents
             set
             {
                 Properties.Set("DURATION", value);
-                ExtrapolateTimes();
+                ExtrapolateTimes(1);
             }
         }
 
@@ -186,17 +186,23 @@ namespace Ical.Net.CalendarComponents
             base.OnDeserializing(context);
         }
 
-        private void ExtrapolateTimes()
+        private void ExtrapolateTimes(int source)
         {
-            if (Due == null && DtStart != null && Duration != default(TimeSpan))
+            /*
+			 * Source values, a fix introduced to prevent StackOverflow exceptions from occuring.
+			 *    0 = Due
+			 *	  1 = Duration
+			 *	  2 = DtStart
+			 */
+            if (Due == null && DtStart != null && Duration != default(TimeSpan) && source != 0)
             {
                 Due = DtStart.Add(Duration);
             }
-            else if (Duration == default(TimeSpan) && DtStart != null && Due != null)
+            else if (Duration == default(TimeSpan) && DtStart != null && Due != null && source != 1)
             {
                 Duration = Due.Subtract(DtStart);
             }
-            else if (DtStart == null && Duration != default(TimeSpan) && Due != null)
+            else if (DtStart == null && Duration != default(TimeSpan) && Due != null && source != 2)
             {
                 DtStart = Due.Subtract(Duration);
             }

--- a/v2/ical.NET/Components/Event.cs
+++ b/v2/ical.NET/Components/Event.cs
@@ -45,7 +45,7 @@ namespace Ical.Net
             set
             {
                 base.DtStart = value;
-                ExtrapolateTimes();
+                ExtrapolateTimes(2);
             }
         }
 
@@ -68,7 +68,7 @@ namespace Ical.Net
                 if (!Equals(DtEnd, value))
                 {
                     Properties.Set("DTEND", value);
-                    ExtrapolateTimes();
+                    ExtrapolateTimes(0);
                 }
             }
         }
@@ -102,7 +102,7 @@ namespace Ical.Net
                 if (!Equals(Duration, value))
                 {
                     Properties.Set("DURATION", value);
-                    ExtrapolateTimes();
+                    ExtrapolateTimes(1);
                 }
             }
         }
@@ -263,20 +263,27 @@ namespace Ical.Net
         {
             base.OnDeserialized(context);
 
-            ExtrapolateTimes();
+            ExtrapolateTimes(-1);
         }
 
-        private void ExtrapolateTimes()
+        private void ExtrapolateTimes(int source)
         {
-            if (DtEnd == null && DtStart != null && Duration != default(TimeSpan))
+            /*
+			 * Source values, a fix introduced to prevent stack overflow exceptions from occuring.
+			 *   -1 = Anybody, stack overflow could maybe still occur in this case?
+			 *    0 = End
+			 *	  1 = Duration
+			 *	  2 = DtStart
+			 */
+            if (DtEnd == null && DtStart != null && Duration != default(TimeSpan) && source != 0)
             {
                 DtEnd = DtStart.Add(Duration);
             }
-            else if (Duration == default(TimeSpan) && DtStart != null && DtEnd != null)
+            else if (Duration == default(TimeSpan) && DtStart != null && DtEnd != null && source != 1)
             {
                 Duration = DtEnd.Subtract(DtStart);
             }
-            else if (DtStart == null && Duration != default(TimeSpan) && DtEnd != null)
+            else if (DtStart == null && Duration != default(TimeSpan) && DtEnd != null && source != 2)
             {
                 DtStart = DtEnd.Subtract(Duration);
             }

--- a/v2/ical.NET/Components/Todo.cs
+++ b/v2/ical.NET/Components/Todo.cs
@@ -36,7 +36,7 @@ namespace Ical.Net
             set
             {
                 base.DtStart = value;
-                ExtrapolateTimes();
+                ExtrapolateTimes(2);
             }
         }
 
@@ -49,7 +49,7 @@ namespace Ical.Net
             set
             {
                 Properties.Set("DUE", value);
-                ExtrapolateTimes();
+                ExtrapolateTimes(0);
             }
         }
 
@@ -72,7 +72,7 @@ namespace Ical.Net
             set
             {
                 Properties.Set("DURATION", value);
-                ExtrapolateTimes();
+                ExtrapolateTimes(1);
             }
         }
 
@@ -198,17 +198,23 @@ namespace Ical.Net
             base.OnDeserializing(context);
         }
 
-        private void ExtrapolateTimes()
+        private void ExtrapolateTimes(int source)
         {
-            if (Due == null && DtStart != null && Duration != default(TimeSpan))
+            /*
+			 * Source values, a fix introduced to prevent StackOverflow exceptions from occuring.
+			 *    0 = Due
+			 *	  1 = Duration
+			 *	  2 = DtStart
+			 */
+            if (Due == null && DtStart != null && Duration != default(TimeSpan) && source != 0)
             {
                 Due = DtStart.Add(Duration);
             }
-            else if (Duration == default(TimeSpan) && DtStart != null && Due != null)
+            else if (Duration == default(TimeSpan) && DtStart != null && Due != null && source != 1)
             {
                 Duration = Due.Subtract(DtStart);
             }
-            else if (DtStart == null && Duration != default(TimeSpan) && Due != null)
+            else if (DtStart == null && Duration != default(TimeSpan) && Due != null && source != 2)
             {
                 DtStart = Due.Subtract(Duration);
             }


### PR DESCRIPTION
These changes here came from our copy of ical.net. Figured it would be good to push these potentially back. We were seeing some production systems getting stack overflows caused by some fields not being provided when creating a calendar event then setting a value. After setting this value ExtrapolateTimes would then start looping when attempting to set other DtStart, Duration, DtEnd values.

p.s This is my first pull request, familiar with using open source projects but this is my first time going upstream. If there are any changes or suggestions let me know.