### PR TITLE
Use specified culture/format provider when provided to CalDateTime.ToString

### DIFF
--- a/Ical.Net.Tests/AlarmTest.cs
+++ b/Ical.Net.Tests/AlarmTest.cs
@@ -1,4 +1,4 @@
-using Ical.Net.DataTypes;
+﻿using Ical.Net.DataTypes;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;

--- a/Ical.Net.Tests/CalDateTimeTests.cs
+++ b/Ical.Net.Tests/CalDateTimeTests.cs
@@ -174,6 +174,14 @@ namespace Ical.Net.Tests
             yield return new TestCaseData(new DateTime(2022, 8, 30), "o", null)
                 .Returns("2022-08-30T00:00:00.0000000+12:00 Pacific/Auckland")
                 .SetName("Date and time formatted using format string with no culture returns string using BCL formatter");
+
+            yield return new TestCaseData(new DateTime(2022, 8, 30, 10, 30, 0), null, CultureInfo.InvariantCulture)
+                .Returns("08/30/2022 10:30:00 Pacific/Auckland")
+                .SetName("Date and time with format provider");
+
+            yield return new TestCaseData(new DateTime(2022, 8, 30), null, CultureInfo.InvariantCulture)
+                .Returns("08/30/2022 Pacific/Auckland")
+                .SetName("Date only with current format provider");
         }
     }
 }

--- a/Ical.Net.Tests/CalDateTimeTests.cs
+++ b/Ical.Net.Tests/CalDateTimeTests.cs
@@ -1,4 +1,6 @@
-﻿using Ical.Net.CalendarComponents;
+using System.Collections.Generic;
+using System.Globalization;
+using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
 using NUnit.Framework;
 using System;
@@ -149,6 +151,29 @@ namespace Ical.Net.Tests
             yield return new TestCaseData(DateTime.SpecifyKind(localDt, DateTimeKind.Unspecified), null)
                 .Returns(DateTimeKind.Unspecified)
                 .SetName("DateTime with Kind = Unspecified and null tzid returns DateTimeKind.Unspecified");
+        }
+
+        [Test, TestCaseSource(nameof(ToStringTestCases))]
+        public string ToStringTests(DateTime localDateTime, string format, IFormatProvider formatProvider)
+            => new CalDateTime(localDateTime, "Pacific/Auckland").ToString(format, formatProvider);
+
+        public static IEnumerable<ITestCaseData> ToStringTestCases()
+        {
+            yield return new TestCaseData(new DateTime(2022, 8, 30, 10, 30, 0), null, null)
+                .Returns($"{new DateTime(2022, 8, 30, 10, 30, 0)} Pacific/Auckland")
+                .SetName("Date and time with current culture formatting returns string using BCL current culture formatted date and time");
+
+            yield return new TestCaseData(new DateTime(2022, 8, 30), null, null)
+                .Returns($"{new DateTime(2022, 8, 30):d} Pacific/Auckland")
+                .SetName("Date only with current culture formatting returns string using BCL current culture formatted date");
+
+            yield return new TestCaseData(new DateTime(2022, 8, 30, 10, 30, 0), "o", null)
+                .Returns("2022-08-30T10:30:00.0000000+12:00 Pacific/Auckland")
+                .SetName("Date and time formatted using format string with no culture returns string using BCL formatter");
+
+            yield return new TestCaseData(new DateTime(2022, 8, 30), "o", null)
+                .Returns("2022-08-30T00:00:00.0000000+12:00 Pacific/Auckland")
+                .SetName("Date and time formatted using format string with no culture returns string using BCL formatter");
         }
     }
 }

--- a/Ical.Net.Tests/DeserializationTests.cs
+++ b/Ical.Net.Tests/DeserializationTests.cs
@@ -448,22 +448,13 @@ END:VCALENDAR
             Assert.That(evt.Transparency, Is.EqualTo(TransparencyType.Transparent));
         }
 
-        /// <summary>
-        /// Tests that DateTime values that are out-of-range are still parsed correctly
-        /// and set to the closest representable date/time in .NET.
-        /// </summary>
         [Test]
-        public void DateTime1()
+        public void DateTime1_Unrepresentable_DateTimeArgs_ShouldThrow()
         {
-            var iCal = Calendar.Load(IcsFiles.DateTime1);
-            Assert.That(iCal.Events, Has.Count.EqualTo(6));
-
-            var evt = iCal.Events["nc2o66s0u36iesitl2l0b8inn8@google.com"];
-            Assert.That(evt, Is.Not.Null);
-
-            // The "Created" date is out-of-bounds.  It should be coerced to the
-            // closest representable date/time.
-            Assert.That(evt.Created.Value, Is.EqualTo(DateTime.MinValue));
+            Assert.That(() =>
+            {
+                _ = Calendar.Load(IcsFiles.DateTime1);
+            }, Throws.Exception.TypeOf<ArgumentOutOfRangeException>());
         }
 
         [Test]

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -2828,7 +2828,7 @@ Has.Count.EqualTo(dateTimes.Length),
         [TestCase("SECONDLY", 1, true)]
         [TestCase("MINUTELY", 60, true)]
         [TestCase("HOURLY", 3600, true)]
