### PR TITLE
Keep apart `VEVENT.DTEND` and `.DURATION`

### DIFF
--- a/Ical.Net.Tests/CalendarEventTest.cs
+++ b/Ical.Net.Tests/CalendarEventTest.cs
@@ -469,4 +469,81 @@ END:VCALENDAR";
         var expectedNegative = TimeSpan.FromMinutes(-17.5);
         Assert.That(negativeOffset?.Offset, Is.EqualTo(expectedNegative));
     }
+
+
+    [Test, Category("CalendarEvent")]
+    public void TestGetEffectiveDuration()
+    {
+        var now = _now.Subtract(TimeSpan.FromTicks(_now.Ticks % TimeSpan.TicksPerSecond));
+
+        var evt = new CalendarEvent()
+        {
+            DtStart = new CalDateTime(now) { HasTime = true },
+            DtEnd = new CalDateTime(now.AddHours(1)) { HasTime = true },
+        };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(evt.DtStart.Value, Is.EqualTo(now));
+            Assert.That(evt.DtEnd.Value, Is.EqualTo(now.AddHours(1)));
+            Assert.That(evt.GetFirstDuration(), Is.EqualTo(TimeSpan.FromHours(1)));
+        });
+
+        evt = new CalendarEvent()
+        {
+            DtStart = new CalDateTime(now.Date) { HasTime = true },
+            DtEnd = new CalDateTime(now.Date.AddHours(1)) { HasTime = true },
+        };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(evt.DtStart.Value, Is.EqualTo(now.Date));
+            Assert.That(evt.GetFirstDuration(), Is.EqualTo(TimeSpan.FromHours(1)));
+        });
+
+        evt = new CalendarEvent()
+        {
+            DtStart = new CalDateTime(now.Date) { HasTime = false },
+        };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(evt.DtStart.Value, Is.EqualTo(now.Date));
+            Assert.That(evt.GetFirstDuration(), Is.EqualTo(TimeSpan.FromDays(1)));
+        });
+
+        evt = new CalendarEvent()
+        {
+            DtStart = new CalDateTime(now) { HasTime = true },
+            Duration = TimeSpan.FromHours(2),
+        };
+
+        Assert.Multiple(() => {
+            Assert.That(evt.DtStart.Value, Is.EqualTo(now));
+            Assert.That(evt.DtEnd, Is.Null);
+            Assert.That(evt.GetFirstDuration(), Is.EqualTo(TimeSpan.FromHours(2)));
+        });
+
+        evt = new CalendarEvent()
+        {
+            DtStart = new CalDateTime(now.Date) { HasTime = true },
+            Duration = TimeSpan.FromHours(2),
+        };
+
+        Assert.Multiple(() => {
+            Assert.That(evt.DtStart.Value, Is.EqualTo(now.Date));
+            Assert.That(evt.GetFirstDuration(), Is.EqualTo(TimeSpan.FromHours(2)));
+        });
+
+        evt = new CalendarEvent()
+        {
+            DtStart = new CalDateTime(now.Date) { HasTime = false },
+            Duration = TimeSpan.FromDays(1),
+        };
+
+        Assert.Multiple(() => {
+            Assert.That(evt.DtStart.Value, Is.EqualTo(now.Date));
+            Assert.That(evt.GetFirstDuration(), Is.EqualTo(TimeSpan.FromDays(1)));
+        });
+    }
 }

--- a/Ical.Net.Tests/DeserializationTests.cs
+++ b/Ical.Net.Tests/DeserializationTests.cs
@@ -552,4 +552,26 @@ END:VCALENDAR
             Assert.That(props[i].Value, Is.EqualTo("2." + i));
         }
     }
+
+    [Test]
+    [TestCase(true)]
+    [TestCase(false)]
+    public void KeepApartDtEndAndDuration_Tests(bool useDtEnd)
+    {
+        var calStr = $@"BEGIN:VCALENDAR
+BEGIN:VEVENT
+DTSTART:20070406T230000Z
+{(useDtEnd ? "DTEND:20070407T010000Z" : "DURATION:PT1H")}
+END:VEVENT
+END:VCALENDAR
+";
+
+        var calendar = Calendar.Load(calStr);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(calendar.Events.Single().DtEnd != null, Is.EqualTo(useDtEnd));
+            Assert.That(calendar.Events.Single().Duration != default, Is.EqualTo(!useDtEnd));
+        });
+    }
 }

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -3728,4 +3728,34 @@ END:VCALENDAR
 
         Assert.That(startDates, Is.EqualTo(testCase.Instances));
     }
