### PR TITLE
Use dotnet 7 regex source generator

### DIFF
--- a/src/Ical.Net.CoreUnitTests/Ical.Net.CoreUnitTests.csproj
+++ b/src/Ical.Net.CoreUnitTests/Ical.Net.CoreUnitTests.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net50</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\IcalNetStrongnameKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Ical.Net\Ical.Net.csproj" />

--- a/src/Ical.Net/Ical.Net.csproj
+++ b/src/Ical.Net/Ical.Net.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <LangVersion>8</LangVersion>
+    <LangVersion>11</LangVersion>
     <PackageVersion>4.2.0</PackageVersion>
     <Title>Ical.Net</Title>
     <PackageProjectUrl>https://github.com/rianjs/ical.net</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/rianjs/ical.net</RepositoryUrl>
     <PackageReleaseNotes>hhttps://github.com/rianjs/ical.net/blob/master/release-notes.md</PackageReleaseNotes>
-    <TargetFrameworks>netstandard2.0;net50</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <Authors>Rian Stockbower, Douglas Day, &amp; Contributors</Authors>
     <Company />
     <SignAssembly>true</SignAssembly>
@@ -21,10 +21,10 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>bin\Release\Ical.Net.xml</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+    <DefineConstants>SUPPORTS_REGEX_CODEGEN</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NodaTime" Version="3.0.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
+    <PackageReference Include="NodaTime" Version="3.1.6" />
   </ItemGroup>
 </Project>

--- a/src/Ical.Net/Serialization/DataTypes/DateTimeSerializer.cs
+++ b/src/Ical.Net/Serialization/DataTypes/DateTimeSerializer.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
 using Ical.Net.DataTypes;
+using Ical.Net.Utility;
 
 namespace Ical.Net.Serialization.DataTypes
 {
@@ -93,8 +94,6 @@ namespace Ical.Net.Serialization.DataTypes
         }
 
         private const RegexOptions _ciCompiled = RegexOptions.Compiled | RegexOptions.IgnoreCase;
-        internal static readonly Regex DateOnlyMatch = new Regex(@"^((\d{4})(\d{2})(\d{2}))?$", _ciCompiled);
-        internal static readonly Regex FullDateTimePatternMatch = new Regex(@"^((\d{4})(\d{2})(\d{2}))T((\d{2})(\d{2})(\d{2})(Z)?)$", _ciCompiled);
 
         public override object Deserialize(TextReader tr)
         {
@@ -109,10 +108,10 @@ namespace Ical.Net.Serialization.DataTypes
             // Decode the value as necessary
             value = Decode(dt, value);
 
-            var match = FullDateTimePatternMatch.Match(value);
+            var match = CompiledRegularExpressions.FullDateTime.Match(value);
             if (!match.Success)
             {
-                match = DateOnlyMatch.Match(value);
+                match = CompiledRegularExpressions.DateOnly.Match(value);
             }
 
             if (!match.Success)

--- a/src/Ical.Net/Serialization/DataTypes/RequestStatusSerializer.cs
+++ b/src/Ical.Net/Serialization/DataTypes/RequestStatusSerializer.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.IO;
 using System.Text;
-using System.Text.RegularExpressions;
 using Ical.Net.DataTypes;
+using Ical.Net.Utility;
 
 namespace Ical.Net.Serialization.DataTypes
 {
@@ -58,10 +58,7 @@ namespace Ical.Net.Serialization.DataTypes
                 return null;
             }
         }
-
-        internal static readonly Regex NarrowRequestMatch = new Regex(@"(.*?[^\\]);(.*?[^\\]);(.+)", RegexOptions.Compiled);
-        internal static readonly Regex BroadRequestMatch = new Regex(@"(.*?[^\\]);(.+)", RegexOptions.Compiled);
-
+        
         public override object Deserialize(TextReader tr)
         {
             var value = tr.ReadToEnd();
@@ -86,10 +83,10 @@ namespace Ical.Net.Serialization.DataTypes
                     return null;
                 }
 