-        [TestCase("DAILY", 24*3600, false)]
+        [TestCase("DAILY", 24*3600, true)]
         public void Evaluate1(string freq, int secsPerInterval, bool hasTime)
         {
             Calendar cal = new Calendar();
@@ -2837,7 +2837,7 @@ Has.Count.EqualTo(dateTimes.Length),
             evt.Summary = "Event summary";
 
             // Start at midnight, UTC time
-            evt.Start = new CalDateTime(DateTime.SpecifyKind(DateTime.Today, DateTimeKind.Utc)) { HasTime = false };
+            evt.Start = new CalDateTime(DateTime.SpecifyKind(DateTime.Today, DateTimeKind.Utc)); // { HasTime = false };
 
             // This case (DTSTART of type DATE and FREQ=MINUTELY) is undefined in RFC 5545.
             // ical.net handles the case by pretending DTSTART has the time set to midnight.

--- a/Ical.Net.Tests/SimpleDeserializationTests.cs
+++ b/Ical.Net.Tests/SimpleDeserializationTests.cs
@@ -451,22 +451,15 @@ END:VCALENDAR
             Assert.That(evt.Transparency, Is.EqualTo(TransparencyType.Transparent));
         }
 
-        /// <summary>
-        /// Tests that DateTime values that are out-of-range are still parsed correctly
-        /// and set to the closest representable date/time in .NET.
-        /// </summary>
         [Test, Category("Deserialization")]
-        public void DateTime1()
+        public void DateTime1_Unrepresentable_DateTimeArgs_ShouldThrow()
         {
-            var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.DateTime1)).Cast<Calendar>().Single();
-            Assert.That(iCal.Events, Has.Count.EqualTo(6));
-
-            var evt = iCal.Events["nc2o66s0u36iesitl2l0b8inn8@google.com"];
-            Assert.That(evt, Is.Not.Null);
-
-            // The "Created" date is out-of-bounds.  It should be coerced to the
-            // closest representable date/time.
-            Assert.That(evt.Created.Value, Is.EqualTo(DateTime.MinValue));
+            Assert.That(() =>
+            {
+                _ = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.DateTime1))
+                    .Cast<Calendar>()
+                    .Single();
+            }, Throws.Exception.TypeOf<ArgumentOutOfRangeException>());
         }
 
         [Test, Category("Deserialization"), Ignore("Ignore until @thoemy commits the EventStatus.ics file")]

--- a/Ical.Net/CalendarComponents/CalendarEvent.cs
+++ b/Ical.Net/CalendarComponents/CalendarEvent.cs
@@ -126,11 +126,37 @@ namespace Ical.Net.CalendarComponents
                 // has a time value.
                 if (Start != null)
                 {
-                    Start.HasTime = !value;
+                    if (value)
+                    {
+                        // Ensure time part is not set
+                        var dt = new CalDateTime(Start);
+                        dt.SetValue(DateOnly.FromDateTime(Start.Value), null, Start.Value.Kind);
+                        Start = dt;
+                    }
+                    else
+                    {
+                        // Ensure time part is set
+                        var dt = new CalDateTime(Start);
+                        dt.SetValue(DateOnly.FromDateTime(Start.Value), TimeOnly.FromDateTime(Start.Value), Start.Value.Kind);
+                        Start = dt;
+                    }
                 }
                 if (End != null)
                 {
-                    End.HasTime = !value;
+                    if (value)
+                    {
+                        // Ensure time part is not set
+                        var dt = new CalDateTime(End);
+                        dt.SetValue(DateOnly.FromDateTime(End.Value), null, End.Value.Kind);
+                        End = dt;
+                    }
+                    else
+                    {
+                        // Ensure time part is set
+                        var dt = new CalDateTime(End);
+                        dt.SetValue(DateOnly.FromDateTime(End.Value), TimeOnly.FromDateTime(End.Value), End.Value.Kind);
+                        End = dt;
+                    }
                 }
 
                 if (value && Start != null && End != null && Equals(Start.Date, End.Date))

--- a/Ical.Net/CalendarComponents/VTimeZone.cs
+++ b/Ical.Net/CalendarComponents/VTimeZone.cs
@@ -1,4 +1,4 @@
-using Ical.Net.DataTypes;
+﻿using Ical.Net.DataTypes;
 using Ical.Net.Proxies;
 using Ical.Net.Utility;
 using NodaTime;
@@ -177,7 +177,7 @@ namespace Ical.Net.CalendarComponents
             timeZoneInfo.TimeZoneName = oldestInterval.Name;
 
             var start = oldestInterval.IsoLocalStart.ToDateTimeUnspecified() + delta;
-            timeZoneInfo.Start = new CalDateTime(start) { HasTime = true };
+            timeZoneInfo.Start = new CalDateTime(start);
 
             if (isRRule)
             {
@@ -244,7 +244,6 @@ namespace Ical.Net.CalendarComponents
                     continue;
                 }
 
-                date.HasTime = true;
                 periodList.Add(date);
                 tzi.RecurrenceDates.Add(periodList);
             }

--- a/Ical.Net/DataTypes/CalDateTime.cs
+++ b/Ical.Net/DataTypes/CalDateTime.cs
@@ -538,13 +538,13 @@ namespace Ical.Net.DataTypes
             }
             if (HasTime && HasDate)
             {
-                return Value + tz;
+                return Value.ToString(formatProvider) + tz;
             }
             if (HasTime)
             {
                 return Value.TimeOfDay + tz;
             }
-            return Value.ToString("d") + tz;
+            return Value.ToString("d", formatProvider) + tz;
         }
     }
 }

--- a/Ical.Net/DataTypes/CalDateTime.cs
+++ b/Ical.Net/DataTypes/CalDateTime.cs
@@ -2,6 +2,7 @@
 using Ical.Net.Utility;
 using NodaTime;
 using System;
+using System.Globalization;
 using System.IO;
 
 namespace Ical.Net.DataTypes
