### PR TITLE
Increased the precision for geographic location

### DIFF
--- a/src/Ical.Net/DataTypes/GeographicLocation.cs
+++ b/src/Ical.Net/DataTypes/GeographicLocation.cs
@@ -30,7 +30,7 @@ namespace Ical.Net.DataTypes
 
         public override void CopyFrom(ICopyable obj) {}
 
-        public override string ToString() => Latitude.ToString("0.000000") + ";" + Longitude.ToString("0.000000");
+        public override string ToString() => Latitude.ToString("0.000000######") + ";" + Longitude.ToString("0.000000######");
 
         protected bool Equals(GeographicLocation other) => Latitude.Equals(other.Latitude) && Longitude.Equals(other.Longitude);
 

--- a/src/Ical.Net/Serialization/DataTypes/GeographicLocationSerializer.cs
+++ b/src/Ical.Net/Serialization/DataTypes/GeographicLocationSerializer.cs
@@ -21,8 +21,8 @@ namespace Ical.Net.Serialization.DataTypes
                 return null;
             }
 
-            var value = g.Latitude.ToString("0.000000", CultureInfo.InvariantCulture.NumberFormat) + ";"
-                + g.Longitude.ToString("0.000000", CultureInfo.InvariantCulture.NumberFormat);
+            var value = g.Latitude.ToString("0.000000######", CultureInfo.InvariantCulture.NumberFormat) + ";"
+                + g.Longitude.ToString("0.000000######", CultureInfo.InvariantCulture.NumberFormat);
             return Encode(g, value);
         }
 


### PR DESCRIPTION
… to store up to 12 decimals places

As per https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.1.6, we interpret this to allow for greater precision.  The previous serialization was rounding up instead of truncating.
[ref: SML-3994]