+
+    [Test]
+    // Reproducer from https://github.com/ical-org/ical.net/issues/629
+    public void ShouldCreateARecurringYearlyEvent()
+    {
+        var springAdminEvent = new CalendarEvent
+        {
+            Start = new CalDateTime(DateTime.Parse("2024-04-15")),
+            End = new CalDateTime(DateTime.Parse("2024-04-15")),
+            RecurrenceRules = new List<RecurrencePattern> { new RecurrencePattern(FrequencyType.Yearly, 1) },
+        };
+
+        var calendar = new Calendar();
+        calendar.Events.Add(springAdminEvent);
+        var searchStart = DateTime.Parse("2024-04-15");
+        var searchEnd = DateTime.Parse("2050-5-31");
+        var occurrences = calendar.GetOccurrences(searchStart, searchEnd);
+        Assert.That(occurrences.Count, Is.EqualTo(27));
+
+        springAdminEvent.Start = new CalDateTime(DateTime.Parse("2024-04-16"));
+        springAdminEvent.End = new CalDateTime(DateTime.Parse("2024-04-16"));
+        springAdminEvent.RecurrenceRules = new List<RecurrencePattern> { new RecurrencePattern(FrequencyType.Yearly, 1) };
+
+        searchStart = DateTime.Parse("2024-04-16");
+        searchEnd = DateTime.Parse("2050-5-31");
+        occurrences = calendar.GetOccurrences(searchStart, searchEnd);
+
+        //occurences is 26 here, omitting 4/16/2024
+        Assert.That(occurrences.Count, Is.EqualTo(27));
+    }
 }

--- a/Ical.Net.Tests/SymmetricSerializationTests.cs
+++ b/Ical.Net.Tests/SymmetricSerializationTests.cs
@@ -25,7 +25,7 @@ public class SymmetricSerializationTests
     private static readonly DateTime _later = _nowTime.AddHours(1);
     private static CalendarSerializer GetNewSerializer() => new CalendarSerializer();
     private static string SerializeToString(Calendar c) => GetNewSerializer().SerializeToString(c);
-    private static CalendarEvent GetSimpleEvent() => new CalendarEvent { DtStart = new CalDateTime(_nowTime), DtEnd = new CalDateTime(_later), Duration = _later - _nowTime };
+    private static CalendarEvent GetSimpleEvent() => new CalendarEvent { DtStart = new CalDateTime(_nowTime), DtEnd = new CalDateTime(_later) };
     private static Calendar UnserializeCalendar(string s) => Calendar.Load(s);
 
     [Test, TestCaseSource(nameof(Event_TestCases))]
@@ -53,7 +53,6 @@ public class SymmetricSerializationTests
         {
             DtStart = new CalDateTime(_nowTime),
             DtEnd = new CalDateTime(_later),
-            Duration = TimeSpan.FromHours(1),
             RecurrenceRules = new List<RecurrencePattern> { rrule },
         };
 

--- a/Ical.Net.Tests/SymmetricSerializationTests.cs
+++ b/Ical.Net.Tests/SymmetricSerializationTests.cs
@@ -25,7 +25,17 @@ public class SymmetricSerializationTests
     private static readonly DateTime _later = _nowTime.AddHours(1);
     private static CalendarSerializer GetNewSerializer() => new CalendarSerializer();
     private static string SerializeToString(Calendar c) => GetNewSerializer().SerializeToString(c);
-    private static CalendarEvent GetSimpleEvent() => new CalendarEvent { DtStart = new CalDateTime(_nowTime), DtEnd = new CalDateTime(_later) };
+    private static CalendarEvent GetSimpleEvent(bool useDtEnd = true)
+    {
+        var evt = new CalendarEvent { DtStart = new CalDateTime(_nowTime) };
+        if (useDtEnd)
+            evt.DtEnd = new CalDateTime(_later);
+        else
+            evt.Duration = _later - _nowTime;
+
+        return evt;
+    }
+
     private static Calendar UnserializeCalendar(string s) => Calendar.Load(s);
 
     [Test, TestCaseSource(nameof(Event_TestCases))]