@@ -10,7 +11,7 @@ namespace Ical.Net.DataTypes
     /// The iCalendar equivalent of the .NET <see cref="DateTime"/> class.
     /// <remarks>
     /// In addition to the features of the <see cref="DateTime"/> class, the <see cref="CalDateTime"/>
-    /// class handles time zone differences, and integrates seamlessly into the iCalendar framework.
+    /// class handles time zones, and integrates seamlessly into the iCalendar framework.
     /// </remarks>
     /// </summary>
     public sealed class CalDateTime : EncodableDataType, IDateTime
@@ -19,17 +20,26 @@ namespace Ical.Net.DataTypes
 
         public static CalDateTime Today => new CalDateTime(DateTime.Today);
 
-        private bool _hasDate;
-        private bool _hasTime;
+        public static CalDateTime UtcNow => new CalDateTime(DateTime.UtcNow);
 
+        private DateOnly? _dateOnly;
+        private TimeOnly? _timeOnly;
+
+        /// <summary>
+        /// This constructor is required for the SerializerFactory to work.
+        /// </summary>
         public CalDateTime() { }
 
         public CalDateTime(IDateTime value)
         {
-            Initialize(value.Value, value.TzId, null);
+            if (value.HasTime)
+                Initialize(new DateOnly(value.Year, value.Month, value.Day), new TimeOnly(value.Hour, value.Minute, value.Second), value.Date.Kind, value.TzId, null);
+            else
+                Initialize(new DateOnly(value.Year, value.Month, value.Day), null, value.Date.Kind, value.TzId, null);
         }
 
-        public CalDateTime(DateTime value) : this(value, null) { }
+        public CalDateTime(DateTime value) : this(value, value.Kind == DateTimeKind.Utc ? "UTC" : null)
+        { }
 
         /// <summary>
         /// Specifying a `tzId` value will override `value`'s `DateTimeKind` property. If the time zone specified is UTC, the underlying `DateTimeKind` will be
@@ -38,29 +48,38 @@ namespace Ical.Net.DataTypes
         /// </summary>
         public CalDateTime(DateTime value, string tzId)
         {
-            Initialize(value, tzId, null);
+            Initialize(new DateOnly(value.Year, value.Month, value.Day), new TimeOnly(value.Hour, value.Minute, value.Second), value.Date.Kind, tzId, null);
         }
 
         public CalDateTime(int year, int month, int day, int hour, int minute, int second)
         {
-            Initialize(year, month, day, hour, minute, second, null, null);
-            HasTime = true;
+            Initialize(new DateOnly(year, month, day), new TimeOnly(hour, minute, second), DateTimeKind.Unspecified, null, null);
         }
 
         public CalDateTime(int year, int month, int day, int hour, int minute, int second, string tzId)
         {
-            Initialize(year, month, day, hour, minute, second, tzId, null);
-            HasTime = true;
+            Initialize(new DateOnly(year, month, day), new TimeOnly(hour, minute, second), DateTimeKind.Unspecified, tzId, null);
         }
 
         public CalDateTime(int year, int month, int day, int hour, int minute, int second, string tzId, Calendar cal)
         {
-            Initialize(year, month, day, hour, minute, second, tzId, cal);
-            HasTime = true;
+            Initialize(new DateOnly(year, month, day), new TimeOnly(hour, minute, second), DateTimeKind.Unspecified, tzId, cal);
         }
 
-        public CalDateTime(int year, int month, int day) : this(year, month, day, 0, 0, 0) { }
-        public CalDateTime(int year, int month, int day, string tzId) : this(year, month, day, 0, 0, 0, tzId) { }
+        public CalDateTime(int year, int month, int day)
+        {
+            Initialize(new DateOnly(year, month, day), null, DateTimeKind.Unspecified, null, null);
+        }
+
+        public CalDateTime(int year, int month, int day, string tzId)
+        {
+            Initialize(new DateOnly(year, month, day), null, DateTimeKind.Unspecified, tzId, null);
+        }
+
+        public CalDateTime(DateOnly date, TimeOnly time, string tzId = null)
+        {
+            Initialize(date, time, DateTimeKind.Unspecified, tzId, null);
+        }
 
         public CalDateTime(string value)
         {
@@ -68,55 +87,58 @@ namespace Ical.Net.DataTypes
             CopyFrom(serializer.Deserialize(new StringReader(value)) as ICopyable);
         }
 
-        private void Initialize(int year, int month, int day, int hour, int minute, int second, string tzId, Calendar cal)
+        /// <summary>
+        /// Sets the date/time for <see cref="Value"/> so that it
+        /// can be used as a date-only or a date-time value.
+        /// </summary>
+        /// <param name="date"></param>
+        /// <param name="time"></param>
+        /// <param name="kind"></param>
+        public void SetValue(DateOnly date, TimeOnly? time, DateTimeKind kind)
         {
-            Initialize(CoerceDateTime(year, month, day, hour, minute, second, DateTimeKind.Local), tzId, cal);
+            _value = time.HasValue
+                ? new DateTime(date.Year, date.Month, date.Day, time.Value.Hour, time.Value.Minute, time.Value.Second, kind)
+                : new DateTime(date.Year, date.Month, date.Day, 0, 0, 0, kind);
+
+            _dateOnly = date;
+            _timeOnly = time;
         }
 
