### PR TITLE
A few updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+## OS-specific files
+.DS_Store
+
 ## Benchmark.net files
 *.html
 *.csv

--- a/net-core/Ical.Net.CoreUnitTests/Ical.Net.CoreUnitTests.csproj
+++ b/net-core/Ical.Net.CoreUnitTests/Ical.Net.CoreUnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net50</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\IcalNetStrongnameKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/net-core/Ical.Net/Ical.Net.csproj
+++ b/net-core/Ical.Net/Ical.Net.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
-    <Version>5.0.0</Version>
-    <Authors>Rian Stockbower, Douglas Day &amp; Contributors</Authors>
+    <TargetFrameworks>netstandard2.0;net50</TargetFrameworks>
+    <Version>4.2.0</Version>
+    <Authors>Rian Stockbower, Douglas Day, &amp; Contributors</Authors>
     <Company />
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\IcalNetStrongnameKey.snk</AssemblyOriginatorKeyFile>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <PackageId>Fusonic.Ical.Net</PackageId>
+    <PackageId>Ical.Net</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseFile>license.md</PackageLicenseFile>
-    <Description>An iCalendar (RFC 5545) control library. See https://github.com/rianjs/ical.net for details.</Description>
+    <Description>An iCalendar (RFC 5545) library. See https://github.com/rianjs/ical.net for details.</Description>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>bin\Release\Ical.Net.xml</DocumentationFile>

--- a/net-core/PerfTests/PerfTests.csproj
+++ b/net-core/PerfTests/PerfTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net50</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
net472 implements netstandard20, so we shouldn't need to explicitly target it
Unify build targets across csproj files
Update nuget package version