### PR TITLE
Minor fix for relative uri's for dotnet 7

### DIFF
--- a/src/Ical.Net/Serialization/DataTypes/AttachmentSerializer.cs
+++ b/src/Ical.Net/Serialization/DataTypes/AttachmentSerializer.cs
@@ -10,7 +10,7 @@ namespace Ical.Net.Serialization.DataTypes
 
         public AttachmentSerializer(SerializationContext ctx) : base(ctx) { }
 
-        public override Type TargetType => typeof (Attachment);
+        public override Type TargetType => typeof(Attachment);
 
         public override string SerializeToString(object obj)
         {
@@ -72,7 +72,8 @@ namespace Ical.Net.Serialization.DataTypes
                 // The default VALUE type for attachments is URI.  So, let's
                 // grab the URI by default.
                 var uriValue = Decode(a, attachment);
-                a.Uri = new Uri(uriValue);
+                a.Uri = new Uri(uriValue, UriKind.RelativeOrAbsolute);
+
 
                 return a;
             }

--- a/src/Ical.Net/Serialization/DataTypes/UriSerializer.cs
+++ b/src/Ical.Net/Serialization/DataTypes/UriSerializer.cs
@@ -6,11 +6,11 @@ namespace Ical.Net.Serialization.DataTypes
 {
     public class UriSerializer : EncodableDataTypeSerializer
     {
-        public UriSerializer() {}
+        public UriSerializer() { }
 
-        public UriSerializer(SerializationContext ctx) : base(ctx) {}
+        public UriSerializer(SerializationContext ctx) : base(ctx) { }
 
-        public override Type TargetType => typeof (string);
+        public override Type TargetType => typeof(string);
 
         public override string SerializeToString(object obj)
         {
@@ -19,7 +19,7 @@ namespace Ical.Net.Serialization.DataTypes
                 return null;
             }
 
-            var uri = (Uri) obj;
+            var uri = (Uri)obj;
 
             if (SerializationContext.Peek() is ICalendarObject co)
             {
@@ -52,10 +52,10 @@ namespace Ical.Net.Serialization.DataTypes
 
             try
             {
-                var uri = new Uri(value);
+                var uri = new Uri(value, UriKind.RelativeOrAbsolute);
                 return uri;
             }
-            catch {}
+            catch { }
             return null;
         }
     }


### PR DESCRIPTION
Since dotnet 7 Microsoft set the default behavior in the uri constructor to `UriKind.Absolute` to be able to support both again i've overwritten the default with `UriKind.RelativeOrAbsolute` this way relative uri's and uri's withour `http` can also be used again from dotnet 7 and higher.

![grafik](https://user-images.githubusercontent.com/36736700/228047537-d7c17264-8b98-4f97-b2d3-4f9180fb7ee5.png)