-        private void Initialize(DateTime value, string tzId, Calendar cal)
+        private void Initialize(DateOnly date, TimeOnly? time, DateTimeKind kind, string tzId, Calendar cal)
         {
-            if (!string.IsNullOrWhiteSpace(tzId) && !tzId.Equals("UTC", StringComparison.OrdinalIgnoreCase))
+            _dateOnly = date;
+            _timeOnly = time;
+
+            if ((!string.IsNullOrWhiteSpace(tzId) && !tzId.Equals("UTC", StringComparison.OrdinalIgnoreCase))
+                || (string.IsNullOrEmpty(tzId) && kind == DateTimeKind.Local))
             {
                 // Definitely local
-                value = DateTime.SpecifyKind(value, DateTimeKind.Local);
                 TzId = tzId;
+
+                _value = time.HasValue
+                    ? new DateTime(date.Year, date.Month, date.Day, time.Value.Hour, time.Value.Minute, time.Value.Second, DateTimeKind.Local)
+                    : new DateTime(date.Year, date.Month, date.Day, 0, 0, 0, DateTimeKind.Local);
             }
-            else if (string.Equals("UTC", tzId, StringComparison.OrdinalIgnoreCase) || value.Kind == DateTimeKind.Utc)
+            else if (string.Equals("UTC", tzId, StringComparison.OrdinalIgnoreCase) || kind == DateTimeKind.Utc)
             {
-                // Probably UTC
-                value = DateTime.SpecifyKind(value, DateTimeKind.Utc);
+                // It is UTC
                 TzId = "UTC";
+
+                _value = time.HasValue
+                    ? new DateTime(date.Year, date.Month, date.Day, time.Value.Hour, time.Value.Minute, time.Value.Second, DateTimeKind.Utc)
+                    : new DateTime(date.Year, date.Month, date.Day, 0, 0, 0, DateTimeKind.Utc);
             }
-
-            Value = new DateTime(value.Year, value.Month, value.Day, value.Hour, value.Minute, value.Second, value.Kind);
-            HasDate = true;
-            HasTime = value.Second != 0 || value.Minute != 0 || value.Hour != 0;
-            AssociatedObject = cal;
-        }
-
-        private DateTime CoerceDateTime(int year, int month, int day, int hour, int minute, int second, DateTimeKind kind)
-        {
-            var dt = DateTime.MinValue;
-
-            // NOTE: determine if a date/time value exceeds the representable date/time values in .NET.
-            // If so, let's automatically adjust the date/time to compensate.
-            // FIXME: should we have a parsing setting that will throw an exception
-            // instead of automatically adjusting the date/time value to the
-            // closest representable date/time?
-            try
+            else
             {
-                if (year > 9999)
-                {
-                    dt = DateTime.MaxValue;
-                }
-                else if (year > 0)
-                {
-                    dt = new DateTime(year, month, day, hour, minute, second, kind);
-                }
-            }
-            catch { }
+                // Unspecified
+                TzId = string.Empty;
 
-            return dt;
+                _value = time.HasValue
+                    ? new DateTime(date.Year, date.Month, date.Day, time.Value.Hour, time.Value.Minute, time.Value.Second, DateTimeKind.Unspecified)
+                    : new DateTime(date.Year, date.Month, date.Day, 0, 0, 0, DateTimeKind.Unspecified);
+            }
+
+            AssociatedObject = cal;
         }
 
         public override ICalendarObject AssociatedObject
@@ -136,16 +158,20 @@ namespace Ical.Net.DataTypes
         {
             base.CopyFrom(obj);
 
-            var dt = obj as IDateTime;
-            if (dt == null)
+            if (obj is not IDateTime dt)
             {
                 return;
             }
 
+            if (dt is CalDateTime calDt)
+            {
+                // Maintain the private date/time only flags form the original object
+                _dateOnly = calDt._dateOnly;
+                _timeOnly = calDt._timeOnly;
+            }
+
+            // Copy the underlying DateTime value and time zone ID
             _value = dt.Value;
-            _hasDate = dt.HasDate;
-            _hasTime = dt.HasTime;
-            // String assignments create new instances
             TzId = dt.TzId;
 
             AssociateWith(dt);
@@ -154,7 +180,7 @@ namespace Ical.Net.DataTypes
         public bool Equals(CalDateTime other)
             => this == other;
 
-        public override bool Equals(object other)
+        public override bool Equals(object? other)
             => other is IDateTime && (CalDateTime)other == this;
 
         public override int GetHashCode()
@@ -238,7 +264,6 @@ namespace Ical.Net.DataTypes
             }
         }
 
-        private DateTime _asUtc = DateTime.MinValue;
         /// <summary>
         /// Returns a representation of the DateTime in Coordinated Universal Time (UTC)
         /// </summary>