@@ -48,23 +58,32 @@ public class SymmetricSerializationTests
 
     public static IEnumerable<ITestCaseData> Event_TestCases()
     {
+        return Event_TestCasesInt(true).Concat(Event_TestCasesInt(false));
+    }
+
+    private static IEnumerable<ITestCaseData> Event_TestCasesInt(bool useDtEnd)
+    {
         var rrule = new RecurrencePattern(FrequencyType.Daily, 1) { Count = 5 };
         var e = new CalendarEvent
         {
             DtStart = new CalDateTime(_nowTime),
-            DtEnd = new CalDateTime(_later),
             RecurrenceRules = new List<RecurrencePattern> { rrule },
         };
 
+        if (useDtEnd)
+            e.DtEnd = new CalDateTime(_later);
+        else
+            e.Duration = _later - _nowTime;
+
         var calendar = new Calendar();
         calendar.Events.Add(e);
-        yield return new TestCaseData(calendar).SetName("readme.md example");
+        yield return new TestCaseData(calendar).SetName($"readme.md example with {(useDtEnd ? "DTEND" : "DURATION")}");
 
-        e = GetSimpleEvent();
+        e = GetSimpleEvent(useDtEnd);
         e.Description = "This is an event description that is really rather long. Hopefully the line breaks work now, and it's serialized properly.";
         calendar = new Calendar();
         calendar.Events.Add(e);
-        yield return new TestCaseData(calendar).SetName("Description serialization isn't working properly. Issue #60");
+        yield return new TestCaseData(calendar).SetName($"Description serialization isn't working properly. Issue #60 {(useDtEnd ? "DTEND" : "DURATION")}");
     }
 
     [Test]

--- a/Ical.Net/CalendarComponents/CalendarEvent.cs
+++ b/Ical.Net/CalendarComponents/CalendarEvent.cs
@@ -275,7 +275,6 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
          *   -1 = Anybody, stack overflow could maybe still occur in this case?
          *    0 = End
          *	  1 = Duration
-         *	  2 = DtStart
          */
         if (DtEnd == null && DtStart != null && Duration != default(TimeSpan) && source != 0)
         {
@@ -284,10 +283,6 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
         else if (Duration == default(TimeSpan) && DtStart != null && DtEnd != null && source != 1)
         {
             Duration = DtEnd.Subtract(DtStart);
-        }
-        else if (DtStart == null && Duration != default(TimeSpan) && DtEnd != null && source != 2)
-        {
-            DtStart = DtEnd.Subtract(Duration);
         }
     }
 

--- a/Ical.Net/Evaluation/EventEvaluator.cs
+++ b/Ical.Net/Evaluation/EventEvaluator.cs
@@ -45,19 +45,19 @@ public class EventEvaluator : RecurringEvaluator
 
         foreach (var period in Periods)
         {
-            period.Duration = CalendarEvent.Duration;
+            period.Duration = CalendarEvent.GetFirstDuration();
             period.EndTime = period.Duration == default
                 ? period.StartTime
-                : period.StartTime.Add(CalendarEvent.Duration);
+                : period.StartTime.Add(CalendarEvent.GetFirstDuration());
         }
 
         // Ensure each period has a duration
         foreach (var period in Periods.Where(p => p.EndTime == null))
         {
-            period.Duration = CalendarEvent.Duration;
+            period.Duration = CalendarEvent.GetFirstDuration();
             period.EndTime = period.Duration == default
                 ? period.StartTime
-                : period.StartTime.Add(CalendarEvent.Duration);
+                : period.StartTime.Add(CalendarEvent.GetFirstDuration());
         }
 
         return Periods;


### PR DESCRIPTION
Fixes https://github.com/ical-org/ical.net/issues/574
Fixes https://github.com/ical-org/ical.net/issues/629

According to RFC 5545 `VEVENT`'s properties `DTEND` and `DURATION` cannot be calculated from each other, because the evaluation rules are slightly different. The previous implementation of `CalendarEvent` extrapolated both values based on each other, and as a consequence remove the information, which of both was originally specified.

With this PR the extrapolation only happens on the fly when needed but only the originally specified property is stored. The additional information is not used for any calculations so far, but can in the future.

DISCUSS: This is a breaking change, as uses might expect DtEnd to be calculated from Duration and vice versa. An alternative would be to keep the behavior of the properties as is but calculate fallback on the fly when needed rather than upfront. That way the `CalendarEvent.DtEnd` and `.Duration` properties would behave as before but the serialized versions might still be slightly different. However, the behavior would be less transparent and potentially confuse new users. TBD