-                var match = NarrowRequestMatch.Match(value);
+                var match = CompiledRegularExpressions.NarrowRequest.Match(value);
                 if (!match.Success)
                 {
-                    match = BroadRequestMatch.Match(value);
+                    match = CompiledRegularExpressions.BroadRequest.Match(value);
                 }
 
                 if (match.Success)

--- a/src/Ical.Net/Serialization/DataTypes/StatusCodeSerializer.cs
+++ b/src/Ical.Net/Serialization/DataTypes/StatusCodeSerializer.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
-using System.Text.RegularExpressions;
 using Ical.Net.DataTypes;
+using Ical.Net.Utility;
 
 namespace Ical.Net.Serialization.DataTypes
 {
@@ -29,8 +29,6 @@ namespace Ical.Net.Serialization.DataTypes
             return Encode(sc, Escape(string.Join(".", vals)));
         }
 
-        internal static readonly Regex StatusCode = new Regex(@"\d(\.\d+)*", RegexOptions.Compiled | RegexOptions.CultureInvariant);
-
         public override object Deserialize(TextReader tr)
         {
             var value = tr.ReadToEnd();
@@ -44,7 +42,7 @@ namespace Ical.Net.Serialization.DataTypes
             // Decode the value as needed
             value = Decode(sc, value);
 
-            var match = StatusCode.Match(value);
+            var match = CompiledRegularExpressions.StatusCode.Match(value);
             if (!match.Success)
             {
                 return null;

--- a/src/Ical.Net/Serialization/DataTypes/StringSerializer.cs
+++ b/src/Ical.Net/Serialization/DataTypes/StringSerializer.cs
@@ -3,8 +3,8 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using Ical.Net.DataTypes;
+using Ical.Net.Utility;
 
 namespace Ical.Net.Serialization.DataTypes
 {
@@ -13,8 +13,6 @@ namespace Ical.Net.Serialization.DataTypes
         public StringSerializer() {}
 
         public StringSerializer(SerializationContext ctx) : base(ctx) {}
-
-        internal static readonly Regex SingleBackslashMatch = new Regex(@"(?<!\\)\\(?!\\)", RegexOptions.Compiled);
 
         protected virtual string Unescape(string value)
         {
@@ -31,7 +29,7 @@ namespace Ical.Net.Serialization.DataTypes
             value = value.Replace("\\\"", "\"");
 
             // Replace all single-backslashes with double-backslashes.
-            value = SingleBackslashMatch.Replace(value, "\\\\");
+            value = CompiledRegularExpressions.SingleBackslash.Replace(value, "\\\\");
 
             // Unescape double backslashes
             value = value.Replace(@"\\", @"\");
@@ -98,7 +96,6 @@ namespace Ical.Net.Serialization.DataTypes
             return string.Join(",", values);
         }
 
-        internal static readonly Regex UnescapedCommas = new Regex(@"(?<!\\),", RegexOptions.Compiled);
         public override object Deserialize(TextReader tr)
         {
             if (tr == null)
@@ -132,7 +129,7 @@ namespace Ical.Net.Serialization.DataTypes
                 };
             }
 
-            var encodedValues = serializeAsList ? UnescapedCommas.Split(value) : new[] { value };
+            var encodedValues = serializeAsList ? CompiledRegularExpressions.UnescapedCommas.Split(value) : new[] { value };
             var escapedValues = encodedValues.Select(v => Decode(dt, v)).ToList();
             var values = escapedValues.Select(Unescape).ToList();
 

--- a/src/Ical.Net/Serialization/DataTypes/TimeSpanSerializer.cs
+++ b/src/Ical.Net/Serialization/DataTypes/TimeSpanSerializer.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Text;
-using System.Text.RegularExpressions;
+using Ical.Net.Utility;
 
 namespace Ical.Net.Serialization.DataTypes
 {
@@ -66,17 +66,13 @@ namespace Ical.Net.Serialization.DataTypes
             return sb.ToString();
         }
 
-        internal static readonly Regex TimespanMatch =
-            new Regex(@"^(?<sign>\+|-)?P(((?<week>\d+)W)|(?<main>((?<day>\d+)D)?(?<time>T((?<hour>\d+)H)?((?<minute>\d+)M)?((?<second>\d+)S)?)?))$",
-                RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
         public override object Deserialize(TextReader tr)
         {
             var value = tr.ReadToEnd();
 
             try
             {
-                var match = TimespanMatch.Match(value);
+                var match = CompiledRegularExpressions.Timespan.Match(value);
                 var days = 0;
                 var hours = 0;
                 var minutes = 0;

--- a/src/Ical.Net/Serialization/DataTypes/UtcOffsetSerializer.cs
+++ b/src/Ical.Net/Serialization/DataTypes/UtcOffsetSerializer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Globalization;
 using System.IO;
-using System.Text.RegularExpressions;
 using Ical.Net.DataTypes;
 
 namespace Ical.Net.Serialization.DataTypes
@@ -27,8 +26,6 @@ namespace Ical.Net.Serialization.DataTypes
             }
             return null;
         }
-
-        internal static readonly Regex DecodeOffset = new Regex(@"(\+|-)(\d{2})(\d{2})(\d{2})?", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public override object Deserialize(TextReader tr)
         {

--- a/src/Ical.Net/Serialization/DataTypes/WeekDaySerializer.cs
+++ b/src/Ical.Net/Serialization/DataTypes/WeekDaySerializer.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
-using System.Text.RegularExpressions;
 using Ical.Net.DataTypes;
+using Ical.Net.Utility;
 
 namespace Ical.Net.Serialization.DataTypes
 {
@@ -30,8 +30,6 @@ namespace Ical.Net.Serialization.DataTypes
             return Encode(ds, value);
         }
 
-        private static readonly Regex _dayOfWeek = new Regex(@"(\+|-)?(\d{1,2})?(\w{2})", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
         public override object Deserialize(TextReader tr)
         {
             var value = tr.ReadToEnd();
@@ -42,7 +40,7 @@ namespace Ical.Net.Serialization.DataTypes
             // Decode the value, if necessary
             value = Decode(ds, value);
 
-            var match = _dayOfWeek.Match(value);
+            var match = CompiledRegularExpressions.DayOfWeek.Match(value);
             if (!match.Success)
             {
                 return null;

--- a/src/Ical.Net/Utility/CompiledRegularExpressions.cs
+++ b/src/Ical.Net/Utility/CompiledRegularExpressions.cs
@@ -1,0 +1,274 @@
+using System.Text.RegularExpressions;
+
+// ReSharper disable InconsistentNaming
+
+namespace Ical.Net.Utility;
+
+#if SUPPORTS_REGEX_CODEGEN
+internal static partial class CompiledRegularExpressions
+#else
+internal static class CompiledRegularExpressions
+#endif
+{
+    private const string NarrowRequestPattern = @"(.*?[^\\]);(.*?[^\\]);(.+)";
+    private const RegexOptions NarrowRequestOptions = RegexOptions.Compiled;
+#if SUPPORTS_REGEX_CODEGEN
+    [GeneratedRegex(NarrowRequestPattern, NarrowRequestOptions)]
+    private static partial Regex NarrowRequestRegex();
+    internal static Regex NarrowRequest => NarrowRequestRegex();
+#else
+    internal static readonly Regex NarrowRequest = new(NarrowRequestPattern, NarrowRequestOptions);
+#endif
+
+    private const string BroadRequestPattern = @"(.*?[^\\]);(.+)";
+    private const RegexOptions BroadRequestOptions = RegexOptions.Compiled;
+#if SUPPORTS_REGEX_CODEGEN
+    [GeneratedRegex(BroadRequestPattern, BroadRequestOptions)]
+    private static partial Regex BroadRequestRegex();
+    internal static Regex BroadRequest => BroadRequestRegex();
+#else
+    internal static readonly Regex BroadRequest = new(BroadRequestPattern, BroadRequestOptions);
+#endif
+
+    private const string NormalizeToCrLfPattern = @"((\r(?=[^\n]))|((?<=[^\r])\n))";
+    private const RegexOptions NormalizeToCrLfOptions = RegexOptions.Compiled;
+#if SUPPORTS_REGEX_CODEGEN
+    [GeneratedRegex(NormalizeToCrLfPattern, NormalizeToCrLfOptions)]
+    private static partial Regex NormalizeToCrLfRegex();
+    internal static Regex NormalizeToCrLf = NormalizeToCrLfRegex();
+#else
+    internal static readonly Regex NormalizeToCrLf = new(NormalizeToCrLfPattern, NormalizeToCrLfOptions);
+#endif
+
+    private const string NewLinePattern = @"(\r\n[ \t])";
+    private const RegexOptions NewLineOptions = RegexOptions.Compiled;
+#if SUPPORTS_REGEX_CODEGEN
+    [GeneratedRegex(NewLinePattern, NewLineOptions)]
+    private static partial Regex NewLineRegex();
+    internal static Regex NewLine => NewLineRegex();
+#else
+    internal static readonly Regex NewLine = new(NewLinePattern, NewLineOptions);
+#endif
+
+    private const string DateOnlyPattern = @"^((\d{4})(\d{2})(\d{2}))?$";
+    private const RegexOptions DateOnlyOptions = RegexOptions.Compiled | RegexOptions.IgnoreCase;
+#if SUPPORTS_REGEX_CODEGEN
+    [GeneratedRegex(DateOnlyPattern, DateOnlyOptions)]
+    private static partial Regex DateOnlyRegex();
+    internal static Regex DateOnly => DateOnlyRegex();
+#else
+    internal static readonly Regex DateOnly = new(DateOnlyPattern, DateOnlyOptions);
+#endif
+
+    private const string FullDateTimePattern = @"^((\d{4})(\d{2})(\d{2}))T((\d{2})(\d{2})(\d{2})(Z)?)$";
+    private const RegexOptions FullDateTimeOptions = RegexOptions.Compiled | RegexOptions.IgnoreCase;
+#if SUPPORTS_REGEX_CODEGEN
+    [GeneratedRegex(FullDateTimePattern, FullDateTimeOptions)]
+    private static partial Regex FullDateTimeRegex();
+    internal static Regex FullDateTime = FullDateTimeRegex();
+#else
+    internal static readonly Regex FullDateTime = new(FullDateTimePattern, FullDateTimeOptions);
+#endif
+
+    private const string SingleBackslashPattern = @"(?<!\\)\\(?!\\)";
+    private const RegexOptions SingleBackslashOptions = RegexOptions.Compiled;
+#if SUPPORTS_REGEX_CODEGEN
+    [GeneratedRegex(SingleBackslashPattern, SingleBackslashOptions)]
+    private static partial Regex SingleBackslashRegex();
+    internal static Regex SingleBackslash => SingleBackslashRegex();
+#else
+    internal static readonly Regex SingleBackslash = new(SingleBackslashPattern, SingleBackslashOptions);
+#endif
+
+    private const string OtherIntervalPattern =
+        @"every\s+(?<Interval>other|\d+)?\w{0,2}\s*(?<Freq>second|minute|hour|day|week|month|year)s?,?\s*(?<More>.+)";
+
+    private const RegexOptions OtherIntervalOptions = RegexOptions.Compiled | RegexOptions.IgnoreCase;
+
+#if SUPPORTS_REGEX_CODEGEN
+    [GeneratedRegex(OtherIntervalPattern, OtherIntervalOptions)]
+    private static partial Regex OtherIntervalRegex();
+    internal static Regex OtherInterval => OtherIntervalRegex();
+#else
+    internal static readonly Regex OtherInterval = new(OtherIntervalPattern, OtherIntervalOptions);
+#endif
+
+    private const string AdverbFrequenciesPattern =
+        @"FREQ=(SECONDLY|MINUTELY|HOURLY|DAILY|WEEKLY|MONTHLY|YEARLY);?(.*)";
+
+    private const RegexOptions AdverbFrequenciesOptions = RegexOptions.Compiled | RegexOptions.IgnoreCase;
+
+#if SUPPORTS_REGEX_CODEGEN
+    [GeneratedRegex(AdverbFrequenciesPattern, AdverbFrequenciesOptions)]
+    private static partial Regex AdverbFrequenciesRegex();
+    internal static Regex AdverbFrequencies => AdverbFrequenciesRegex();
+#else
+    internal static readonly Regex AdverbFrequencies = new(AdverbFrequenciesPattern, AdverbFrequenciesOptions);
+#endif
+
+    private const string NumericTemporalUnitsPattern = @"(?<Num>\d+)\w\w\s+(?<Type>second|minute|hour|day|week|month)";
+    private const RegexOptions NumericTemporalUnitsOptions = RegexOptions.Compiled | RegexOptions.IgnoreCase;
+#if SUPPORTS_REGEX_CODEGEN
+    [GeneratedRegex(NumericTemporalUnitsPattern, NumericTemporalUnitsOptions)]
+    private static partial Regex NumericTemporalUnitsRegex();
+    internal static Regex NumericTemporalUnits = NumericTemporalUnitsRegex();
+#else
+    internal static readonly Regex NumericTemporalUnits =
+        new(NumericTemporalUnitsPattern, NumericTemporalUnitsOptions);
+#endif
+
+    private const string TemporalUnitTypePattern = @"(?<Type>second|minute|hour|day|week|month)\s+(?<Num>\d+)";
+    private const RegexOptions TemporalUnitTypeOptions = RegexOptions.Compiled | RegexOptions.IgnoreCase;
+#if SUPPORTS_REGEX_CODEGEN
+    [GeneratedRegex(TemporalUnitTypePattern, TemporalUnitTypeOptions)]
+    private static partial Regex TemporalUnitTypeRegex();
+    internal static Regex TemporalUnitType => TemporalUnitTypeRegex();
+#else
+    internal static readonly Regex TemporalUnitType = new(TemporalUnitTypePattern, TemporalUnitTypeOptions);
+#endif
+
+    private const string RelativeDaysOfWeekPattern =
+        @"(?<Num>\d+\w{0,2})?(\w|\s)+?(?<First>first)?(?<Last>last)?\s*((?<Day>sunday|monday|tuesday|wednesday|thursday|friday|saturday)\s*(and|or)?\s*)+";
+
+    private const RegexOptions RelativeDaysOfWeekOptions = RegexOptions.Compiled | RegexOptions.IgnoreCase;
+
+#if SUPPORTS_REGEX_CODEGEN
+    [GeneratedRegex(RelativeDaysOfWeekPattern, RelativeDaysOfWeekOptions)]
+    private static partial Regex RelativeDaysOfWeekRegex();
+    internal static Regex RelativeDaysOfWeek = RelativeDaysOfWeekRegex();
+#else
+    internal static readonly Regex RelativeDaysOfWeek = new(RelativeDaysOfWeekPattern, RelativeDaysOfWeekOptions);
+#endif
+
+    private const string TimePattern =
+        @"at\s+(?<Hour>\d{1,2})(:(?<Minute>\d{2})((:|\.)(?<Second>\d{2}))?)?\s*(?<Meridian>(a|p)m?)?";
+
+    private const RegexOptions TimeOptions = RegexOptions.Compiled | RegexOptions.IgnoreCase;
+#if SUPPORTS_REGEX_CODEGEN
+    [GeneratedRegex(TimePattern, TimeOptions)]
+    private static partial Regex TimeRegex();
+    internal static Regex Time => TimeRegex();
+#else
+    internal static readonly Regex Time = new(TimePattern, TimeOptions);
+#endif
+
+    private const string RecurUntilPattern = @"^\s*until\s+(?<DateTime>.+)$";
+    private const RegexOptions RecurUntilOptions = RegexOptions.Compiled | RegexOptions.IgnoreCase;
+#if SUPPORTS_REGEX_CODEGEN
+    [GeneratedRegex(RecurUntilPattern, RecurUntilOptions)]
+    private static partial Regex RecurUntilRegex();
+    internal static Regex RecurUntil => RecurUntilRegex();
+#else
+    internal static readonly Regex RecurUntil = new(RecurUntilPattern, RecurUntilOptions);
+#endif
+
+    private const string SpecificRecurrenceCountPattern = @"^\s*for\s+(?<Count>\d+)\s+occurrences\s*$";
+    private const RegexOptions SpecificRecurrenceCountOptions = RegexOptions.Compiled | RegexOptions.IgnoreCase;
+#if SUPPORTS_REGEX_CODEGEN
+    [GeneratedRegex(SpecificRecurrenceCountPattern, SpecificRecurrenceCountOptions)]
+    private static partial Regex SpecificRecurrenceCountRegex();
+    internal static Regex SpecificRecurrenceCount => SpecificRecurrenceCountRegex();
+#else
+    internal static readonly Regex SpecificRecurrenceCount =
+        new(SpecificRecurrenceCountPattern, SpecificRecurrenceCountOptions);
+#endif
+
+    private const string StatusCodePattern = @"\d(\.\d+)*";
+    private const RegexOptions StatusCodePatternOptions = RegexOptions.Compiled | RegexOptions.CultureInvariant;
+#if SUPPORTS_REGEX_CODEGEN
+    [GeneratedRegex(StatusCodePattern, StatusCodePatternOptions)]
+    private static partial Regex StatusCodeRegex();
+    internal static Regex StatusCode => StatusCodeRegex();
+#else
+    internal static readonly Regex StatusCode = new(StatusCodePattern, StatusCodePatternOptions);
+#endif
+
+    private const string DayOfWeekPattern = @"(\+|-)?(\d{1,2})?(\w{2})";
+    private const RegexOptions DayOfWeekPatternOptions = RegexOptions.Compiled | RegexOptions.IgnoreCase;
+#if SUPPORTS_REGEX_CODEGEN
+    [GeneratedRegex(DayOfWeekPattern, DayOfWeekPatternOptions)]
+    private static partial Regex DayOfWeekRegex();
+    internal static Regex DayOfWeek => DayOfWeekRegex();
+#else
+    internal static readonly Regex DayOfWeek = new(DayOfWeekPattern, DayOfWeekPatternOptions);
+#endif
+
+    private const string UnescapedCommasPattern = @"(?<!\\),";
+    private const RegexOptions UnescapedCommasOptions = RegexOptions.Compiled;
+#if SUPPORTS_REGEX_CODEGEN
+    [GeneratedRegex(UnescapedCommasPattern, UnescapedCommasOptions)]
+    private static partial Regex UnescapedCommasRegex();
+    internal static Regex UnescapedCommas => UnescapedCommasRegex();
+#else
+    internal static readonly Regex UnescapedCommas = new(UnescapedCommasPattern, UnescapedCommasOptions);
+#endif
+
+    private const string TimespanPattern =
+        @"^(?<sign>\+|-)?P(((?<week>\d+)W)|(?<main>((?<day>\d+)D)?(?<time>T((?<hour>\d+)H)?((?<minute>\d+)M)?((?<second>\d+)S)?)?))$";
+
+    private const RegexOptions TimespanOptions = RegexOptions.Compiled | RegexOptions.IgnoreCase;
+#if SUPPORTS_REGEX_CODEGEN
+    [GeneratedRegex(TimespanPattern, TimespanOptions)]
+    private static partial Regex TimespanRegex();
+    internal static Regex Timespan => TimespanRegex();
+#else
+    internal static readonly Regex Timespan = new(TimespanPattern, TimespanOptions);
+#endif
+
+    private const string DecodeOffsetPattern = @"(\+|-)(\d{2})(\d{2})(\d{2})?";
+    private const RegexOptions DecodeOffsetOptions = RegexOptions.Compiled;
+#if SUPPORTS_REGEX_CODEGEN
+    [GeneratedRegex(DecodeOffsetPattern, DecodeOffsetOptions)]
+    private static partial Regex DecodeOffsetRegex();
+    private static Regex DecodeOffset => DecodeOffsetRegex();
+#else
+    internal static readonly Regex DecodeOffset = new(DecodeOffsetPattern, DecodeOffsetOptions);
+#endif
+
+
+    internal const string ContentLineNameGroup = "name";
+    internal const string ContentLineValueGroup = "value";
+    internal const string ContentLineParamNameGroup = "paramName";
+    internal const string ContentLineParamValueGroup = "paramValue";
+
+    // name          = iana-token / x-name
+    // iana-token    = 1*(ALPHA / DIGIT / "-")
+    // x-name        = "X-" [vendorid "-"] 1*(ALPHA / DIGIT / "-")
+    // vendorid      = 3*(ALPHA / DIGIT)
+    // Add underscore to match behavior of bug 2033495
+    private const string ContentLineIdentifier = "[-A-Za-z0-9_]+";
+
+    // param-value   = paramtext / quoted-string
+    // paramtext     = *SAFE-CHAR
+    // quoted-string = DQUOTE *QSAFE-CHAR DQUOTE
+    // QSAFE-CHAR    = WSP / %x21 / %x23-7E / NON-US-ASCII
+    // ; Any character except CONTROL and DQUOTE
+    // SAFE-CHAR     = WSP / %x21 / %x23-2B / %x2D-39 / %x3C-7E
+    //               / NON-US-ASCII
+    // ; Any character except CONTROL, DQUOTE, ";", ":", ","
+    private const string ContentLineParamValue =
+        $"((?<{ContentLineParamValueGroup}>[^\\x00-\\x08\\x0A-\\x1F\\x7F\";:,]*)|\"(?<{ContentLineParamValueGroup}>[^\\x00-\\x08\\x0A-\\x1F\\x7F\"]*)\")";
+
+    // param         = param-name "=" param-value *("," param-value)
+    // param-name    = iana-token / x-name
+    private const string ContentLineParamName = $"(?<{ContentLineParamNameGroup}>{ContentLineIdentifier})";
+
+    private const string ContentLineParam =
+        $"{ContentLineParamName}={ContentLineParamValue}(,{ContentLineParamValue})*";
+
+    // contentline   = name *(";" param ) ":" value CRLF
+    private const string ContentLineName = $"(?<{ContentLineNameGroup}>{ContentLineIdentifier})";
+
+    // value         = *VALUE-CHAR
+    private const string ContentLineValue = $"(?<{ContentLineValueGroup}>[^\\x00-\\x08\\x0E-\\x1F\\x7F]*)";
+    private const RegexOptions ContentLineOptions = RegexOptions.Compiled;
+    private const string ContentLinePattern = $"^{ContentLineName}(;{ContentLineParam})*:{ContentLineValue}$";
+
+#if SUPPORTS_REGEX_CODEGEN
+    [GeneratedRegex(ContentLinePattern, ContentLineOptions)]
+    private static partial Regex ContentLineRegex();
+    internal static Regex ContentLine => ContentLineRegex();
+#else
+    internal static readonly Regex ContentLine = new(ContentLinePattern, ContentLineOptions);
+#endif
+}

--- a/src/Ical.Net/Utility/TextUtil.cs
+++ b/src/Ical.Net/Utility/TextUtil.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text.RegularExpressions;
 using Ical.Net.Serialization;
 
 namespace Ical.Net.Utility
@@ -47,25 +46,21 @@ namespace Ical.Net.Utility
             return s;
         }
 
-        internal static readonly Regex NormalizeToCrLf = new Regex(@"((\r(?=[^\n]))|((?<=[^\r])\n))", RegexOptions.Compiled);
-
         /// <summary>
         /// Normalizes line endings, converting "\r" into "\r\n" and "\n" into "\r\n".        
         /// </summary>
         public static TextReader Normalize(string s, SerializationContext ctx)
         {
             // Replace \r and \n with \r\n.
-            s = NormalizeToCrLf.Replace(s, SerializationConstants.LineBreak);
+            s = CompiledRegularExpressions.NormalizeToCrLf.Replace(s, SerializationConstants.LineBreak);
 
             s = RemoveEmptyLines(UnwrapLines(s));
 
             return new StringReader(s);
         }
-
-        internal static readonly Regex NewLineMatch = new Regex(@"(\r\n[ \t])", RegexOptions.Compiled);
-
+        
         /// <summary> Unwraps lines from the RFC 5545 "line folding" technique. </summary>
-        public static string UnwrapLines(string s) => NewLineMatch.Replace(s, string.Empty);
+        public static string UnwrapLines(string s) => CompiledRegularExpressions.NewLine.Replace(s, string.Empty);
 
         public static bool Contains(this string haystack, string needle, StringComparison stringComparison)
             => haystack.IndexOf(needle, stringComparison) >= 0;

--- a/src/PerfTests/PerfTests.csproj
+++ b/src/PerfTests/PerfTests.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net50</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds support for [dotnet 7 regular expression source generators](https://learn.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-source-generators). 

Adds significant performance boost.

Since source generators require partial classes, I moved all regular expressions into a single file and wrap the partial methods with a property for simplicity.

I also upgraded all referenced nuget packages to latest.

dotnet 5 is not supported on Apple silicon. I had to also upgrade to dotnet 6.

### dotnet 6 benchmark (Not using regex source generator)
```shell
// * Summary *

BenchmarkDotNet=v0.13.5, OS=macOS Ventura 13.2.1 (22D68) [Darwin 22.3.0]
Apple M1 Max, 1 CPU, 10 logical and 10 physical cores
.NET SDK=7.0.200
  [Host]     : .NET 6.0.14 (6.0.1423.7309), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 6.0.14 (6.0.1423.7309), Arm64 RyuJIT AdvSIMD


|                                                          Method |     Mean |    Error |   StdDev |
|---------------------------------------------------------------- |---------:|---------:|---------:|
|                                                  SingleThreaded | 36.55 ms | 0.712 ms | 0.666 ms |
|                                         ParallelUponDeserialize | 38.59 ms | 0.762 ms | 1.068 ms |
|                                      ParallelUponGetOccurrences | 39.84 ms | 0.700 ms | 0.719 ms |
| ParallelDeserializeSequentialGatherEventsParallelGetOccurrences | 39.17 ms | 0.769 ms | 1.078 ms |
```

### dotnet 7 benchmark (Using regex source generators)
```shell
// * Summary *

BenchmarkDotNet=v0.13.5, OS=macOS Ventura 13.2.1 (22D68) [Darwin 22.3.0]
Apple M1 Max, 1 CPU, 10 logical and 10 physical cores
.NET SDK=7.0.200
  [Host]     : .NET 7.0.3 (7.0.323.6910), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 7.0.3 (7.0.323.6910), Arm64 RyuJIT AdvSIMD


|                                                          Method |     Mean |    Error |   StdDev |
|---------------------------------------------------------------- |---------:|---------:|---------:|
|                                                  SingleThreaded | 28.01 ms | 0.125 ms | 0.098 ms |
|                                         ParallelUponDeserialize | 33.15 ms | 0.631 ms | 0.751 ms |
|                                      ParallelUponGetOccurrences | 31.07 ms | 0.522 ms | 0.488 ms |
| ParallelDeserializeSequentialGatherEventsParallelGetOccurrences | 32.36 ms | 0.620 ms | 0.806 ms |
```