@@ -246,67 +271,106 @@ namespace Ical.Net.DataTypes
         {
             get
             {
-                if (_asUtc == DateTime.MinValue)
-                {
-                    // In order of weighting:
-                    //  1) Specified TzId
-                    //  2) Value having a DateTimeKind.Utc
-                    //  3) Use the OS's time zone
+                // In order of weighting:
+                //  1) Specified TzId
+                //  2) Value having a DateTimeKind.Utc
+                //  3) Use the OS's time zone
+                DateTime asUtc;
 
-                    if (!string.IsNullOrWhiteSpace(TzId))
-                    {
-                        var asLocal = DateUtil.ToZonedDateTimeLeniently(Value, TzId);
-                        _asUtc = asLocal.ToDateTimeUtc();
-                    }
-                    else if (IsUtc || Value.Kind == DateTimeKind.Utc)
-                    {
-                        _asUtc = DateTime.SpecifyKind(Value, DateTimeKind.Utc);
-                    }
-                    else
-                    {
-                        _asUtc = DateTime.SpecifyKind(Value, DateTimeKind.Local).ToUniversalTime();
-                    }
+                if (!string.IsNullOrWhiteSpace(TzId))
+                {
+                    var asLocal = DateUtil.ToZonedDateTimeLeniently(Value, TzId);
+                    return asLocal.ToDateTimeUtc();
                 }
-                return _asUtc;
+
+                if (IsUtc || Value.Kind == DateTimeKind.Utc)
+                {
+                    asUtc = DateTime.SpecifyKind(Value, DateTimeKind.Utc);
+                    return asUtc;
+                }
+
+                asUtc = DateTime.SpecifyKind(Value, DateTimeKind.Local).ToUniversalTime();
+                return asUtc;
             }
         }
 
         private DateTime _value;
+
+        /// <summary>
+        /// Gets/sets the underlying DateTime value stored.
+        /// Use <see cref="SetValue"/> instead.
+        /// </summary>
         public DateTime Value
         {
             get => _value;
+
+            [Obsolete("This setter is depreciated and will be removed in a future version. Use SetValue instead.", false)]
             set
             {
+                // Kind must be checked in addition to the value,
+                // as the value can be the same but the Kind different.
                 if (_value == value && _value.Kind == value.Kind)
                 {
                     return;
                 }
 
-                _asUtc = DateTime.MinValue;
+                // Maintain the initial date/time only flags
+                // if the date/time parts are unchanged.
+                // This is a temporary workaround.
+
+                if (value.Date != _value.Date)
+                    _dateOnly = DateOnly.FromDateTime(value);
+
+                if (value.TimeOfDay != _value.TimeOfDay)
+                    _timeOnly = TimeOnly.FromDateTime(value);
+
                 _value = value;
             }
         }
 
+        /// <summary>
+        /// Returns true if the underlying DateTime value is in UTC.
+        /// </summary>
         public bool IsUtc => _value.Kind == DateTimeKind.Utc;
 
+        /// <summary>
+        /// Returns true if the underlying DateTime has a 'date' part (year, month, day),
+        /// otherwise the DateTime is considered a 'time' only.
+        /// </summary>
         public bool HasDate
         {
-            get => _hasDate;
-            set => _hasDate = value;
+            get => _dateOnly.HasValue;
+            [Obsolete("This setter is depreciated and will be removed in a future version. Use SetValue instead.", false)]
+            set
+            {
+                if (value && !_dateOnly.HasValue) _dateOnly = new DateOnly(Value.Year, Value.Month, Value.Day);
+                if (!value) _dateOnly = null;
+            }
         }
 
+        /// <summary>
+        /// Returns true if the underlying DateTime has a 'time' part (hour, minute, second),
+        /// otherwise the DateTime is considered a 'date' only.
+        /// </summary>
         public bool HasTime
         {
-            get => _hasTime;
-            set => _hasTime = value;
+            get => _timeOnly.HasValue;
+            [Obsolete("This setter is depreciated and will be removed in a future version. Use SetValue instead.", false)]
+            set
+            {
+                if (value && !_timeOnly.HasValue) _timeOnly = new TimeOnly(Value.Hour, Value.Minute, Value.Hour);
+                if (!value) _timeOnly = null;
+            }
         }
 
         private string _tzId = string.Empty;
 
         /// <summary>
-        /// Setting the TzId to a local time zone will set Value.Kind to Local. Setting TzId to UTC will set Value.Kind to Utc. If the incoming value is null
-        /// or whitespace, Value.Kind will be set to Unspecified. Setting the TzId will NOT incur a UTC offset conversion under any circumstances. To convert
-        /// to another time zone, use the ToTimeZone() method.
+        /// Setting the <see cref="TzId"/> to a local time zone will set <see cref="Value"/> to <see cref="DateTimeKind.Local"/>.
+        /// Setting <see cref="TzId"/> to UTC will set <see cref="Value"/> to <see cref="DateTimeKind.Utc"/>.
+        /// If the value is set to <see langword="null"/>  or whitespace, <see cref="Value"/> will be <see cref="DateTimeKind.Unspecified"/>.
+        /// Setting the TzId will NOT incur a UTC offset conversion.
+        /// To convert to another time zone, use <see cref="ToTimeZone"/>.
         /// </summary>
         public string TzId
         {
@@ -325,14 +389,12 @@ namespace Ical.Net.DataTypes
                     return;
                 }
 
-                _asUtc = DateTime.MinValue;
-
                 var isEmpty = string.IsNullOrWhiteSpace(value);
                 if (isEmpty)
                 {
                     Parameters.Remove("TZID");
                     _tzId = null;
-                    Value = DateTime.SpecifyKind(Value, DateTimeKind.Local);
+                    _value = DateTime.SpecifyKind(_value, DateTimeKind.Local);
                     return;
                 }
 
@@ -340,7 +402,7 @@ namespace Ical.Net.DataTypes
                     ? DateTimeKind.Utc
                     : DateTimeKind.Local;
 
-                Value = DateTime.SpecifyKind(Value, kind);
+                _value = DateTime.SpecifyKind(_value, kind);
                 Parameters.Set("TZID", value);
                 _tzId = value;
             }
@@ -373,15 +435,10 @@ namespace Ical.Net.DataTypes
         public TimeSpan TimeOfDay => Value.TimeOfDay;
 
         /// <summary>
