### PR TITLE
Bugfix: UNTIL now works correctly for positive TZ offset

### DIFF
--- a/v2/ical.NET/Evaluation/RecurrencePatternEvaluator.cs
+++ b/v2/ical.NET/Evaluation/RecurrencePatternEvaluator.cs
@@ -299,7 +299,7 @@ namespace Ical.Net.Evaluation
                         {
                             break;
                         }
-                        else if (pattern.Until == DateTime.MinValue || candidate <= pattern.Until)
+                        else
                         {
                             var utcCandidate = DateUtil.FromTimeZoneToTimeZone(candidate, DateUtil.GetZone(seed.TzId), DateTimeZone.Utc).ToDateTimeUtc();
                             if (!dates.Contains(candidate) && (pattern.Until == DateTime.MinValue || utcCandidate <= pattern.Until))


### PR DESCRIPTION
In our application, using the RecurrencePatternEvaluator, we noticed a bug which boils down to what was reported in https://github.com/rianjs/ical.net/issues/406 .

This is our simple fix to this bug, all unit tests remain functional.

We did not work on the .Net Core implementation, which seems quite different. Is this by design?