-        /// Returns a representation of the IDateTime in the specified time zone
+        /// Returns a representation of the <see cref="IDateTime"/> in the <paramref name="tzId"/> time zone
         /// </summary>
         public IDateTime ToTimeZone(string tzId)
         {
-            if (string.IsNullOrWhiteSpace(tzId))
-            {
-                throw new ArgumentException("You must provide a valid time zone id", nameof(tzId));
-            }
-
             // If TzId is empty, it's a system-local datetime, so we should use the system time zone as the starting point.
             var originalTzId = string.IsNullOrWhiteSpace(TzId)
                 ? TimeZoneInfo.Local.Id
@@ -396,7 +453,8 @@ namespace Ical.Net.DataTypes
         }
 
         /// <summary>
-        /// Returns a DateTimeOffset representation of the Value. If a TzId is specified, it will use that time zone's UTC offset, otherwise it will use the
+        /// Returns a <see cref="DateTimeOffset"/> representation of the <see cref="Value"/>.
+        /// If a TzId is specified, it will use that time zone's UTC offset, otherwise it will use the
         /// system-local time zone.
         /// </summary>
         public DateTimeOffset AsDateTimeOffset =>
@@ -404,12 +462,14 @@ namespace Ical.Net.DataTypes
                 ? new DateTimeOffset(AsSystemLocal)
                 : DateUtil.ToZonedDateTimeLeniently(Value, TzId).ToDateTimeOffset();
 
+        /// <inheritdoc cref="DateTime.Add"/>
         public IDateTime Add(TimeSpan ts) => this + ts;
 
         public IDateTime Subtract(TimeSpan ts) => this - ts;
 
         public TimeSpan Subtract(IDateTime dt) => this - dt;
 
+        /// <inheritdoc cref="DateTime.AddYears"/>
         public IDateTime AddYears(int years)
         {
             var dt = Copy<IDateTime>();
@@ -417,69 +477,68 @@ namespace Ical.Net.DataTypes
             return dt;
         }
 
+        /// <inheritdoc cref="DateTime.AddMonths"/>
         public IDateTime AddMonths(int months)
         {
-            var dt = Copy<IDateTime>();
-            dt.Value = Value.AddMonths(months);
+            var dt = Copy<CalDateTime>();
+            var newValue = Value.AddMonths(months);
+            dt.SetValue(DateOnly.FromDateTime(newValue), dt._timeOnly, newValue.Kind);
             return dt;
         }
 
+        /// <inheritdoc cref="DateTime.AddDays"/>
         public IDateTime AddDays(int days)
         {
-            var dt = Copy<IDateTime>();
-            dt.Value = Value.AddDays(days);
+            var dt = Copy<CalDateTime>();
+            var newValue = Value.AddDays(days);
+            dt.SetValue(DateOnly.FromDateTime(newValue), dt._timeOnly, newValue.Kind);
             return dt;
         }
 
+        /// <inheritdoc cref="DateTime.AddHours"/>
         public IDateTime AddHours(int hours)
         {
-            var dt = Copy<IDateTime>();
-            if (!dt.HasTime && hours % 24 > 0)
-            {
-                dt.HasTime = true;
-            }
-            dt.Value = Value.AddHours(hours);
+            var dt = Copy<CalDateTime>();
+            var newValue = Value.AddHours(hours);
+            dt.SetValue(DateOnly.FromDateTime(newValue), TimeOnly.FromDateTime(newValue), newValue.Kind);
             return dt;
         }
 
+        /// <inheritdoc cref="DateTime.AddMinutes"/>
         public IDateTime AddMinutes(int minutes)
         {
-            var dt = Copy<IDateTime>();
-            if (!dt.HasTime && minutes % 1440 > 0)
-            {
-                dt.HasTime = true;
-            }
-            dt.Value = Value.AddMinutes(minutes);
+            var dt = Copy<CalDateTime>();
+            var newValue = Value.AddMinutes(minutes);
+            dt.SetValue(DateOnly.FromDateTime(newValue), TimeOnly.FromDateTime(newValue), newValue.Kind);
             return dt;
         }
 
+        /// <inheritdoc cref="DateTime.AddSeconds"/>
         public IDateTime AddSeconds(int seconds)
         {
-            var dt = Copy<IDateTime>();
-            if (!dt.HasTime && seconds % 86400 > 0)
-            {
-                dt.HasTime = true;
-            }
-            dt.Value = Value.AddSeconds(seconds);
+            var dt = Copy<CalDateTime>();
+            var newValue = Value.AddSeconds(seconds);
+            dt.SetValue(DateOnly.FromDateTime(newValue), TimeOnly.FromDateTime(newValue), newValue.Kind);
             return dt;
         }
 
+        /// <inheritdoc cref="DateTime.AddMilliseconds"/>
+        /// <remarks>Milliseconds less than full seconds get truncated.</remarks>
         public IDateTime AddMilliseconds(int milliseconds)
         {
-            var dt = Copy<IDateTime>();
-            if (!dt.HasTime && milliseconds % 86400000 > 0)
-            {
-                dt.HasTime = true;
-            }
-            dt.Value = Value.AddMilliseconds(milliseconds);
+            var dt = Copy<CalDateTime>();
+            var newValue = Value.AddMilliseconds(milliseconds);
+            dt.SetValue(DateOnly.FromDateTime(newValue), TimeOnly.FromDateTime(newValue), newValue.Kind);
             return dt;
         }
 
+        /// <inheritdoc cref="DateTime.AddTicks"/>
+        /// <remarks>Ticks less than full seconds get truncated.</remarks>
         public IDateTime AddTicks(long ticks)
         {
-            var dt = Copy<IDateTime>();
-            dt.HasTime = true;
-            dt.Value = Value.AddTicks(ticks);
+            var dt = Copy<CalDateTime>();
+            var newValue = Value.AddTicks(ticks);
+            dt.SetValue(DateOnly.FromDateTime(newValue), TimeOnly.FromDateTime(newValue), newValue.Kind);
             return dt;
         }
 
@@ -526,25 +585,22 @@ namespace Ical.Net.DataTypes
 
         public string ToString(string format, IFormatProvider formatProvider)
         {
-            var tz = TimeZoneName;
-            if (!string.IsNullOrEmpty(tz))
+            formatProvider ??= CultureInfo.InvariantCulture;
+            var dateTimeOffset = AsDateTimeOffset;
+
+            // Use the .NET format options to format the DateTimeOffset
+
+            if (HasTime && !HasDate)
             {
-                tz = " " + tz;
+                return $"{dateTimeOffset.TimeOfDay.ToString(format, formatProvider)} {_tzId}";
             }
 
-            if (format != null)
-            {
-                return Value.ToString(format, formatProvider) + tz;
-            }
             if (HasTime && HasDate)
             {
-                return Value.ToString(formatProvider) + tz;
+                return $"{dateTimeOffset.ToString(format, formatProvider)} {_tzId}";
             }
-            if (HasTime)
-            {
-                return Value.TimeOfDay + tz;
-            }
-            return Value.ToString("d", formatProvider) + tz;
+
+            return $"{dateTimeOffset.ToString("d", formatProvider)} {_tzId}";
         }
     }
 }

--- a/Ical.Net/DataTypes/Trigger.cs
+++ b/Ical.Net/DataTypes/Trigger.cs
@@ -31,8 +31,8 @@ namespace Ical.Net.DataTypes
                 // DateTime and Duration are mutually exclusive
                 Duration = null;
 
-                // Do not allow timeless date/time values
-                _mDateTime.HasTime = true;
+                // Ensure date/time has a time part
+                _mDateTime = new CalDateTime(_mDateTime.Value);
             }
         }
 

--- a/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
@@ -908,9 +908,6 @@ namespace Ical.Net.Evaluation
             // with the reference date.
             IDateTime newDt = new CalDateTime(dt, referenceDate.TzId);
 
-            // NOTE: fixes bug #2938007 - hasTime missing
-            newDt.HasTime = referenceDate.HasTime;
-
             newDt.AssociateWith(referenceDate);
 
             // Create a period from the new date/time.
@@ -932,8 +929,8 @@ namespace Ical.Net.Evaluation
                 // This case is not defined by RFC 5545. We handle it by evaluating the rule
                 // as if referenceDate had a time (i.e. set to midnight).
 
-                referenceDate = referenceDate.Copy<IDateTime>();
-                referenceDate.HasTime = true;
+                // Ensure referenceDate has a time part
+                referenceDate = new CalDateTime(referenceDate);
             }
 
             // Create a recurrence pattern suitable for use during evaluation.

--- a/Ical.Net/Evaluation/RecurrenceUtil.cs
+++ b/Ical.Net/Evaluation/RecurrenceUtil.cs
@@ -15,7 +15,7 @@ namespace Ical.Net.Evaluation
         }
 
         public static HashSet<Occurrence> GetOccurrences(IRecurrable recurrable, IDateTime dt, bool includeReferenceDateInResults) => GetOccurrences(recurrable,
-            new CalDateTime(dt.AsSystemLocal.Date), new CalDateTime(dt.AsSystemLocal.Date.AddDays(1).AddSeconds(-1)), includeReferenceDateInResults);
+            new CalDateTime(dt.Date), new CalDateTime(dt.Date.AddDays(1).AddSeconds(-1)), includeReferenceDateInResults);
 
         public static HashSet<Occurrence> GetOccurrences(IRecurrable recurrable, IDateTime periodStart, IDateTime periodEnd, bool includeReferenceDateInResults)
         {

--- a/Ical.Net/Ical.Net.csproj
+++ b/Ical.Net/Ical.Net.csproj
@@ -8,6 +8,9 @@
     <ItemGroup>
         <PackageReference Include="NodaTime" Version="3.2.0" />
     </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'">
+        <PackageReference Include="Portable.System.DateTimeOnly" Version="8.0.1" />
+    </ItemGroup>
     <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
             <_Parameter1>Ical.Net.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100a1f790f70176d52efbd248577bdb292be2d0acc62f3227c523e267d64767f207f81536c77bb91d17031a5afbc2d69cd3b5b3b9c98fa8df2cd363ec90a08639a1213ad70079eff666bcc14cf6574b899f4ad0eac672c8f763291cb1e0a2304d371053158cb398b2e6f9eeb45db7d1b4d2bbba1f985676c5ca4602fab3671d34bf</_Parameter1>

--- a/Ical.Net/Serialization/DataTypes/DateTimeSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/DateTimeSerializer.cs
@@ -6,43 +6,27 @@ using System.Text.RegularExpressions;
 
 namespace Ical.Net.Serialization.DataTypes
 {
+    /// <summary>
+    /// A serializer for the <see cref="CalDateTime"/> data type.
+    /// </summary>
     public class DateTimeSerializer : EncodableDataTypeSerializer
     {
+        /// <summary>
+        /// This constructor is required for the SerializerFactory to work.
+        /// </summary>
         public DateTimeSerializer() { }
 
+        /// <summary>
+        /// Creates a new instance of the <see cref="DateTimeSerializer"/> class.
+        /// </summary>
+        /// <param name="ctx"></param>
         public DateTimeSerializer(SerializationContext ctx) : base(ctx) { }
-
-        private DateTime CoerceDateTime(int year, int month, int day, int hour, int minute, int second, DateTimeKind kind)
-        {
-            var dt = DateTime.MinValue;
-
-            // NOTE: determine if a date/time value exceeds the representable date/time values in .NET.
-            // If so, let's automatically adjust the date/time to compensate.
-            // FIXME: should we have a parsing setting that will throw an exception
-            // instead of automatically adjusting the date/time value to the
-            // closest representable date/time?
-            try
-            {
-                if (year > 9999)
-                {
-                    dt = DateTime.MaxValue;
-                }
-                else if (year > 0)
-                {
-                    dt = new DateTime(year, month, day, hour, minute, second, kind);
-                }
-            }
-            catch { }
-
-            return dt;
-        }
 
         public override Type TargetType => typeof(CalDateTime);
 
         public override string SerializeToString(object obj)
         {
-            var dt = obj as IDateTime;
-            if (dt == null)
+            if (obj is not IDateTime dt)
             {
                 return null;
             }
@@ -77,7 +61,7 @@ namespace Ical.Net.Serialization.DataTypes
                 dt.SetValueType("DATE");
             }
 
-            var value = new StringBuilder();
+            var value = new StringBuilder(512);
             value.Append($"{dt.Year:0000}{dt.Month:00}{dt.Day:00}");
             if (dt.HasTime)
             {
@@ -92,16 +76,16 @@ namespace Ical.Net.Serialization.DataTypes
             return Encode(dt, value.ToString());
         }
 
-        private const RegexOptions _ciCompiled = RegexOptions.Compiled | RegexOptions.IgnoreCase;
-        internal static readonly Regex DateOnlyMatch = new Regex(@"^((\d{4})(\d{2})(\d{2}))?$", _ciCompiled, RegexDefaults.Timeout);
-        internal static readonly Regex FullDateTimePatternMatch = new Regex(@"^((\d{4})(\d{2})(\d{2}))T((\d{2})(\d{2})(\d{2})(Z)?)$", _ciCompiled, RegexDefaults.Timeout);
+        private const RegexOptions Options = RegexOptions.Compiled | RegexOptions.IgnoreCase;
+        internal static readonly Regex DateOnlyMatch = new Regex(@"^((\d{4})(\d{2})(\d{2}))?$", Options, RegexDefaults.Timeout);
+        internal static readonly Regex FullDateTimePatternMatch = new Regex(@"^((\d{4})(\d{2})(\d{2}))T((\d{2})(\d{2})(\d{2})(Z)?)$", Options, RegexDefaults.Timeout);
 
         public override object Deserialize(TextReader tr)
         {
             var value = tr.ReadToEnd();
 
-            var dt = CreateAndAssociate() as IDateTime;
-            if (dt == null)
+            // CalDateTime is defined as the Target type
+            if (CreateAndAssociate() is not CalDateTime dt)
             {
                 return null;
             }
@@ -119,28 +103,21 @@ namespace Ical.Net.Serialization.DataTypes
             {
                 return null;
             }
-            var now = DateTime.Now;
 
-            var year = now.Year;
-            var month = now.Month;
-            var date = now.Day;
-            var hour = 0;
-            var minute = 0;
-            var second = 0;
+            var datePart = new DateOnly(); // Initialize. At this point, we know that the date part is present
+            TimeOnly? timePart = null;
 
             if (match.Groups[1].Success)
             {
-                dt.HasDate = true;
-                year = Convert.ToInt32(match.Groups[2].Value);
-                month = Convert.ToInt32(match.Groups[3].Value);
-                date = Convert.ToInt32(match.Groups[4].Value);
+                datePart = new DateOnly(Convert.ToInt32(match.Groups[2].Value),
+                    Convert.ToInt32(match.Groups[3].Value),
+                    Convert.ToInt32(match.Groups[4].Value));
             }
             if (match.Groups.Count >= 6 && match.Groups[5].Success)
             {
-                dt.HasTime = true;
-                hour = Convert.ToInt32(match.Groups[6].Value);
-                minute = Convert.ToInt32(match.Groups[7].Value);
-                second = Convert.ToInt32(match.Groups[8].Value);
+                timePart = new TimeOnly(Convert.ToInt32(match.Groups[6].Value),
+                    Convert.ToInt32(match.Groups[7].Value),
+                    Convert.ToInt32(match.Groups[8].Value));
             }
 
             var isUtc = match.Groups[9].Success;
@@ -153,7 +130,8 @@ namespace Ical.Net.Serialization.DataTypes
                 dt.TzId = "UTC";
             }
 
-            dt.Value = CoerceDateTime(year, month, date, hour, minute, second, kind);
+            dt.SetValue(datePart, timePart, kind);
+ 
             return dt;
         }
     }

--- a/Ical.Net/Serialization/DataTypes/RecurrencePatternSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/RecurrencePatternSerializer.cs
@@ -142,8 +142,8 @@ namespace Ical.Net.Serialization.DataTypes
                 var serializer = factory.Build(typeof(IDateTime), SerializationContext) as IStringSerializer;
                 if (serializer != null)
                 {
+                    // Ensure util has a time part
                     IDateTime until = new CalDateTime(recur.Until);
-                    until.HasTime = true;
                     values.Add("UNTIL=" + serializer.SerializeToString(until));
                 }
             }


### PR DESCRIPTION
The ToString method on CalDateTime has useful logic to render the date and/or time components, but this rendering ignores the format provider and always uses the current culture. The format provider is currently used when the format string is specified, but not otherwise.

This PR adds some characterisation tests and alters ToString to use the format provider for date formatting.