### PR TITLE
Migrated Ical.Net.Tests project from NUnit3 to NUnit 4

### DIFF
--- a/Ical.Net.Tests/AlarmTest.cs
+++ b/Ical.Net.Tests/AlarmTest.cs
@@ -25,9 +25,9 @@ namespace Ical.Net.Tests
             //Only compare the UTC values here, since we care about the time coordinate when the alarm fires, and nothing else
             foreach (var alarm in alarms.Select(a => a.DateTime.AsUtc))
             {
-                Assert.IsTrue(utcDates.Contains(alarm), "Alarm triggers at " + alarm + ", but it should not.");
+                Assert.That(utcDates.Contains(alarm), Is.True, "Alarm triggers at " + alarm + ", but it should not.");
             }
-            Assert.IsTrue(dates.Count == alarms.Count, "There were " + alarms.Count + " alarm occurrences; there should have been " + dates.Count + ".");
+            Assert.That(dates.Count == alarms.Count, Is.True, "There were " + alarms.Count + " alarm occurrences; there should have been " + dates.Count + ".");
         }
 
         [Test, Category("Alarm")]

--- a/Ical.Net.Tests/AttendeeTest.cs
+++ b/Ical.Net.Tests/AttendeeTest.cs
@@ -42,26 +42,29 @@ namespace Ical.Net.Tests
         public void Add1Attendee()
         {
             var evt = VEventFactory();
-            Assert.AreEqual(0, evt.Attendees.Count);
+            Assert.That(evt.Attendees.Count, Is.EqualTo(0));
 
             evt.Attendees.Add(_attendees[0]);
-            Assert.AreEqual(1, evt.Attendees.Count);
+            Assert.That(evt.Attendees, Has.Count.EqualTo(1));
 
-            //the properties below had been set to null during the Attendees.Add operation in NuGet version 2.1.4
-            Assert.AreEqual(ParticipationRole.RequiredParticipant, evt.Attendees[0].Role);
-            Assert.AreEqual(EventParticipationStatus.Tentative, evt.Attendees[0].ParticipationStatus);
+            Assert.Multiple(() =>
+            {
+                //the properties below had been set to null during the Attendees.Add operation in NuGet version 2.1.4
+                Assert.That(evt.Attendees[0].Role, Is.EqualTo(ParticipationRole.RequiredParticipant));
+                Assert.That(evt.Attendees[0].ParticipationStatus, Is.EqualTo(EventParticipationStatus.Tentative));
+            });
         }
 
         [Test, Category("Attendee")]
         public void Add2Attendees()
         {
             var evt = VEventFactory();
-            Assert.AreEqual(0, evt.Attendees.Count);
+            Assert.That(evt.Attendees.Count, Is.EqualTo(0));
 
             evt.Attendees.Add(_attendees[0]);
             evt.Attendees.Add(_attendees[1]);
-            Assert.AreEqual(2, evt.Attendees.Count);
-            Assert.AreEqual(ParticipationRole.RequiredParticipant, evt.Attendees[1].Role);
+            Assert.That(evt.Attendees, Has.Count.EqualTo(2));
+            Assert.That(evt.Attendees[1].Role, Is.EqualTo(ParticipationRole.RequiredParticipant));
         }
 
         /// <summary>
@@ -71,17 +74,17 @@ namespace Ical.Net.Tests
         public void Remove1Attendee()
         {
             var evt = VEventFactory();
-            Assert.AreEqual(0, evt.Attendees.Count);
+            Assert.That(evt.Attendees.Count, Is.EqualTo(0));
 
             var attendee = _attendees.First();
             evt.Attendees.Add(attendee);
-            Assert.AreEqual(1, evt.Attendees.Count);
+            Assert.That(evt.Attendees, Has.Count.EqualTo(1));
 
             evt.Attendees.Remove(attendee);
-            Assert.AreEqual(0, evt.Attendees.Count);
+            Assert.That(evt.Attendees.Count, Is.EqualTo(0));
 
             evt.Attendees.Remove(_attendees.Last());
-            Assert.AreEqual(0, evt.Attendees.Count);
+            Assert.That(evt.Attendees.Count, Is.EqualTo(0));
         }
     }
 }

--- a/Ical.Net.Tests/CalDateTimeTests.cs
+++ b/Ical.Net.Tests/CalDateTimeTests.cs
@@ -1,8 +1,8 @@
 ﻿using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
 using NUnit.Framework;
-using NUnit.Framework.Interfaces;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace Ical.Net.Tests
@@ -36,10 +36,10 @@ namespace Ical.Net.Tests
             var convertedStart = calendarEvent.Start.ToTimeZone(targetTimeZone);
             var convertedAsUtc = convertedStart.AsUtc;
 
-            Assert.AreEqual(startAsUtc, convertedAsUtc);
+            Assert.That(convertedAsUtc, Is.EqualTo(startAsUtc));
         }
 
-        public static IEnumerable<ITestCaseData> ToTimeZoneTestCases()
+        public static IEnumerable ToTimeZoneTestCases()
         {
             const string bclCst = "Central Standard Time";
             const string bclEastern = "Eastern Standard Time";
@@ -70,7 +70,7 @@ namespace Ical.Net.Tests
         public DateTimeOffset AsDateTimeOffsetTests(CalDateTime incoming)
             => incoming.AsDateTimeOffset;
 
-        public static IEnumerable<ITestCaseData> AsDateTimeOffsetTestCases()
+        public static IEnumerable AsDateTimeOffsetTestCases()
         {
             const string nyTzId = "America/New_York";
             var summerDate = DateTime.Parse("2018-05-15T11:00");
@@ -106,18 +106,18 @@ namespace Ical.Net.Tests
 
             var someDt = new CalDateTime(someTime.DateTime) { TzId = "America/New_York" };
             var firstUtc = someDt.AsUtc;
-            Assert.AreEqual(someTime.UtcDateTime, firstUtc);
+            Assert.That(firstUtc, Is.EqualTo(someTime.UtcDateTime));
 
             someDt.TzId = "Europe/Berlin";
             var berlinUtc = someDt.AsUtc;
-            Assert.AreNotEqual(firstUtc, berlinUtc);
+            Assert.That(berlinUtc, Is.Not.EqualTo(firstUtc));
         }
 
         [Test, TestCaseSource(nameof(DateTimeKindOverrideTestCases))]
         public DateTimeKind DateTimeKindOverrideTests(DateTime dateTime, string tzId)
             => new CalDateTime(dateTime, tzId).Value.Kind;
 
-        public static IEnumerable<ITestCaseData> DateTimeKindOverrideTestCases()
+        public static IEnumerable DateTimeKindOverrideTestCases()
         {
             const string localTz = "America/New_York";
             var localDt = DateTime.SpecifyKind(DateTime.Parse("2018-05-21T11:35:33"), DateTimeKind.Local);

--- a/Ical.Net.Tests/CalendarEventTest.cs
+++ b/Ical.Net.Tests/CalendarEventTest.cs
@@ -1,9 +1,9 @@
-using Ical.Net.CalendarComponents;
+﻿using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
 using Ical.Net.Serialization;
 using NUnit.Framework;
-using NUnit.Framework.Interfaces;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -32,8 +32,8 @@ namespace Ical.Net.Tests
             };
 
             cal.Events.Add(evt);
-            Assert.AreEqual(1, cal.Children.Count);
-            Assert.AreSame(evt, cal.Children[0]);
+            Assert.That(cal.Children, Has.Count.EqualTo(1));
+            Assert.That(cal.Children[0], Is.SameAs(evt));
         }
 
         /// <summary>
@@ -52,12 +52,17 @@ namespace Ical.Net.Tests
             };
 
             cal.Events.Add(evt);
-            Assert.AreEqual(1, cal.Children.Count);
-            Assert.AreSame(evt, cal.Children[0]);
-
+            Assert.Multiple(() =>
+            {
+                Assert.That(cal.Children, Has.Count.EqualTo(1));
+                Assert.That(cal.Children[0], Is.SameAs(evt));
+            });
             cal.RemoveChild(evt);
-            Assert.AreEqual(0, cal.Children.Count);
-            Assert.AreEqual(0, cal.Events.Count);
+            Assert.Multiple(() =>
+            {
+                Assert.That(cal.Children.Count, Is.EqualTo(0));
+                Assert.That(cal.Events.Count, Is.EqualTo(0));
+            });
         }
 
         /// <summary>
@@ -76,12 +81,18 @@ namespace Ical.Net.Tests
             };
 
             cal.Events.Add(evt);
-            Assert.AreEqual(1, cal.Children.Count);
-            Assert.AreSame(evt, cal.Children[0]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(cal.Children, Has.Count.EqualTo(1));
+                Assert.That(cal.Children[0], Is.SameAs(evt));
+            });
 
             cal.Events.Remove(evt);
-            Assert.AreEqual(0, cal.Children.Count);
-            Assert.AreEqual(0, cal.Events.Count);
+            Assert.Multiple(() =>
+            {
+                Assert.That(cal.Children.Count, Is.EqualTo(0));
+                Assert.That(cal.Events.Count, Is.EqualTo(0));
+            });
         }
 
         /// <summary>
@@ -101,7 +112,7 @@ namespace Ical.Net.Tests
             };
 
             cal.Events.Add(evt);
-            Assert.IsNotNull(evt.DtStamp);
+            Assert.That(evt.DtStamp, Is.Not.Null);
         }
 
         /// <summary>
@@ -120,7 +131,7 @@ namespace Ical.Net.Tests
             };
 
             cal.Events.Add(evt);
-            Assert.IsTrue(evt.DtStamp.IsUtc, "DTSTAMP should always be of type UTC.");
+            Assert.That(evt.DtStamp.IsUtc, Is.True, "DTSTAMP should always be of type UTC.");
         }
 
         /// <summary>
@@ -135,7 +146,7 @@ namespace Ical.Net.Tests
             return !result.Contains("TZID=") && result.EndsWith("Z");
         }
 
-        public static IEnumerable<ITestCaseData> EnsureAutomaticallySetDtStampIsSerializedAsUtcKind_TestCases()
+        public static IEnumerable EnsureAutomaticallySetDtStampIsSerializedAsUtcKind_TestCases()
         {
             var emptyCalendar = new Calendar();
             var evt = new CalendarEvent();
@@ -210,8 +221,8 @@ END:VCALENDAR";
             var noException = Calendar.Load(icalNoException).Events.First();
             var withException = Calendar.Load(icalWithException).Events.First();
 
-            Assert.AreNotEqual(noException, withException);
-            Assert.AreNotEqual(noException.GetHashCode(), withException.GetHashCode());
+            Assert.That(withException, Is.Not.EqualTo(noException));
+            Assert.That(withException.GetHashCode(), Is.Not.EqualTo(noException.GetHashCode()));
         }
 
         private static CalendarEvent GetSimpleEvent() => new CalendarEvent
@@ -229,13 +240,13 @@ END:VCALENDAR";
             testRrule.RecurrenceRules = new List<RecurrencePattern> { rrule };
 
             var simpleEvent = GetSimpleEvent();
-            Assert.AreNotEqual(simpleEvent, testRrule);
-            Assert.AreNotEqual(simpleEvent.GetHashCode(), testRrule.GetHashCode());
+            Assert.That(testRrule, Is.Not.EqualTo(simpleEvent));
+            Assert.That(testRrule.GetHashCode(), Is.Not.EqualTo(simpleEvent.GetHashCode()));
 
             var testRdate = GetSimpleEvent();
             testRdate.RecurrenceDates = new List<PeriodList> { new PeriodList { new Period(new CalDateTime(_now)) } };
-            Assert.AreNotEqual(simpleEvent, testRdate);
-            Assert.AreNotEqual(simpleEvent.GetHashCode(), testRdate.GetHashCode());
+            Assert.That(testRdate, Is.Not.EqualTo(simpleEvent));
+            Assert.That(testRdate.GetHashCode(), Is.Not.EqualTo(simpleEvent.GetHashCode()));
         }
 
         private static List<RecurrencePattern> GetSimpleRecurrenceList()
@@ -263,13 +274,16 @@ END:VCALENDAR";
             var eventA = calendar.Events.First();
             var eventB = cal2.Events.First();
 
-            Assert.AreEqual(eventA.RecurrenceRules.First(), eventB.RecurrenceRules.First());
-            Assert.AreEqual(eventA.RecurrenceRules.First().GetHashCode(), eventB.RecurrenceRules.First().GetHashCode());
-            Assert.AreEqual(eventA.ExceptionDates.First(), eventB.ExceptionDates.First());
-            Assert.AreEqual(eventA.ExceptionDates.First().GetHashCode(), eventB.ExceptionDates.First().GetHashCode());
-            Assert.AreEqual(eventA.GetHashCode(), eventB.GetHashCode());
-            Assert.AreEqual(eventA, eventB);
-            Assert.AreEqual(calendar, cal2);
+            Assert.Multiple(() =>
+            {
+                Assert.That(eventB.RecurrenceRules.First(), Is.EqualTo(eventA.RecurrenceRules.First()));
+                Assert.That(eventB.RecurrenceRules.First().GetHashCode(), Is.EqualTo(eventA.RecurrenceRules.First().GetHashCode()));
+                Assert.That(eventB.ExceptionDates.First(), Is.EqualTo(eventA.ExceptionDates.First()));
+                Assert.That(eventB.ExceptionDates.First().GetHashCode(), Is.EqualTo(eventA.ExceptionDates.First().GetHashCode()));
+                Assert.That(eventB.GetHashCode(), Is.EqualTo(eventA.GetHashCode()));
+                Assert.That(eventB, Is.EqualTo(eventA));
+                Assert.That(cal2, Is.EqualTo(calendar));
+            });
         }
 
         [Test]
@@ -288,15 +302,18 @@ END:VCALENDAR";
             cal1.Events.Add(vEvent);
             var serialized = serializer.SerializeToString(cal1);
             var deserializedNoExDate = Calendar.Load(serialized);
-            Assert.AreEqual(cal1, deserializedNoExDate);
+            Assert.That(deserializedNoExDate, Is.EqualTo(cal1));
 
             vEvent.ExceptionDates = GetExceptionDates();
             serialized = serializer.SerializeToString(cal1);
             var deserializedWithExDate = Calendar.Load(serialized);
 
-            Assert.AreNotEqual(deserializedNoExDate.Events.First(), deserializedWithExDate.Events.First());
-            Assert.AreNotEqual(deserializedNoExDate.Events.First().GetHashCode(), deserializedWithExDate.Events.First().GetHashCode());
-            Assert.AreNotEqual(deserializedNoExDate, deserializedWithExDate);
+            Assert.Multiple(() =>
+            {
+                Assert.That(deserializedWithExDate.Events.First(), Is.Not.EqualTo(deserializedNoExDate.Events.First()));
+                Assert.That(deserializedWithExDate.Events.First().GetHashCode(), Is.Not.EqualTo(deserializedNoExDate.Events.First().GetHashCode()));
+                Assert.That(deserializedWithExDate, Is.Not.EqualTo(deserializedNoExDate));
+            });
         }
 
         [Test]
@@ -307,14 +324,17 @@ END:VCALENDAR";
 
             var eventB = GetSimpleEvent();
             eventB.RecurrenceRules = GetSimpleRecurrenceList();
-            Assert.IsFalse(ReferenceEquals(eventA, eventB));
-            Assert.AreEqual(eventA, eventB);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ReferenceEquals(eventA, eventB), Is.False);
+                Assert.That(eventB, Is.EqualTo(eventA));
+            });
 
             var foreverDailyRule = new RecurrencePattern(FrequencyType.Daily, 1);
             eventB.RecurrenceRules = new List<RecurrencePattern> { foreverDailyRule };
 
-            Assert.AreNotEqual(eventA, eventB);
-            Assert.AreNotEqual(eventA.GetHashCode(), eventB.GetHashCode());
+            Assert.That(eventB, Is.Not.EqualTo(eventA));
+            Assert.That(eventB.GetHashCode(), Is.Not.EqualTo(eventA.GetHashCode()));
         }
 
         [Test]
@@ -367,10 +387,13 @@ END:VCALENDAR";
             var calendarA = Calendar.Load(eventA);
             var calendarB = Calendar.Load(eventB);
 
-            Assert.AreEqual(calendarA.Events.First().GetHashCode(), calendarB.Events.First().GetHashCode());
-            Assert.AreEqual(calendarA.Events.First(), calendarB.Events.First());
-            Assert.AreEqual(calendarA.GetHashCode(), calendarB.GetHashCode());
-            Assert.AreEqual(calendarA, calendarB);
+            Assert.Multiple(() =>
+            {
+                Assert.That(calendarB.Events.First().GetHashCode(), Is.EqualTo(calendarA.Events.First().GetHashCode()));
+                Assert.That(calendarB.Events.First(), Is.EqualTo(calendarA.Events.First()));
+                Assert.That(calendarB.GetHashCode(), Is.EqualTo(calendarA.GetHashCode()));
+                Assert.That(calendarB, Is.EqualTo(calendarA));
+            });
         }
 
         [Test]
@@ -380,16 +403,19 @@ END:VCALENDAR";
             var resources = new[] { "Foo", "Bar", "Baz" };
 
             e.Resources = new List<string>(resources);
-            CollectionAssert.AreEquivalent(e.Resources, resources);
+            Assert.That(resources, Is.EquivalentTo(e.Resources));
 
             var newResources = new[] { "Hello", "Goodbye" };
             e.Resources = new List<string>(newResources);
-            CollectionAssert.AreEquivalent(e.Resources, newResources);
-            Assert.IsFalse(e.Resources.Any(r => resources.Contains(r)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(newResources, Is.EquivalentTo(e.Resources));
+                Assert.That(e.Resources.Any(r => resources.Contains(r)), Is.False);
+            });
 
             e.Resources = null;
             //See https://github.com/rianjs/ical.net/issues/208 -- this should be changed later so the collection is really null
-            Assert.AreEqual(0, e.Resources?.Count);
+            Assert.That(e.Resources?.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -429,14 +455,14 @@ END:VCALENDAR";
                 .Skip(1).Take(1).First()
                 .Properties.First().Value as UtcOffset;
             var expectedPositive = TimeSpan.FromMinutes(17.5);
-            Assert.AreEqual(expectedPositive, positiveOffset?.Offset);
+            Assert.That(positiveOffset?.Offset, Is.EqualTo(expectedPositive));
 
             var negativeOffset = timezones
                 .First()
                 .Properties.First().Value as UtcOffset;
 
             var expectedNegative = TimeSpan.FromMinutes(-17.5);
-            Assert.AreEqual(expectedNegative, negativeOffset?.Offset);
+            Assert.That(negativeOffset?.Offset, Is.EqualTo(expectedNegative));
         }
     }
 }

--- a/Ical.Net.Tests/CalendarPropertiesTest.cs
+++ b/Ical.Net.Tests/CalendarPropertiesTest.cs
@@ -23,7 +23,7 @@ namespace Ical.Net.Tests
 
             var lines = result.Split(new [] { SerializationConstants.LineBreak }, StringSplitOptions.None);
             var propLine = lines.FirstOrDefault(x => x.StartsWith("X-WR-CALNAME:"));
-            Assert.AreEqual($"{propName}:{propValue}", propLine);
+            Assert.That(propLine, Is.EqualTo($"{propName}:{propValue}"));
         }
 
         [Test]
@@ -47,7 +47,7 @@ namespace Ical.Net.Tests
             calendar.Events.Add(@event);
 
             var serialized = new CalendarSerializer().SerializeToString(calendar);
-            Assert.IsTrue(serialized.Contains("X-ALT-DESC;"));
+            Assert.That(serialized.Contains("X-ALT-DESC;"), Is.True);
         }
 
         [Test]

--- a/Ical.Net.Tests/CollectionHelpersTests.cs
+++ b/Ical.Net.Tests/CollectionHelpersTests.cs
@@ -20,14 +20,17 @@ namespace Ical.Net.Tests
         [Test]
         public void ExDateTests()
         {
-            Assert.AreEqual(GetExceptionDates(), GetExceptionDates());
-            Assert.AreNotEqual(GetExceptionDates(), null);
-            Assert.AreNotEqual(null, GetExceptionDates());
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetExceptionDates(), Is.EqualTo(GetExceptionDates()));
+                Assert.That(GetExceptionDates(), Is.Not.Null);
+                Assert.That(GetExceptionDates(), Is.Not.EqualTo(null));
+            });
 
             var changedPeriod = GetExceptionDates();
             changedPeriod.First().First().StartTime = new CalDateTime(_now.AddHours(-1));
 
-            Assert.AreNotEqual(GetExceptionDates(), changedPeriod);
+            Assert.That(changedPeriod, Is.Not.EqualTo(GetExceptionDates()));
         }
     }
 }

--- a/Ical.Net.Tests/ComponentTest.cs
+++ b/Ical.Net.Tests/ComponentTest.cs
@@ -13,9 +13,9 @@ namespace Ical.Net.Tests
             var iCal = new Calendar();
             var evt = iCal.Create<CalendarEvent>();
 
-            Assert.IsNotNull(evt.Uid);
-            Assert.IsNull(evt.Created); // We don't want this to be set automatically
-            Assert.IsNotNull(evt.DtStamp);
+            Assert.That(evt.Uid, Is.Not.Null);
+            Assert.That(evt.Created, Is.Null); // We don't want this to be set automatically
+            Assert.That(evt.DtStamp, Is.Not.Null);
         }
 
         [Test, Category("Components")]
@@ -36,8 +36,11 @@ namespace Ical.Net.Tests
             var secondStartAsUtc = e.Start.AsUtc;
             var secondEndAsUtc = e.End.AsUtc;
 
-            Assert.AreNotEqual(firstStartAsUtc, secondStartAsUtc);
-            Assert.AreNotEqual(firstEndAsUtc, secondEndAsUtc);
+            Assert.Multiple(() =>
+            {
+                Assert.That(secondStartAsUtc, Is.Not.EqualTo(firstStartAsUtc));
+                Assert.That(secondEndAsUtc, Is.Not.EqualTo(firstEndAsUtc));
+            });
         }
     }
 }

--- a/Ical.Net.Tests/ConcurrentDeserializationTests.cs
+++ b/Ical.Net.Tests/ConcurrentDeserializationTests.cs
@@ -21,7 +21,7 @@ namespace Ical.Net.Tests
 
             var deserializedCalendars = calendars.AsParallel().SelectMany(CalendarCollection.Load);
             var materialized = deserializedCalendars.ToList();
-            Assert.AreEqual(5, materialized.Count);
+            Assert.That(materialized, Has.Count.EqualTo(5));
         }
     }
 }

--- a/Ical.Net.Tests/CopyTest.cs
+++ b/Ical.Net.Tests/CopyTest.cs
@@ -1,10 +1,9 @@
-using Ical.Net.CalendarComponents;
+﻿using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
 using Ical.Net.Serialization;
 using NUnit.Framework;
-using NUnit.Framework.Interfaces;
 using System;
-using System.Collections.Generic;
+using System.Collections;
 using System.Text.RegularExpressions;
 
 namespace Ical.Net.Tests
@@ -20,7 +19,7 @@ namespace Ical.Net.Tests
             SerializationTests.CompareCalendars(iCal1, iCal2);
         }
 
-        public static IEnumerable<ITestCaseData> CopyCalendarTest_TestCases()
+        public static IEnumerable CopyCalendarTest_TestCases()
         {
             yield return new TestCaseData(IcsFiles.Attachment3).SetName("Attachment3");
             yield return new TestCaseData(IcsFiles.Bug2148092).SetName("Bug2148092");
@@ -63,16 +62,16 @@ namespace Ical.Net.Tests
             var e = GetSimpleEvent();
             e.Uid = "Hello";
             var copy = e.Copy<CalendarEvent>();
-            Assert.AreEqual(e.Uid, copy.Uid);
+            Assert.That(copy.Uid, Is.EqualTo(e.Uid));
 
             copy.Uid = "Goodbye";
 
             const string uidPattern = "UID:";
             var serializedOrig = SerializeEvent(e);
-            Assert.AreEqual(1, Regex.Matches(serializedOrig, uidPattern).Count);
+            Assert.That(Regex.Matches(serializedOrig, uidPattern), Has.Count.EqualTo(1));
 
             var serializedCopy = SerializeEvent(copy);
-            Assert.AreEqual(1, Regex.Matches(serializedCopy, uidPattern).Count);
+            Assert.That(Regex.Matches(serializedCopy, uidPattern), Has.Count.EqualTo(1));
         }
     }
 }

--- a/Ical.Net.Tests/DateTimeSerializerTests.cs
+++ b/Ical.Net.Tests/DateTimeSerializerTests.cs
@@ -17,7 +17,7 @@ namespace Ical.Net.Tests
                 new CalDateTime(new DateTime(1997, 7, 14, 13, 30, 0, DateTimeKind.Local), "US-Eastern"));
 
             // TZID is applied elsewhere - just make sure this doesn't have 'Z' appended. 
-            Assert.AreEqual("19970714T133000", result);
+            Assert.That(result, Is.EqualTo("19970714T133000"));
         }
     }
 }

--- a/Ical.Net.Tests/DeserializationTests.cs
+++ b/Ical.Net.Tests/DeserializationTests.cs
@@ -1,4 +1,4 @@
-using Ical.Net.CalendarComponents;
+﻿using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
 using Ical.Net.Serialization;
 using Ical.Net.Serialization.DataTypes;
@@ -19,32 +19,40 @@ namespace Ical.Net.Tests
         public void Attendee1()
         {
             var iCal = Calendar.Load(IcsFiles.Attendee1);
-            Assert.AreEqual(1, iCal.Events.Count);
+            Assert.That(iCal.Events, Has.Count.EqualTo(1));
 
             var evt = iCal.Events.First();
             // Ensure there are 2 attendees
-            Assert.AreEqual(2, evt.Attendees.Count);
+            Assert.That(evt.Attendees, Has.Count.EqualTo(2));
 
             var attendee1 = evt.Attendees[0];
             var attendee2 = evt.Attendees[1];
 
-            // Values
-            Assert.AreEqual(new Uri("mailto:joecool@example.com"), attendee1.Value);
-            Assert.AreEqual(new Uri("mailto:ildoit@example.com"), attendee2.Value);
+            Assert.Multiple(() =>
+            {
+                // Values
+                Assert.That(attendee1.Value, Is.EqualTo(new Uri("mailto:joecool@example.com")));
+                Assert.That(attendee2.Value, Is.EqualTo(new Uri("mailto:ildoit@example.com")));
 
-            // MEMBERS
-            Assert.AreEqual(1, attendee1.Members.Count);
-            Assert.AreEqual(0, attendee2.Members.Count);
-            Assert.AreEqual(new Uri("mailto:DEV-GROUP@example.com"), attendee1.Members[0]);
+                // MEMBERS
+                Assert.That(attendee1.Members, Has.Count.EqualTo(1));
+                Assert.That(attendee2.Members.Count, Is.EqualTo(0));
+            });
+            Assert.Multiple(() =>
+            {
+                Assert.That(attendee1.Members[0], Is.EqualTo(new Uri("mailto:DEV-GROUP@example.com").ToString()));
 
-            // DELEGATED-FROM
-            Assert.AreEqual(0, attendee1.DelegatedFrom.Count);
-            Assert.AreEqual(1, attendee2.DelegatedFrom.Count);
-            Assert.AreEqual(new Uri("mailto:immud@example.com"), attendee2.DelegatedFrom[0]);
-
-            // DELEGATED-TO
-            Assert.AreEqual(0, attendee1.DelegatedTo.Count);
-            Assert.AreEqual(0, attendee2.DelegatedTo.Count);
+                // DELEGATED-FROM
+                Assert.That(attendee1.DelegatedFrom.Count, Is.EqualTo(0));
+                Assert.That(attendee2.DelegatedFrom, Has.Count.EqualTo(1));
+                Assert.That(attendee2.DelegatedFrom[0], Is.EqualTo(new Uri("mailto:immud@example.com").ToString()));
+            });
+            Assert.Multiple(() =>
+            {
+                // DELEGATED-TO
+                Assert.That(attendee1.DelegatedTo.Count, Is.EqualTo(0));
+                Assert.That(attendee2.DelegatedTo.Count, Is.EqualTo(0));
+            });
         }
 
         /// <summary>
@@ -56,22 +64,25 @@ namespace Ical.Net.Tests
         public void Attendee2()
         {
             var iCal = Calendar.Load(IcsFiles.Attendee2);
-            Assert.AreEqual(1, iCal.Events.Count);
+            Assert.That(iCal.Events, Has.Count.EqualTo(1));
 
             var evt = iCal.Events.First();
             // Ensure there is 1 attendee
-            Assert.AreEqual(1, evt.Attendees.Count);
+            Assert.That(evt.Attendees, Has.Count.EqualTo(1));
 
             var attendee1 = evt.Attendees;
 
             // Values
-            Assert.AreEqual(new Uri("mailto:joecool@example.com"), attendee1[0].Value);
+            Assert.That(attendee1[0].Value, Is.EqualTo(new Uri("mailto:joecool@example.com")));
 
-            // MEMBERS
-            Assert.AreEqual(3, attendee1[0].Members.Count);
-            Assert.AreEqual(new Uri("mailto:DEV-GROUP@example.com"), attendee1[0].Members[0]);
-            Assert.AreEqual(new Uri("mailto:ANOTHER-GROUP@example.com"), attendee1[0].Members[1]);
-            Assert.AreEqual(new Uri("mailto:THIRD-GROUP@example.com"), attendee1[0].Members[2]);
+            Assert.Multiple(() =>
+            {
+                // MEMBERS
+                Assert.That(attendee1[0].Members, Has.Count.EqualTo(3));
+                Assert.That(attendee1[0].Members[0], Is.EqualTo(new Uri("mailto:DEV-GROUP@example.com").ToString()));
+                Assert.That(attendee1[0].Members[1], Is.EqualTo(new Uri("mailto:ANOTHER-GROUP@example.com").ToString()));
+                Assert.That(attendee1[0].Members[2], Is.EqualTo(new Uri("mailto:THIRD-GROUP@example.com").ToString()));
+            });
         }
 
         /// <summary>
@@ -83,8 +94,11 @@ namespace Ical.Net.Tests
         public void Bug2033495()
         {
             var iCal = Calendar.Load(IcsFiles.Bug2033495);
-            Assert.AreEqual(1, iCal.Events.Count);
-            Assert.AreEqual(iCal.Properties["X-LOTUS-CHILD_UID"].Value, "XXX");
+            Assert.Multiple(() =>
+            {
+                Assert.That(iCal.Events, Has.Count.EqualTo(1));
+                Assert.That(iCal.Properties["X-LOTUS-CHILD_UID"].Value, Is.EqualTo("XXX"));
+            });
         }
 
         /// <summary>
@@ -95,16 +109,22 @@ namespace Ical.Net.Tests
         public void Bug2938007()
         {
             var iCal = Calendar.Load(IcsFiles.Bug2938007);
-            Assert.AreEqual(1, iCal.Events.Count);
+            Assert.That(iCal.Events, Has.Count.EqualTo(1));
 
             var evt = iCal.Events.First();
-            Assert.AreEqual(true, evt.Start.HasTime);
-            Assert.AreEqual(true, evt.End.HasTime);
+            Assert.Multiple(() =>
+            {
+                Assert.That(evt.Start.HasTime, Is.EqualTo(true));
+                Assert.That(evt.End.HasTime, Is.EqualTo(true));
+            });
 
             foreach (var o in evt.GetOccurrences(new CalDateTime(2010, 1, 17, 0, 0, 0), new CalDateTime(2010, 2, 1, 0, 0, 0)))
             {
-                Assert.AreEqual(true, o.Period.StartTime.HasTime);
-                Assert.AreEqual(true, o.Period.EndTime.HasTime);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(o.Period.StartTime.HasTime, Is.EqualTo(true));
+                    Assert.That(o.Period.EndTime.HasTime, Is.EqualTo(true));
+                });
             }
         }
 
@@ -121,7 +141,7 @@ namespace Ical.Net.Tests
             var ms = new MemoryStream();
             serializer.Serialize(calendar, ms, Encoding.UTF8);
 
-            Assert.IsTrue(ms.CanWrite);
+            Assert.That(ms.CanWrite, Is.True);
         }
 
         /// <summary>
@@ -131,7 +151,7 @@ namespace Ical.Net.Tests
         public void CaseInsensitive4()
         {
             var iCal = Calendar.Load(IcsFiles.CaseInsensitive4);
-            Assert.AreEqual("2.5", iCal.Version);
+            Assert.That(iCal.Version, Is.EqualTo("2.5"));
         }
 
         [Test]
@@ -157,7 +177,7 @@ namespace Ical.Net.Tests
 
             foreach (string item in items)
             {
-                Assert.IsTrue(found.ContainsKey(item), "Event should contain CATEGORY '" + item + "', but it was not found.");
+                Assert.That(found.ContainsKey(item), Is.True, "Event should contain CATEGORY '" + item + "', but it was not found.");
             }
         }
 
@@ -165,16 +185,19 @@ namespace Ical.Net.Tests
         public void EmptyLines1()
         {
             var iCal = Calendar.Load(IcsFiles.EmptyLines1);
-            Assert.AreEqual(2, iCal.Events.Count, "iCalendar should have 2 events");
+            Assert.That(iCal.Events, Has.Count.EqualTo(2), "iCalendar should have 2 events");
         }
 
         [Test]
         public void EmptyLines2()
         {
             var calendars = CalendarCollection.Load(IcsFiles.EmptyLines2);
-            Assert.AreEqual(2, calendars.Count);
-            Assert.AreEqual(2, calendars[0].Events.Count, "iCalendar should have 2 events");
-            Assert.AreEqual(2, calendars[1].Events.Count, "iCalendar should have 2 events");
+            Assert.That(calendars, Has.Count.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(calendars[0].Events, Has.Count.EqualTo(2), "iCalendar should have 2 events");
+                Assert.That(calendars[1].Events, Has.Count.EqualTo(2), "iCalendar should have 2 events");
+            });
         }
 
         /// <summary>
@@ -185,7 +208,7 @@ namespace Ical.Net.Tests
         public void EmptyLines3()
         {
             var iCal = Calendar.Load(IcsFiles.EmptyLines3);
-            Assert.AreEqual(1, iCal.Todos.Count, "iCalendar should have 1 todo");
+            Assert.That(iCal.Todos, Has.Count.EqualTo(1), "iCalendar should have 1 todo");
         }
 
         /// <summary>
@@ -195,7 +218,7 @@ namespace Ical.Net.Tests
         public void EmptyLines4()
         {
             var iCal = Calendar.Load(IcsFiles.EmptyLines4);
-            Assert.AreEqual(28, iCal.Events.Count);
+            Assert.That(iCal.Events, Has.Count.EqualTo(28));
         }
 
         [Test]
@@ -205,7 +228,9 @@ namespace Ical.Net.Tests
             ProgramTest.TestCal(iCal);
             var evt = iCal.Events.First();
 
-            Assert.AreEqual(
+            Assert.That(
+evt.Attachments[0].ToString(),
+                Is.EqualTo("This is a test to try out base64 encoding without being too large.\r\n" +
 "This is a test to try out base64 encoding without being too large.\r\n" +
 "This is a test to try out base64 encoding without being too large.\r\n" +
 "This is a test to try out base64 encoding without being too large.\r\n" +
@@ -216,9 +241,7 @@ namespace Ical.Net.Tests
 "This is a test to try out base64 encoding without being too large.\r\n" +
 "This is a test to try out base64 encoding without being too large.\r\n" +
 "This is a test to try out base64 encoding without being too large.\r\n" +
-"This is a test to try out base64 encoding without being too large.\r\n" +
-"This is a test to try out base64 encoding without being too large.",
-                evt.Attachments[0].ToString(),
+"This is a test to try out base64 encoding without being too large."),
                 "Attached value does not match.");
         }
 
@@ -229,8 +252,11 @@ namespace Ical.Net.Tests
             ProgramTest.TestCal(iCal);
             var evt = iCal.Events.First();
 
-            Assert.AreEqual("uuid1153170430406", evt.Uid, "UID should be 'uuid1153170430406'; it is " + evt.Uid);
-            Assert.AreEqual(1, evt.Sequence, "SEQUENCE should be 1; it is " + evt.Sequence);
+            Assert.Multiple(() =>
+            {
+                Assert.That(evt.Uid, Is.EqualTo("uuid1153170430406"), "UID should be 'uuid1153170430406'; it is " + evt.Uid);
+                Assert.That(evt.Sequence, Is.EqualTo(1), "SEQUENCE should be 1; it is " + evt.Sequence);
+            });
         }
 
         [Test]
@@ -267,9 +293,9 @@ END:VEVENT
 END:VCALENDAR
 ";
             var iCal = Calendar.Load(sr);
-            Assert.IsTrue(iCal.Events.Count == 2, "There should be 2 events in the parsed calendar");
-            Assert.IsNotNull(iCal.Events["fd940618-45e2-4d19-b118-37fd7a8e3906"], "Event fd940618-45e2-4d19-b118-37fd7a8e3906 should exist in the calendar");
-            Assert.IsNotNull(iCal.Events["ebfbd3e3-cc1e-4a64-98eb-ced2598b3908"], "Event ebfbd3e3-cc1e-4a64-98eb-ced2598b3908 should exist in the calendar");
+            Assert.That(iCal.Events.Count == 2, Is.True, "There should be 2 events in the parsed calendar");
+            Assert.That(iCal.Events["fd940618-45e2-4d19-b118-37fd7a8e3906"], Is.Not.Null, "Event fd940618-45e2-4d19-b118-37fd7a8e3906 should exist in the calendar");
+            Assert.That(iCal.Events["ebfbd3e3-cc1e-4a64-98eb-ced2598b3908"], Is.Not.Null, "Event ebfbd3e3-cc1e-4a64-98eb-ced2598b3908 should exist in the calendar");
         }
 
         [Test]
@@ -279,8 +305,11 @@ END:VCALENDAR
             ProgramTest.TestCal(iCal);
             var evt = iCal.Events.First();
 
-            Assert.AreEqual(37.386013, evt.GeographicLocation.Latitude, "Latitude should be 37.386013; it is not.");
-            Assert.AreEqual(-122.082932, evt.GeographicLocation.Longitude, "Longitude should be -122.082932; it is not.");
+            Assert.Multiple(() =>
+            {
+                Assert.That(evt.GeographicLocation.Latitude, Is.EqualTo(37.386013), "Latitude should be 37.386013; it is not.");
+                Assert.That(evt.GeographicLocation.Longitude, Is.EqualTo(-122.082932), "Longitude should be -122.082932; it is not.");
+            });
         }
 
         [Test]
@@ -289,7 +318,7 @@ END:VCALENDAR
             var tzId = "Europe/Berlin";
             var iCal = Calendar.Load(IcsFiles.Google1);
             var evt = iCal.Events["594oeajmftl3r9qlkb476rpr3c@google.com"];
-            Assert.IsNotNull(evt);
+            Assert.That(evt, Is.Not.Null);
 
             IDateTime dtStart = new CalDateTime(2006, 12, 18, tzId);
             IDateTime dtEnd = new CalDateTime(2006, 12, 23, tzId);
@@ -305,9 +334,9 @@ END:VCALENDAR
             };
 
             for (var i = 0; i < dateTimes.Length; i++)
-                Assert.AreEqual(dateTimes[i], occurrences[i].Period.StartTime, "Event should occur at " + dateTimes[i]);
+                Assert.That(occurrences[i].Period.StartTime, Is.EqualTo(dateTimes[i]), "Event should occur at " + dateTimes[i]);
 
-            Assert.AreEqual(dateTimes.Length, occurrences.Count, "There should be exactly " + dateTimes.Length + " occurrences; there were " + occurrences.Count);
+            Assert.That(occurrences, Has.Count.EqualTo(dateTimes.Length), "There should be exactly " + dateTimes.Length + " occurrences; there were " + occurrences.Count);
         }
 
         /// <summary>
@@ -317,23 +346,26 @@ END:VCALENDAR
         public void RecurrenceDates1()
         {
             var iCal = Calendar.Load(IcsFiles.RecurrenceDates1);
-            Assert.AreEqual(1, iCal.Events.Count);
-            Assert.AreEqual(3, iCal.Events.First().RecurrenceDates.Count);
+            Assert.That(iCal.Events, Has.Count.EqualTo(1));
+            Assert.That(iCal.Events.First().RecurrenceDates, Has.Count.EqualTo(3));
 
-            Assert.AreEqual((CalDateTime)new DateTime(1997, 7, 14, 12, 30, 0, DateTimeKind.Utc), iCal.Events.First().RecurrenceDates[0][0].StartTime);
-            Assert.AreEqual((CalDateTime)new DateTime(1996, 4, 3, 2, 0, 0, DateTimeKind.Utc), iCal.Events.First().RecurrenceDates[1][0].StartTime);
-            Assert.AreEqual((CalDateTime)new DateTime(1996, 4, 3, 4, 0, 0, DateTimeKind.Utc), iCal.Events.First().RecurrenceDates[1][0].EndTime);
-            Assert.AreEqual(new CalDateTime(1997, 1, 1), iCal.Events.First().RecurrenceDates[2][0].StartTime);
-            Assert.AreEqual(new CalDateTime(1997, 1, 20), iCal.Events.First().RecurrenceDates[2][1].StartTime);
-            Assert.AreEqual(new CalDateTime(1997, 2, 17), iCal.Events.First().RecurrenceDates[2][2].StartTime);
-            Assert.AreEqual(new CalDateTime(1997, 4, 21), iCal.Events.First().RecurrenceDates[2][3].StartTime);
-            Assert.AreEqual(new CalDateTime(1997, 5, 26), iCal.Events.First().RecurrenceDates[2][4].StartTime);
-            Assert.AreEqual(new CalDateTime(1997, 7, 4), iCal.Events.First().RecurrenceDates[2][5].StartTime);
-            Assert.AreEqual(new CalDateTime(1997, 9, 1), iCal.Events.First().RecurrenceDates[2][6].StartTime);
-            Assert.AreEqual(new CalDateTime(1997, 10, 14), iCal.Events.First().RecurrenceDates[2][7].StartTime);
-            Assert.AreEqual(new CalDateTime(1997, 11, 28), iCal.Events.First().RecurrenceDates[2][8].StartTime);
-            Assert.AreEqual(new CalDateTime(1997, 11, 29), iCal.Events.First().RecurrenceDates[2][9].StartTime);
-            Assert.AreEqual(new CalDateTime(1997, 12, 25), iCal.Events.First().RecurrenceDates[2][10].StartTime);
+            Assert.Multiple(() =>
+            {
+                Assert.That(iCal.Events.First().RecurrenceDates[0][0].StartTime, Is.EqualTo((CalDateTime)new DateTime(1997, 7, 14, 12, 30, 0, DateTimeKind.Utc)));
+                Assert.That(iCal.Events.First().RecurrenceDates[1][0].StartTime, Is.EqualTo((CalDateTime)new DateTime(1996, 4, 3, 2, 0, 0, DateTimeKind.Utc)));
+                Assert.That(iCal.Events.First().RecurrenceDates[1][0].EndTime, Is.EqualTo((CalDateTime)new DateTime(1996, 4, 3, 4, 0, 0, DateTimeKind.Utc)));
+                Assert.That(iCal.Events.First().RecurrenceDates[2][0].StartTime, Is.EqualTo(new CalDateTime(1997, 1, 1)));
+                Assert.That(iCal.Events.First().RecurrenceDates[2][1].StartTime, Is.EqualTo(new CalDateTime(1997, 1, 20)));
+                Assert.That(iCal.Events.First().RecurrenceDates[2][2].StartTime, Is.EqualTo(new CalDateTime(1997, 2, 17)));
+                Assert.That(iCal.Events.First().RecurrenceDates[2][3].StartTime, Is.EqualTo(new CalDateTime(1997, 4, 21)));
+                Assert.That(iCal.Events.First().RecurrenceDates[2][4].StartTime, Is.EqualTo(new CalDateTime(1997, 5, 26)));
+                Assert.That(iCal.Events.First().RecurrenceDates[2][5].StartTime, Is.EqualTo(new CalDateTime(1997, 7, 4)));
+                Assert.That(iCal.Events.First().RecurrenceDates[2][6].StartTime, Is.EqualTo(new CalDateTime(1997, 9, 1)));
+                Assert.That(iCal.Events.First().RecurrenceDates[2][7].StartTime, Is.EqualTo(new CalDateTime(1997, 10, 14)));
+                Assert.That(iCal.Events.First().RecurrenceDates[2][8].StartTime, Is.EqualTo(new CalDateTime(1997, 11, 28)));
+                Assert.That(iCal.Events.First().RecurrenceDates[2][9].StartTime, Is.EqualTo(new CalDateTime(1997, 11, 29)));
+                Assert.That(iCal.Events.First().RecurrenceDates[2][10].StartTime, Is.EqualTo(new CalDateTime(1997, 12, 25)));
+            });
         }
 
         /// <summary>
@@ -343,32 +375,44 @@ END:VCALENDAR
         public void RequestStatus1()
         {
             var iCal = Calendar.Load(IcsFiles.RequestStatus1);
-            Assert.AreEqual(1, iCal.Events.Count);
-            Assert.AreEqual(4, iCal.Events.First().RequestStatuses.Count);
+            Assert.That(iCal.Events, Has.Count.EqualTo(1));
+            Assert.That(iCal.Events.First().RequestStatuses, Has.Count.EqualTo(4));
 
             var rs = iCal.Events.First().RequestStatuses[0];
-            Assert.AreEqual(2, rs.StatusCode.Primary);
-            Assert.AreEqual(0, rs.StatusCode.Secondary);
-            Assert.AreEqual("Success", rs.Description);
-            Assert.IsNull(rs.ExtraData);
+            Assert.Multiple(() =>
+            {
+                Assert.That(rs.StatusCode.Primary, Is.EqualTo(2));
+                Assert.That(rs.StatusCode.Secondary, Is.EqualTo(0));
+                Assert.That(rs.Description, Is.EqualTo("Success"));
+            });
+            Assert.That(rs.ExtraData, Is.Null);
 
             rs = iCal.Events.First().RequestStatuses[1];
-            Assert.AreEqual(3, rs.StatusCode.Primary);
-            Assert.AreEqual(1, rs.StatusCode.Secondary);
-            Assert.AreEqual("Invalid property value", rs.Description);
-            Assert.AreEqual("DTSTART:96-Apr-01", rs.ExtraData);
+            Assert.Multiple(() =>
+            {
+                Assert.That(rs.StatusCode.Primary, Is.EqualTo(3));
+                Assert.That(rs.StatusCode.Secondary, Is.EqualTo(1));
+                Assert.That(rs.Description, Is.EqualTo("Invalid property value"));
+                Assert.That(rs.ExtraData, Is.EqualTo("DTSTART:96-Apr-01"));
+            });
 
             rs = iCal.Events.First().RequestStatuses[2];
-            Assert.AreEqual(2, rs.StatusCode.Primary);
-            Assert.AreEqual(8, rs.StatusCode.Secondary);
-            Assert.AreEqual(" Success, repeating event ignored. Scheduled as a single event.", rs.Description);
-            Assert.AreEqual("RRULE:FREQ=WEEKLY;INTERVAL=2", rs.ExtraData);
+            Assert.Multiple(() =>
+            {
+                Assert.That(rs.StatusCode.Primary, Is.EqualTo(2));
+                Assert.That(rs.StatusCode.Secondary, Is.EqualTo(8));
+                Assert.That(rs.Description, Is.EqualTo(" Success, repeating event ignored. Scheduled as a single event."));
+                Assert.That(rs.ExtraData, Is.EqualTo("RRULE:FREQ=WEEKLY;INTERVAL=2"));
+            });
 
             rs = iCal.Events.First().RequestStatuses[3];
-            Assert.AreEqual(4, rs.StatusCode.Primary);
-            Assert.AreEqual(1, rs.StatusCode.Secondary);
-            Assert.AreEqual("Event conflict. Date/time is busy.", rs.Description);
-            Assert.IsNull(rs.ExtraData);
+            Assert.Multiple(() =>
+            {
+                Assert.That(rs.StatusCode.Primary, Is.EqualTo(4));
+                Assert.That(rs.StatusCode.Secondary, Is.EqualTo(1));
+                Assert.That(rs.Description, Is.EqualTo("Event conflict. Date/time is busy."));
+            });
+            Assert.That(rs.ExtraData, Is.Null);
         }
 
         /// <summary>
@@ -381,16 +425,16 @@ END:VCALENDAR
             var value = @"test\with\;characters";
             var unescaped = (string)serializer.Deserialize(new StringReader(value));
 
-            Assert.AreEqual(@"test\with;characters", unescaped, "String unescaping was incorrect.");
+            Assert.That(unescaped, Is.EqualTo(@"test\with;characters"), "String unescaping was incorrect.");
 
             value = @"C:\Path\To\My\New\Information";
             unescaped = (string)serializer.Deserialize(new StringReader(value));
-            Assert.AreEqual("C:\\Path\\To\\My\new\\Information", unescaped, "String unescaping was incorrect.");
+            Assert.That(unescaped, Is.EqualTo("C:\\Path\\To\\My\new\\Information"), "String unescaping was incorrect.");
 
             value = @"\""This\r\nis\Na\, test\""\;\\;,";
             unescaped = (string)serializer.Deserialize(new StringReader(value));
 
-            Assert.AreEqual("\"This\\r\nis\na, test\";\\;,", unescaped, "String unescaping was incorrect.");
+            Assert.That(unescaped, Is.EqualTo("\"This\\r\nis\na, test\";\\;,"), "String unescaping was incorrect.");
         }
 
         [Test]
@@ -398,10 +442,10 @@ END:VCALENDAR
         {
             var iCal = Calendar.Load(IcsFiles.Transparency2);
 
-            Assert.AreEqual(1, iCal.Events.Count);
+            Assert.That(iCal.Events, Has.Count.EqualTo(1));
             var evt = iCal.Events.First();
 
-            Assert.AreEqual(TransparencyType.Transparent, evt.Transparency);
+            Assert.That(evt.Transparency, Is.EqualTo(TransparencyType.Transparent));
         }
 
         /// <summary>
@@ -412,21 +456,21 @@ END:VCALENDAR
         public void DateTime1()
         {
             var iCal = Calendar.Load(IcsFiles.DateTime1);
-            Assert.AreEqual(6, iCal.Events.Count);
+            Assert.That(iCal.Events, Has.Count.EqualTo(6));
 
             var evt = iCal.Events["nc2o66s0u36iesitl2l0b8inn8@google.com"];
-            Assert.IsNotNull(evt);
+            Assert.That(evt, Is.Not.Null);
 
             // The "Created" date is out-of-bounds.  It should be coerced to the
             // closest representable date/time.
-            Assert.AreEqual(DateTime.MinValue, evt.Created.Value);
+            Assert.That(evt.Created.Value, Is.EqualTo(DateTime.MinValue));
         }
 
         [Test]
         public void Language4()
         {
             var iCal = Calendar.Load(IcsFiles.Language4);
-            Assert.IsNotNull(iCal);
+            Assert.That(iCal, Is.Not.Null);
         }
 
         [Test]
@@ -434,7 +478,7 @@ END:VCALENDAR
         {
             var iCal = Calendar.Load(IcsFiles.Outlook2007LineFolds);
             var events = iCal.GetOccurrences(new CalDateTime(2009, 06, 20), new CalDateTime(2009, 06, 22));
-            Assert.AreEqual(1, events.Count);
+            Assert.That(events, Has.Count.EqualTo(1));
         }
 
         [Test]
@@ -443,7 +487,7 @@ END:VCALENDAR
             var longName = "The Exceptionally Long Named Meeting Room Whose Name Wraps Over Several Lines When Exported From Leading Calendar and Office Software Application Microsoft Office 2007";
             var iCal = Calendar.Load(IcsFiles.Outlook2007LineFolds);
             var events = iCal.GetOccurrences<CalendarEvent>(new CalDateTime(2009, 06, 20), new CalDateTime(2009, 06, 22)).OrderBy(o => o.Period.StartTime).ToList();
-            Assert.AreEqual(longName, ((CalendarEvent)events[0].Source).Location);
+            Assert.That(((CalendarEvent)events[0].Source).Location, Is.EqualTo(longName));
         }
 
         /// <summary>
@@ -456,9 +500,12 @@ END:VCALENDAR
 
             var evt = iCal.Events.First();
             IList<CalendarParameter> parms = evt.Properties["DTSTART"].Parameters.AllOf("VALUE").ToList();
-            Assert.AreEqual(2, parms.Count);
-            Assert.AreEqual("DATE", parms[0].Values.First());
-            Assert.AreEqual("OTHER", parms[1].Values.First());
+            Assert.Multiple(() =>
+            {
+                Assert.That(parms, Has.Count.EqualTo(2));
+                Assert.That(parms[0].Values.First(), Is.EqualTo("DATE"));
+                Assert.That(parms[1].Values.First(), Is.EqualTo("OTHER"));
+            });
         }
 
         /// <summary>
@@ -468,7 +515,7 @@ END:VCALENDAR
         public void Parameter2()
         {
             var iCal = Calendar.Load(IcsFiles.Parameter2);
-            Assert.AreEqual(2, iCal.Events.Count);
+            Assert.That(iCal.Events, Has.Count.EqualTo(2));
         }
 
         /// <summary>
@@ -477,16 +524,11 @@ END:VCALENDAR
         [Test]
         public void Parse1()
         {
-            try
+            Assert.That(() =>
             {
                 var content = IcsFiles.Parse1;
                 var iCal = Calendar.Load(content);
-                Assert.IsNotNull(iCal);
-            }
-            catch (Exception e)
-            {
-                Assert.IsInstanceOf<SerializationException>(e);
-            }
+            }, Throws.Exception.TypeOf<SerializationException>());
         }
 
         /// <summary>
@@ -498,11 +540,11 @@ END:VCALENDAR
             var iCal = Calendar.Load(IcsFiles.Property1);
 
             IList<ICalendarProperty> props = iCal.Properties.AllOf("VERSION").ToList();
-            Assert.AreEqual(2, props.Count);
+            Assert.That(props, Has.Count.EqualTo(2));
 
             for (var i = 0; i < props.Count; i++)
             {
-                Assert.AreEqual("2." + i, props[i].Value);
+                Assert.That(props[i].Value, Is.EqualTo("2." + i));
             }
         }
     }

--- a/Ical.Net.Tests/DeserializationTests.cs
+++ b/Ical.Net.Tests/DeserializationTests.cs
@@ -229,19 +229,19 @@ namespace Ical.Net.Tests
             var evt = iCal.Events.First();
 
             Assert.That(
-evt.Attachments[0].ToString(),
-                Is.EqualTo("This is a test to try out base64 encoding without being too large.\r\n" +
-"This is a test to try out base64 encoding without being too large.\r\n" +
-"This is a test to try out base64 encoding without being too large.\r\n" +
-"This is a test to try out base64 encoding without being too large.\r\n" +
-"This is a test to try out base64 encoding without being too large.\r\n" +
-"This is a test to try out base64 encoding without being too large.\r\n" +
-"This is a test to try out base64 encoding without being too large.\r\n" +
-"This is a test to try out base64 encoding without being too large.\r\n" +
-"This is a test to try out base64 encoding without being too large.\r\n" +
-"This is a test to try out base64 encoding without being too large.\r\n" +
-"This is a test to try out base64 encoding without being too large.\r\n" +
-"This is a test to try out base64 encoding without being too large."),
+            evt.Attachments[0].ToString(),
+        Is.EqualTo("This is a test to try out base64 encoding without being too large.\r\n" +
+                "This is a test to try out base64 encoding without being too large.\r\n" +
+                "This is a test to try out base64 encoding without being too large.\r\n" +
+                "This is a test to try out base64 encoding without being too large.\r\n" +
+                "This is a test to try out base64 encoding without being too large.\r\n" +
+                "This is a test to try out base64 encoding without being too large.\r\n" +
+                "This is a test to try out base64 encoding without being too large.\r\n" +
+                "This is a test to try out base64 encoding without being too large.\r\n" +
+                "This is a test to try out base64 encoding without being too large.\r\n" +
+                "This is a test to try out base64 encoding without being too large.\r\n" +
+                "This is a test to try out base64 encoding without being too large.\r\n" +
+                "This is a test to try out base64 encoding without being too large."),
                 "Attached value does not match.");
         }
 

--- a/Ical.Net.Tests/DocumentationExamples.cs
+++ b/Ical.Net.Tests/DocumentationExamples.cs
@@ -35,7 +35,7 @@ namespace Ical.Net.Tests
             var searchStart = DateTime.Parse("2016-07-20");
             var searchEnd = DateTime.Parse("2016-08-05");
             var occurrences = calendar.GetOccurrences(searchStart, searchEnd);
-            Assert.AreEqual(12, occurrences.Count);
+            Assert.That(occurrences, Has.Count.EqualTo(12));
         }
 
         [Test]
@@ -61,7 +61,7 @@ namespace Ical.Net.Tests
             var searchEnd = DateTime.Parse("2016-12-31");
             var tuesdays = vEvent.GetOccurrences(searchStart, searchEnd);
 
-            Assert.AreEqual(13, tuesdays.Count);
+            Assert.That(tuesdays, Has.Count.EqualTo(13));
         }
 
         [Test]
@@ -90,10 +90,10 @@ namespace Ical.Net.Tests
             var searchEnd = DateTime.Parse("2017-01-01");
             var usThanksgivings = vEvent.GetOccurrences(searchStart, searchEnd);
 
-            Assert.AreEqual(17, usThanksgivings.Count);
+            Assert.That(usThanksgivings, Has.Count.EqualTo(17));
             foreach (var thanksgiving in usThanksgivings)
             {
-                Assert.IsTrue(thanksgiving.Period.StartTime.DayOfWeek == DayOfWeek.Thursday);
+                Assert.That(thanksgiving.Period.StartTime.DayOfWeek == DayOfWeek.Thursday, Is.True);
             }
         }
 
@@ -122,7 +122,7 @@ namespace Ical.Net.Tests
             var searchStart = DateTime.Parse("2015-12-31");
             var searchEnd = DateTime.Parse("2017-01-01");
             var occurrences = calendar.GetOccurrences(searchStart, searchEnd);
-            Assert.AreEqual(314, occurrences.Count);
+            Assert.That(occurrences, Has.Count.EqualTo(314));
         }
     }
 }

--- a/Ical.Net.Tests/EqualityAndHashingTests.cs
+++ b/Ical.Net.Tests/EqualityAndHashingTests.cs
@@ -3,8 +3,8 @@ using Ical.Net.DataTypes;
 using Ical.Net.Serialization;
 using Ical.Net.Utility;
 using NUnit.Framework;
-using NUnit.Framework.Interfaces;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -20,13 +20,16 @@ namespace Ical.Net.Tests
         [Test, TestCaseSource(nameof(CalDateTime_TestCases))]
         public void CalDateTime_Tests(CalDateTime incomingDt, CalDateTime expectedDt)
         {
-            Assert.AreEqual(incomingDt.Value, expectedDt.Value);
-            Assert.AreEqual(incomingDt.GetHashCode(), expectedDt.GetHashCode());
-            Assert.AreEqual(incomingDt.TzId, expectedDt.TzId);
-            Assert.IsTrue(incomingDt.Equals(expectedDt));
+            Assert.Multiple(() =>
+            {
+                Assert.That(expectedDt.Value, Is.EqualTo(incomingDt.Value));
+                Assert.That(expectedDt.GetHashCode(), Is.EqualTo(incomingDt.GetHashCode()));
+                Assert.That(expectedDt.TzId, Is.EqualTo(incomingDt.TzId));
+                Assert.That(incomingDt.Equals(expectedDt), Is.True);
+            });
         }
 
-        public static IEnumerable<ITestCaseData> CalDateTime_TestCases()
+        public static IEnumerable CalDateTime_TestCases()
         {
             var nowCalDt = new CalDateTime(_nowTime);
             yield return new TestCaseData(nowCalDt, new CalDateTime(_nowTime)).SetName("Now, no time zone");
@@ -41,22 +44,25 @@ namespace Ical.Net.Tests
             var patternA = GetSimpleRecurrencePattern();
             var patternB = GetSimpleRecurrencePattern();
 
-            Assert.AreEqual(patternA, patternB);
-            Assert.AreEqual(patternA.GetHashCode(), patternB.GetHashCode());
+            Assert.That(patternB, Is.EqualTo(patternA));
+            Assert.That(patternB.GetHashCode(), Is.EqualTo(patternA.GetHashCode()));
         }
 
         [Test, TestCaseSource(nameof(Event_TestCases))]
         public void Event_Tests(CalendarEvent incoming, CalendarEvent expected)
         {
-            Assert.AreEqual(incoming.DtStart, expected.DtStart);
-            Assert.AreEqual(incoming.DtEnd, expected.DtEnd);
-            Assert.AreEqual(incoming.Location, expected.Location);
-            Assert.AreEqual(incoming.Status, expected.Status);
-            Assert.AreEqual(incoming.IsActive, expected.IsActive);
-            Assert.AreEqual(incoming.Duration, expected.Duration);
-            Assert.AreEqual(incoming.Transparency, expected.Transparency);
-            Assert.AreEqual(incoming.GetHashCode(), expected.GetHashCode());
-            Assert.IsTrue(incoming.Equals(expected));
+            Assert.Multiple(() =>
+            {
+                Assert.That(expected.DtStart, Is.EqualTo(incoming.DtStart));
+                Assert.That(expected.DtEnd, Is.EqualTo(incoming.DtEnd));
+                Assert.That(expected.Location, Is.EqualTo(incoming.Location));
+                Assert.That(expected.Status, Is.EqualTo(incoming.Status));
+                Assert.That(expected.IsActive, Is.EqualTo(incoming.IsActive));
+                Assert.That(expected.Duration, Is.EqualTo(incoming.Duration));
+                Assert.That(expected.Transparency, Is.EqualTo(incoming.Transparency));
+                Assert.That(expected.GetHashCode(), Is.EqualTo(incoming.GetHashCode()));
+                Assert.That(incoming.Equals(expected), Is.True);
+            });
         }
 
         private static RecurrencePattern GetSimpleRecurrencePattern() => new RecurrencePattern(FrequencyType.Daily, 1)
@@ -74,7 +80,7 @@ namespace Ical.Net.Tests
         private static string SerializeEvent(CalendarEvent e) => new CalendarSerializer().SerializeToString(new Calendar { Events = { e } });
 
 
-        public static IEnumerable<ITestCaseData> Event_TestCases()
+        public static IEnumerable Event_TestCases()
         {
             var outgoing = GetSimpleEvent();
             var expected = GetSimpleEvent();
@@ -124,20 +130,26 @@ namespace Ical.Net.Tests
                 RecurrenceRules = new List<RecurrencePattern> { rruleB },
             });
 
-            Assert.AreEqual(actualCalendar.GetHashCode(), expectedCalendar.GetHashCode());
-            Assert.IsTrue(actualCalendar.Equals(expectedCalendar));
+            Assert.Multiple(() =>
+            {
+                Assert.That(expectedCalendar.GetHashCode(), Is.EqualTo(actualCalendar.GetHashCode()));
+                Assert.That(actualCalendar.Equals(expectedCalendar), Is.True);
+            });
         }
 
         [Test, TestCaseSource(nameof(VTimeZone_TestCases))]
         public void VTimeZone_Tests(VTimeZone actual, VTimeZone expected)
         {
-            Assert.AreEqual(actual.Url, expected.Url);
-            Assert.AreEqual(actual.TzId, expected.TzId);
-            Assert.AreEqual(actual, expected);
-            Assert.AreEqual(actual.GetHashCode(), expected.GetHashCode());
+            Assert.Multiple(() =>
+            {
+                Assert.That(expected.Url, Is.EqualTo(actual.Url));
+                Assert.That(expected.TzId, Is.EqualTo(actual.TzId));
+                Assert.That(expected, Is.EqualTo(actual));
+                Assert.That(expected.GetHashCode(), Is.EqualTo(actual.GetHashCode()));
+            });
         }
 
-        public static IEnumerable<ITestCaseData> VTimeZone_TestCases()
+        public static IEnumerable VTimeZone_TestCases()
         {
             const string nzSt = "New Zealand Standard Time";
             var first = new VTimeZone
@@ -155,11 +167,14 @@ namespace Ical.Net.Tests
         [Test, TestCaseSource(nameof(Attendees_TestCases))]
         public void Attendees_Tests(Attendee actual, Attendee expected)
         {
-            Assert.AreEqual(expected.GetHashCode(), actual.GetHashCode());
-            Assert.AreEqual(expected, actual);
+            Assert.Multiple(() =>
+            {
+                Assert.That(actual.GetHashCode(), Is.EqualTo(expected.GetHashCode()));
+                Assert.That(actual, Is.EqualTo(expected));
+            });
         }
 
-        public static IEnumerable<ITestCaseData> Attendees_TestCases()
+        public static IEnumerable Attendees_TestCases()
         {
             var tentative1 = new Attendee("MAILTO:james@example.com")
             {
@@ -212,13 +227,16 @@ namespace Ical.Net.Tests
             var a = Calendar.Load(IcsFiles.UsHolidays);
             var b = Calendar.Load(IcsFiles.UsHolidays);
 
-            Assert.IsNotNull(a);
-            Assert.IsNotNull(b);
-            Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
-            Assert.AreEqual(a, b);
+            Assert.That(a, Is.Not.Null);
+            Assert.That(b, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(b.GetHashCode(), Is.EqualTo(a.GetHashCode()));
+                Assert.That(b, Is.EqualTo(a));
+            });
         }
 
-        public static IEnumerable<ITestCaseData> CalendarCollection_TestCases()
+        public static IEnumerable CalendarCollection_TestCases()
         {
             yield return new TestCaseData(IcsFiles.Google1).SetName("Google calendar test case");
             yield return new TestCaseData(IcsFiles.Parse1).SetName("Weird file parse test case");
@@ -231,31 +249,34 @@ namespace Ical.Net.Tests
             var origContents = new[] { "Foo", "Bar" };
             var e = GetSimpleEvent();
             e.Resources = new List<string>(origContents);
-            Assert.IsTrue(e.Resources.Count == 2);
+            Assert.That(e.Resources.Count == 2, Is.True);
 
             e.Resources.Add("Baz");
-            Assert.IsTrue(e.Resources.Count == 3);
+            Assert.That(e.Resources.Count == 3, Is.True);
             var serialized = SerializeEvent(e);
-            Assert.IsTrue(serialized.Contains("Baz"));
+            Assert.That(serialized.Contains("Baz"), Is.True);
 
             e.Resources.Remove("Baz");
-            Assert.IsTrue(e.Resources.Count == 2);
+            Assert.That(e.Resources.Count == 2, Is.True);
             serialized = SerializeEvent(e);
-            Assert.IsFalse(serialized.Contains("Baz"));
+            Assert.That(serialized.Contains("Baz"), Is.False);
 
             e.Resources.Add("Hello");
-            Assert.IsTrue(e.Resources.Contains("Hello"));
+            Assert.That(e.Resources.Contains("Hello"), Is.True);
             serialized = SerializeEvent(e);
-            Assert.IsTrue(serialized.Contains("Hello"));
+            Assert.That(serialized.Contains("Hello"), Is.True);
 
             e.Resources.Clear();
             e.Resources.AddRange(origContents);
-            CollectionAssert.AreEquivalent(e.Resources, origContents);
+            Assert.That(origContents, Is.EquivalentTo(e.Resources));
             serialized = SerializeEvent(e);
-            Assert.IsTrue(serialized.Contains("Foo"));
-            Assert.IsTrue(serialized.Contains("Bar"));
-            Assert.IsFalse(serialized.Contains("Baz"));
-            Assert.IsFalse(serialized.Contains("Hello"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(serialized.Contains("Foo"), Is.True);
+                Assert.That(serialized.Contains("Bar"), Is.True);
+                Assert.That(serialized.Contains("Baz"), Is.False);
+                Assert.That(serialized.Contains("Hello"), Is.False);
+            });
         }
 
         internal static (byte[] original, byte[] copy) GetAttachments()
@@ -271,16 +292,16 @@ namespace Ical.Net.Tests
         {
             var attachments = GetAttachments();
 
-            Assert.AreNotEqual(noAttachment, withAttachment);
-            Assert.AreNotEqual(noAttachment.GetHashCode(), withAttachment.GetHashCode());
+            Assert.That(withAttachment, Is.Not.EqualTo(noAttachment));
+            Assert.That(withAttachment.GetHashCode(), Is.Not.EqualTo(noAttachment.GetHashCode()));
 
             noAttachment.Attachments.Add(new Attachment(attachments.copy));
 
-            Assert.AreEqual(noAttachment, withAttachment);
-            Assert.AreEqual(noAttachment.GetHashCode(), withAttachment.GetHashCode());
+            Assert.That(withAttachment, Is.EqualTo(noAttachment));
+            Assert.That(withAttachment.GetHashCode(), Is.EqualTo(noAttachment.GetHashCode()));
         }
 
-        public static IEnumerable<ITestCaseData> RecurringComponentAttachment_TestCases()
+        public static IEnumerable RecurringComponentAttachment_TestCases()
         {
             var attachments = GetAttachments();
 
@@ -303,11 +324,14 @@ namespace Ical.Net.Tests
         [Test, TestCaseSource(nameof(PeriodTestCases))]
         public void PeriodTests(Period a, Period b)
         {
-            Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
-            Assert.AreEqual(a, b);
+            Assert.Multiple(() =>
+            {
+                Assert.That(b.GetHashCode(), Is.EqualTo(a.GetHashCode()));
+                Assert.That(b, Is.EqualTo(a));
+            });
         }
 
-        public static IEnumerable<ITestCaseData> PeriodTestCases()
+        public static IEnumerable PeriodTestCases()
         {
             yield return new TestCaseData(new Period(new CalDateTime(_nowTime)), new Period(new CalDateTime(_nowTime)))
                 .SetName("Two identical CalDateTimes are equal");
@@ -414,16 +438,19 @@ namespace Ical.Net.Tests
             }
 
             var collectionEqual = CollectionHelpers.Equals(a, b);
-            Assert.AreEqual(true, collectionEqual);
-            Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
+            Assert.Multiple(() =>
+            {
+                Assert.That(collectionEqual, Is.EqualTo(true));
+                Assert.That(b.GetHashCode(), Is.EqualTo(a.GetHashCode()));
+            });
 
             var listOfListA = new List<PeriodList> { a };
             var listOfListB = new List<PeriodList> { b };
-            Assert.IsTrue(CollectionHelpers.Equals(listOfListA, listOfListB));
+            Assert.That(CollectionHelpers.Equals(listOfListA, listOfListB), Is.True);
 
             var aThenB = new List<PeriodList> { a, b };
             var bThenA = new List<PeriodList> { b, a };
-            Assert.IsTrue(CollectionHelpers.Equals(aThenB, bThenA));
+            Assert.That(CollectionHelpers.Equals(aThenB, bThenA), Is.True);
         }
 
         [Test]
@@ -435,7 +462,7 @@ namespace Ical.Net.Tests
             var asLocal = new CalDateTime(nowLocal, "America/New_York");
             var asUtc = new CalDateTime(nowUtc, "UTC");
 
-            Assert.AreNotEqual(asLocal, asUtc);
+            Assert.That(asUtc, Is.Not.EqualTo(asLocal));
         }
 
         private void TestComparison(Func<CalDateTime, IDateTime, bool> calOp, Func<int?, int?, bool> intOp)
@@ -446,12 +473,15 @@ namespace Ical.Net.Tests
             var dtSome = new CalDateTime(2018, 1, 1);
             var dtGreater = new CalDateTime(2019, 1, 1);
 
-            Assert.AreEqual(intOp(null, null), calOp(null, null));
-            Assert.AreEqual(intOp(null, intSome), calOp(null, dtSome));
-            Assert.AreEqual(intOp(intSome, null), calOp(dtSome, null));
-            Assert.AreEqual(intOp(intSome, intSome), calOp(dtSome, dtSome));
-            Assert.AreEqual(intOp(intSome, intGreater), calOp(dtSome, dtGreater));
-            Assert.AreEqual(intOp(intGreater, intSome), calOp(dtGreater, dtSome));
+            Assert.Multiple(() =>
+            {
+                Assert.That(calOp(null, null), Is.EqualTo(intOp(null, null)));
+                Assert.That(calOp(null, dtSome), Is.EqualTo(intOp(null, intSome)));
+                Assert.That(calOp(dtSome, null), Is.EqualTo(intOp(intSome, null)));
+                Assert.That(calOp(dtSome, dtSome), Is.EqualTo(intOp(intSome, intSome)));
+                Assert.That(calOp(dtSome, dtGreater), Is.EqualTo(intOp(intSome, intGreater)));
+                Assert.That(calOp(dtGreater, dtSome), Is.EqualTo(intOp(intGreater, intSome)));
+            });
         }
 
         [Test]

--- a/Ical.Net.Tests/FreeBusyTest.cs
+++ b/Ical.Net.Tests/FreeBusyTest.cs
@@ -21,10 +21,13 @@ namespace Ical.Net.Tests
             evt.End = new CalDateTime(2010, 10, 1, 9, 0, 0);
 
             var freeBusy = cal.GetFreeBusy(new CalDateTime(2010, 10, 1, 0, 0, 0), new CalDateTime(2010, 10, 7, 11, 59, 59));
-            Assert.AreEqual(FreeBusyStatus.Free, freeBusy.GetFreeBusyStatus(new CalDateTime(2010, 10, 1, 7, 59, 59)));
-            Assert.AreEqual(FreeBusyStatus.Busy, freeBusy.GetFreeBusyStatus(new CalDateTime(2010, 10, 1, 8, 0, 0)));
-            Assert.AreEqual(FreeBusyStatus.Busy, freeBusy.GetFreeBusyStatus(new CalDateTime(2010, 10, 1, 8, 59, 59)));
-            Assert.AreEqual(FreeBusyStatus.Free, freeBusy.GetFreeBusyStatus(new CalDateTime(2010, 10, 1, 9, 0, 0)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(freeBusy.GetFreeBusyStatus(new CalDateTime(2010, 10, 1, 7, 59, 59)), Is.EqualTo(FreeBusyStatus.Free));
+                Assert.That(freeBusy.GetFreeBusyStatus(new CalDateTime(2010, 10, 1, 8, 0, 0)), Is.EqualTo(FreeBusyStatus.Busy));
+                Assert.That(freeBusy.GetFreeBusyStatus(new CalDateTime(2010, 10, 1, 8, 59, 59)), Is.EqualTo(FreeBusyStatus.Busy));
+                Assert.That(freeBusy.GetFreeBusyStatus(new CalDateTime(2010, 10, 1, 9, 0, 0)), Is.EqualTo(FreeBusyStatus.Free));
+            });
         }
     }
 }

--- a/Ical.Net.Tests/GetOccurrenceTests.cs
+++ b/Ical.Net.Tests/GetOccurrenceTests.cs
@@ -34,14 +34,20 @@ namespace Ical.Net.Tests
             var firstOccurrence = occurrences.First();
             var firstStartCopy = firstStart.Copy<CalDateTime>();
             var firstEndCopy = firstEnd.Copy<CalDateTime>();
-            Assert.AreEqual(firstStartCopy, firstOccurrence.Period.StartTime);
-            Assert.AreEqual(firstEndCopy, firstOccurrence.Period.EndTime);
+            Assert.Multiple(() =>
+            {
+                Assert.That(firstOccurrence.Period.StartTime, Is.EqualTo(firstStartCopy));
+                Assert.That(firstOccurrence.Period.EndTime, Is.EqualTo(firstEndCopy));
+            });
 
             var secondOccurrence = occurrences.Last();
             var secondStartCopy = secondStart.Copy<CalDateTime>();
             var secondEndCopy = secondEnd.Copy<CalDateTime>();
-            Assert.AreEqual(secondStartCopy, secondOccurrence.Period.StartTime);
-            Assert.AreEqual(secondEndCopy, secondOccurrence.Period.EndTime);
+            Assert.Multiple(() =>
+            {
+                Assert.That(secondOccurrence.Period.StartTime, Is.EqualTo(secondStartCopy));
+                Assert.That(secondOccurrence.Period.EndTime, Is.EqualTo(secondEndCopy));
+            });
         }
 
         [Test]
@@ -75,12 +81,12 @@ namespace Ical.Net.Tests
                 includeReferenceDateInResults: false);
             var occurrenceSet = new HashSet<IDateTime>(occurrences.Select(o => o.Period.StartTime));
 
-            Assert.AreEqual(evaluationsCount, occurrenceSet.Count);
+            Assert.That(occurrenceSet, Has.Count.EqualTo(evaluationsCount));
 
             for (var currentOccurrence = intervalStart; currentOccurrence.CompareTo(intervalEnd) < 0; currentOccurrence = (CalDateTime)currentOccurrence.AddDays(7))
             {
                 var contains = occurrenceSet.Contains(currentOccurrence);
-                Assert.IsTrue(contains, $"Collection does not contain {currentOccurrence}, but it is a {currentOccurrence.DayOfWeek}");
+                Assert.That(contains, Is.True, $"Collection does not contain {currentOccurrence}, but it is a {currentOccurrence.DayOfWeek}");
             }
         }
 
@@ -137,7 +143,7 @@ END:VCALENDAR";
             var occurrences = calendar.GetOccurrences(date);
 
             //We really want to make sure this doesn't explode
-            Assert.AreEqual(1, occurrences.Count);
+            Assert.That(occurrences, Has.Count.EqualTo(1));
         }
 
         [Test]
@@ -200,7 +206,7 @@ END:VCALENDAR
             var startCheck = new DateTime(2016, 11, 11);
             var occurrences = collection.GetOccurrences<CalendarEvent>(startCheck, startCheck.AddMonths(1));
 
-            Assert.IsTrue(occurrences.Count == 4);
+            Assert.That(occurrences.Count == 4, Is.True);
         }
     }
 }

--- a/Ical.Net.Tests/Ical.Net.Tests.csproj
+++ b/Ical.Net.Tests/Ical.Net.Tests.csproj
@@ -5,9 +5,13 @@
         <AssemblyOriginatorKeyFile>..\IcalNetStrongnameKey.snk</AssemblyOriginatorKeyFile>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
-        <PackageReference Include="NUnit" Version="3.14.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageReference Include="NUnit" Version="4.2.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Ical.Net\Ical.Net.csproj" />

--- a/Ical.Net.Tests/JournalTest.cs
+++ b/Ical.Net.Tests/JournalTest.cs
@@ -1,4 +1,4 @@
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using System.Linq;
 
@@ -12,13 +12,16 @@ namespace Ical.Net.Tests
         {
             var iCal = Calendar.Load(IcsFiles.Journal1);
             ProgramTest.TestCal(iCal);
-            Assert.AreEqual(1, iCal.Journals.Count);
+            Assert.That(iCal.Journals, Has.Count.EqualTo(1));
             var j = iCal.Journals[0];
 
-            Assert.IsNotNull(j, "Journal entry was null");
-            Assert.AreEqual(JournalStatus.Draft, j.Status, "Journal entry should have been in DRAFT status, but it was in " + j.Status + " status.");
-            Assert.AreEqual("PUBLIC", j.Class, "Journal class should have been PUBLIC, but was " + j.Class + ".");
-            Assert.IsNull(j.Start);
+            Assert.Multiple(() =>
+            {
+                Assert.That(j, Is.Not.Null, "Journal entry was null");
+                Assert.That(j.Status, Is.EqualTo(JournalStatus.Draft), "Journal entry should have been in DRAFT status, but it was in " + j.Status + " status.");
+                Assert.That(j.Class, Is.EqualTo("PUBLIC"), "Journal class should have been PUBLIC, but was " + j.Class + ".");
+            });
+            Assert.That(j.Start, Is.Null);
         }
 
         [Test, Category("Journal")]
@@ -26,35 +29,40 @@ namespace Ical.Net.Tests
         {
             var iCal = Calendar.Load(IcsFiles.Journal2);
             ProgramTest.TestCal(iCal);
-            Assert.AreEqual(1, iCal.Journals.Count);
+            Assert.That(iCal.Journals, Has.Count.EqualTo(1));
             var j = iCal.Journals.First();
 
-            Assert.IsNotNull(j, "Journal entry was null");
-            Assert.AreEqual(JournalStatus.Final, j.Status, "Journal entry should have been in FINAL status, but it was in " + j.Status + " status.");
-            Assert.AreEqual("PRIVATE", j.Class, "Journal class should have been PRIVATE, but was " + j.Class + ".");
-            Assert.AreEqual("JohnSmith", j.Organizer.CommonName, "Organizer common name should have been JohnSmith, but was " + j.Organizer.CommonName);
-            Assert.IsTrue(
-                string.Equals(
-                    j.Organizer.SentBy.OriginalString,
-                    "mailto:jane_doe@host.com",
-                    StringComparison.OrdinalIgnoreCase),
-                "Organizer should have had been SENT-BY 'mailto:jane_doe@host.com'; it was sent by '" + j.Organizer.SentBy + "'");
-            Assert.IsTrue(
-                string.Equals(
-                    j.Organizer.DirectoryEntry.OriginalString,
-                    "ldap://host.com:6666/o=3DDC%20Associates,c=3DUS??(cn=3DJohn%20Smith)",
-                    StringComparison.OrdinalIgnoreCase),
-                "Organizer's directory entry should have been 'ldap://host.com:6666/o=3DDC%20Associates,c=3DUS??(cn=3DJohn%20Smith)', but it was '" + j.Organizer.DirectoryEntry + "'");
-            Assert.AreEqual(
-                "MAILTO:jsmith@host.com",
-                j.Organizer.Value.OriginalString);
-            Assert.AreEqual(
-                "jsmith",
-                j.Organizer.Value.UserInfo);
-            Assert.AreEqual(
-                "host.com",
-                j.Organizer.Value.Host);
-            Assert.IsNull(j.Start);
+            Assert.Multiple(() =>
+            {
+                Assert.That(j, Is.Not.Null, "Journal entry was null");
+                Assert.That(j.Status, Is.EqualTo(JournalStatus.Final), "Journal entry should have been in FINAL status, but it was in " + j.Status + " status.");
+                Assert.That(j.Class, Is.EqualTo("PRIVATE"), "Journal class should have been PRIVATE, but was " + j.Class + ".");
+                Assert.That(j.Organizer.CommonName, Is.EqualTo("JohnSmith"), "Organizer common name should have been JohnSmith, but was " + j.Organizer.CommonName);
+                Assert.That(
+                    string.Equals(
+                        j.Organizer.SentBy.OriginalString,
+                        "mailto:jane_doe@host.com",
+                        StringComparison.OrdinalIgnoreCase),
+                    Is.True,
+                    "Organizer should have had been SENT-BY 'mailto:jane_doe@host.com'; it was sent by '" + j.Organizer.SentBy + "'");
+                Assert.That(
+                    string.Equals(
+                        j.Organizer.DirectoryEntry.OriginalString,
+                        "ldap://host.com:6666/o=3DDC%20Associates,c=3DUS??(cn=3DJohn%20Smith)",
+                        StringComparison.OrdinalIgnoreCase),
+                    Is.True,
+                    "Organizer's directory entry should have been 'ldap://host.com:6666/o=3DDC%20Associates,c=3DUS??(cn=3DJohn%20Smith)', but it was '" + j.Organizer.DirectoryEntry + "'");
+                Assert.That(
+                    j.Organizer.Value.OriginalString,
+                    Is.EqualTo("MAILTO:jsmith@host.com"));
+                Assert.That(
+                    j.Organizer.Value.UserInfo,
+                    Is.EqualTo("jsmith"));
+                Assert.That(
+                    j.Organizer.Value.Host,
+                    Is.EqualTo("host.com"));
+                Assert.That(j.Start, Is.Null);
+            });
         }
     }
 }

--- a/Ical.Net.Tests/ProgramTest.cs
+++ b/Ical.Net.Tests/ProgramTest.cs
@@ -15,18 +15,18 @@ namespace Ical.Net.Tests
             // The following code loads and displays an iCalendar
             // with US Holidays for 2006.
             var iCal = Calendar.Load(IcsFiles.UsHolidays);
-            Assert.IsNotNull(iCal, "iCalendar did not load.");
+            Assert.That(iCal, Is.Not.Null, "iCalendar did not load.");
         }
 
         private const string _tzid = "US-Eastern";
 
         public static void TestCal(Calendar cal)
         {
-            Assert.IsNotNull(cal, "The iCalendar was not loaded");
+            Assert.That(cal, Is.Not.Null, "The iCalendar was not loaded");
             if (cal.Events.Count > 0)
-                Assert.IsTrue(cal.Events.Count == 1, "Calendar should contain 1 event; however, the iCalendar loaded " + cal.Events.Count + " events");
+                Assert.That(cal.Events.Count == 1, Is.True, "Calendar should contain 1 event; however, the iCalendar loaded " + cal.Events.Count + " events");
             else if (cal.Todos.Count > 0)
-                Assert.IsTrue(cal.Todos.Count == 1, "Calendar should contain 1 todo; however, the iCalendar loaded " + cal.Todos.Count + " todos");
+                Assert.That(cal.Todos.Count == 1, Is.True, "Calendar should contain 1 todo; however, the iCalendar loaded " + cal.Todos.Count + " todos");
         }
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace Ical.Net.Tests
             {
                 IDateTime dt = dateTimes[i];
                 var start = occurrences[i].Period.StartTime;
-                Assert.AreEqual(dt, start);
+                Assert.That(start, Is.EqualTo(dt));
 
                 var expectedZone = DateUtil.GetZone(dt.TimeZoneName);
                 var actualZone = DateUtil.GetZone(timeZones[i]);
@@ -90,12 +90,12 @@ namespace Ical.Net.Tests
                 //Assert.AreEqual();
 
                 //Normalize the time zones and then compare equality
-                Assert.AreEqual(expectedZone, actualZone);
+                Assert.That(actualZone, Is.EqualTo(expectedZone));
 
                 //Assert.IsTrue(dt.TimeZoneName == TimeZones[i], "Event " + dt + " should occur in the " + TimeZones[i] + " timezone");
             }
 
-            Assert.IsTrue(occurrences.Count == dateTimes.Length, "There should be exactly " + dateTimes.Length + " occurrences; there were " + occurrences.Count);
+            Assert.That(occurrences.Count == dateTimes.Length, Is.True, "There should be exactly " + dateTimes.Length + " occurrences; there were " + occurrences.Count);
 
             // Get occurrences for the 2nd event
             occurrences = evt2.GetOccurrences(
@@ -150,11 +150,14 @@ namespace Ical.Net.Tests
             {
                 IDateTime dt = dateTimes1[i];
                 var start = occurrences[i].Period.StartTime;
-                Assert.AreEqual(dt, start);
-                Assert.IsTrue(dt.TimeZoneName == timeZones1[i], "Event " + dt + " should occur in the " + timeZones1[i] + " timezone");
+                Assert.Multiple(() =>
+                {
+                    Assert.That(start, Is.EqualTo(dt));
+                    Assert.That(dt.TimeZoneName == timeZones1[i], Is.True, "Event " + dt + " should occur in the " + timeZones1[i] + " timezone");
+                });
             }
 
-            Assert.AreEqual(dateTimes1.Length, occurrences.Count, "There should be exactly " + dateTimes1.Length + " occurrences; there were " + occurrences.Count);
+            Assert.That(occurrences, Has.Count.EqualTo(dateTimes1.Length), "There should be exactly " + dateTimes1.Length + " occurrences; there were " + occurrences.Count);
         }
 
         [Test]
@@ -166,14 +169,10 @@ namespace Ical.Net.Tests
             var zones = TimeZoneInfo.GetSystemTimeZones();
             foreach (var zone in zones)
             {
-                try
+                Assert.That(() =>
                 {
                     TimeZoneInfo.FindSystemTimeZoneById(zone.Id);
-                }
-                catch (Exception)
-                {
-                    Assert.Fail("Not found: " + zone.StandardName);
-                }
+                }, Throws.Nothing, "Time zone should be found.");
             }
         }
     }

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -37,10 +37,9 @@ namespace Ical.Net.Tests
                 .OrderBy(o => o.Period.StartTime)
                 .ToList();
 
-            Assert.That(
-                occurrences,
-Has.Count.EqualTo(dateTimes.Length),
-                "There should be exactly " + dateTimes.Length + " occurrences; there were " + occurrences.Count);
+            Assert.That(occurrences,
+        Has.Count.EqualTo(dateTimes.Length),
+        "There should be exactly " + dateTimes.Length + " occurrences; there were " + occurrences.Count);
 
             if (evt.RecurrenceRules.Count > 0)
             {

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -1,18 +1,17 @@
-using Ical.Net.CalendarComponents;
+﻿using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
 using Ical.Net.Evaluation;
 using Ical.Net.Serialization;
 using Ical.Net.Serialization.DataTypes;
 using Ical.Net.Utility;
 using NUnit.Framework;
-using NUnit.Framework.Interfaces;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
-using System.Threading;
 
 namespace Ical.Net.Tests
 {
@@ -38,14 +37,14 @@ namespace Ical.Net.Tests
                 .OrderBy(o => o.Period.StartTime)
                 .ToList();
 
-            Assert.AreEqual(
-                dateTimes.Length,
-                occurrences.Count,
+            Assert.That(
+                occurrences,
+Has.Count.EqualTo(dateTimes.Length),
                 "There should be exactly " + dateTimes.Length + " occurrences; there were " + occurrences.Count);
 
             if (evt.RecurrenceRules.Count > 0)
             {
-                Assert.AreEqual(1, evt.RecurrenceRules.Count);
+                Assert.That(evt.RecurrenceRules, Has.Count.EqualTo(1));
             }
 
             for (var i = 0; i < dateTimes.Length; i++)
@@ -54,9 +53,9 @@ namespace Ical.Net.Tests
                 dateTimes[i].AssociatedObject = cal;
 
                 var dt = dateTimes[i];
-                Assert.AreEqual(dt, occurrences[i].Period.StartTime, "Event should occur on " + dt);
+                Assert.That(occurrences[i].Period.StartTime, Is.EqualTo(dt), "Event should occur on " + dt);
                 if (timeZones != null)
-                    Assert.AreEqual(timeZones[i], dt.TimeZoneName, "Event " + dt + " should occur in the " + timeZones[i] + " timezone");
+                    Assert.That(dt.TimeZoneName, Is.EqualTo(timeZones[i]), "Event " + dt + " should occur in the " + timeZones[i] + " timezone");
             }            
         }
 
@@ -95,8 +94,11 @@ namespace Ical.Net.Tests
                     (dt.DayOfWeek == DayOfWeek.Sunday))
                 {
                     var dt1 = dt.AddHours(1);
-                    Assert.AreEqual(dt, occurrences[i].Period.StartTime, "Event should occur at " + dt);
-                    Assert.AreEqual(dt1, occurrences[i + 1].Period.StartTime, "Event should occur at " + dt);
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(occurrences[i].Period.StartTime, Is.EqualTo(dt), "Event should occur at " + dt);
+                        Assert.That(occurrences[i + 1].Period.StartTime, Is.EqualTo(dt1), "Event should occur at " + dt);
+                    });
                     i += 2;
                 }
 
@@ -153,11 +155,15 @@ namespace Ical.Net.Tests
                 if (dt.GreaterThanOrEqual(evt.Start) &&
                     dt.LessThan(new CalDateTime(1997, 12, 24, 0, 0, 0, _tzid)))
                 {
-                    Assert.AreEqual(dt, occurrences[i].Period.StartTime, "Event should occur at " + dt);
-                    Assert.IsTrue(
-                        (dt.LessThan(new CalDateTime(1997, 10, 26, _tzid)) && dt.TimeZoneName == "US-Eastern") ||
-                        (dt.GreaterThan(new CalDateTime(1997, 10, 26, _tzid)) && dt.TimeZoneName == "US-Eastern"),
-                        "Event " + dt + " doesn't occur in the correct time zone (including Daylight & Standard time zones)");
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(occurrences[i].Period.StartTime, Is.EqualTo(dt), "Event should occur at " + dt);
+                        Assert.That(
+                            (dt.LessThan(new CalDateTime(1997, 10, 26, _tzid)) && dt.TimeZoneName == "US-Eastern") ||
+                            (dt.GreaterThan(new CalDateTime(1997, 10, 26, _tzid)) && dt.TimeZoneName == "US-Eastern"),
+                            Is.True,
+                            "Event " + dt + " doesn't occur in the correct time zone (including Daylight & Standard time zones)");
+                    });
                     i++;
                 }
 
@@ -324,7 +330,7 @@ namespace Ical.Net.Tests
                     dt.Month == 1 &&
                     dt.LessThanOrEqual(new CalDateTime(2000, 1, 31, 9, 0, 0, _tzid)))
                 {
-                    Assert.AreEqual(dt, occurrences[i].Period.StartTime, "Event should occur at " + dt);
+                    Assert.That(occurrences[i].Period.StartTime, Is.EqualTo(dt), "Event should occur at " + dt);
                     i++;
                 }
 
@@ -352,9 +358,9 @@ namespace Ical.Net.Tests
 
             var evt1Occurrences = evt1.GetOccurrences(new CalDateTime(1997, 9, 1), new CalDateTime(2000, 12, 31)).OrderBy(o => o.Period.StartTime).ToList();
             var evt2Occurrences = evt2.GetOccurrences(new CalDateTime(1997, 9, 1), new CalDateTime(2000, 12, 31)).OrderBy(o => o.Period.StartTime).ToList();
-            Assert.IsTrue(evt1Occurrences.Count == evt2Occurrences.Count, "ByMonth1 does not match ByMonth2 as it should");
+            Assert.That(evt1Occurrences.Count == evt2Occurrences.Count, Is.True, "ByMonth1 does not match ByMonth2 as it should");
             for (var i = 0; i < evt1Occurrences.Count; i++)
-                Assert.AreEqual(evt1Occurrences[i].Period, evt2Occurrences[i].Period, "PERIOD " + i + " from ByMonth1 (" + evt1Occurrences[i] + ") does not match PERIOD " + i + " from ByMonth2 (" + evt2Occurrences[i] + ")");
+                Assert.That(evt2Occurrences[i].Period, Is.EqualTo(evt1Occurrences[i].Period), "PERIOD " + i + " from ByMonth1 (" + evt1Occurrences[i] + ") does not match PERIOD " + i + " from ByMonth2 (" + evt2Occurrences[i] + ")");
         }
 
         /// <summary>
@@ -536,10 +542,10 @@ namespace Ical.Net.Tests
 
             var evt1Occ = evt1.GetOccurrences(new CalDateTime(1997, 9, 1), new CalDateTime(1999, 1, 1)).OrderBy(o => o.Period.StartTime).ToList();
             var evt2Occ = evt2.GetOccurrences(new CalDateTime(1997, 9, 1), new CalDateTime(1999, 1, 1)).OrderBy(o => o.Period.StartTime).ToList();
-            Assert.AreEqual(evt1Occ.Count, evt2Occ.Count, "WeeklyCountWkst1() does not match WeeklyUntilWkst1() as it should");
+            Assert.That(evt2Occ, Has.Count.EqualTo(evt1Occ.Count), "WeeklyCountWkst1() does not match WeeklyUntilWkst1() as it should");
             for (var i = 0; i < evt1Occ.Count; i++)
             {
-                Assert.AreEqual(evt1Occ[i].Period, evt2Occ[i].Period, "PERIOD " + i + " from WeeklyUntilWkst1 (" + evt1Occ[i].Period + ") does not match PERIOD " + i + " from WeeklyCountWkst1 (" + evt2Occ[i].Period + ")");
+                Assert.That(evt2Occ[i].Period, Is.EqualTo(evt1Occ[i].Period), "PERIOD " + i + " from WeeklyUntilWkst1 (" + evt1Occ[i].Period + ") does not match PERIOD " + i + " from WeeklyCountWkst1 (" + evt2Occ[i].Period + ")");
             }
         }
 
@@ -1182,7 +1188,7 @@ namespace Ical.Net.Tests
             var recurringPeriods1 = rpe1.Evaluate(new CalDateTime(start), start, end, false);
             var recurringPeriods2 = rpe2.Evaluate(new CalDateTime(start), start, end, false);
 
-            Assert.AreEqual(recurringPeriods1.Count, recurringPeriods2.Count);
+            Assert.That(recurringPeriods2, Has.Count.EqualTo(recurringPeriods1.Count));
         }
 
         /// <summary>
@@ -1780,9 +1786,9 @@ namespace Ical.Net.Tests
 
             var evt1Occ = evt1.GetOccurrences(new CalDateTime(1997, 9, 1, _tzid), new CalDateTime(1997, 9, 3, _tzid)).OrderBy(o => o.Period.StartTime).ToList();
             var evt2Occ = evt2.GetOccurrences(new CalDateTime(1997, 9, 1, _tzid), new CalDateTime(1997, 9, 3, _tzid)).OrderBy(o => o.Period.StartTime).ToList();
-            Assert.IsTrue(evt1Occ.Count == evt2Occ.Count, "MinutelyByHour1() does not match DailyByHourMinute1() as it should");
+            Assert.That(evt1Occ.Count == evt2Occ.Count, Is.True, "MinutelyByHour1() does not match DailyByHourMinute1() as it should");
             for (var i = 0; i < evt1Occ.Count; i++)
-                Assert.AreEqual(evt1Occ[i].Period, evt2Occ[i].Period, "PERIOD " + i + " from DailyByHourMinute1 (" + evt1Occ[i].Period + ") does not match PERIOD " + i + " from MinutelyByHour1 (" + evt2Occ[i].Period + ")");
+                Assert.That(evt2Occ[i].Period, Is.EqualTo(evt1Occ[i].Period), "PERIOD " + i + " from DailyByHourMinute1 (" + evt1Occ[i].Period + ") does not match PERIOD " + i + " from MinutelyByHour1 (" + evt2Occ[i].Period + ")");
         }
 
         /// <summary>
@@ -1867,19 +1873,11 @@ namespace Ical.Net.Tests
         [Test, Category("Recurrence")]
         public void Secondly1()
         {
-            var evt = new AutoResetEvent(false);
-
-            try
+            Assert.That(() =>
             {
                 var iCal = Calendar.Load(IcsFiles.Secondly1);
-                var occurrences = iCal.GetOccurrences(new CalDateTime(2007, 6, 21, 8, 0, 0, _tzid), new CalDateTime(2007, 7, 21, 8, 0, 0, _tzid));
-            }
-            catch (ArgumentException)
-            {
-                evt.Set();
-            }
-
-            Assert.IsTrue(evt.WaitOne(2000), "Evaluation engine should have failed.");
+                _ = iCal.GetOccurrences(new CalDateTime(2007, 6, 21, 8, 0, 0, _tzid), new CalDateTime(2007, 7, 21, 8, 0, 0, _tzid));
+            }, Throws.Exception.TypeOf<ArgumentException>(), "Evaluation engine should have failed.");
         }
 
         /// <summary>
@@ -1917,21 +1915,17 @@ namespace Ical.Net.Tests
         /// <summary>
         /// Ensures that if configured, MINUTELY recurrence rules are not allowed.
         /// </summary>
-        [Test, Category("Recurrence")/*, ExpectedException(typeof(EvaluationEngineException))*/]
+        [Test, Category("Recurrence")]
         public void Minutely1()
         {
-            try
+            Assert.That(() =>
             {
                 var iCal = Calendar.Load(IcsFiles.Minutely1);
                 iCal.RecurrenceRestriction = RecurrenceRestrictionType.RestrictMinutely;
                 var occurrences = iCal.GetOccurrences(
                     new CalDateTime(2007, 6, 21, 8, 0, 0, _tzid),
                     new CalDateTime(2007, 7, 21, 8, 0, 0, _tzid));
-            }
-            catch (Exception e)
-            {
-                Assert.IsInstanceOf<ArgumentException>(e);
-            }
+            }, Throws.Exception.TypeOf<ArgumentException>());
         }
 
         /// <summary>
@@ -1967,17 +1961,13 @@ namespace Ical.Net.Tests
         [Test, Category("Recurrence")/*, ExpectedException(typeof(EvaluationEngineException))*/]
         public void Hourly1()
         {
-            try
+            Assert.That(() =>
             {
                 var iCal = Calendar.Load(IcsFiles.Hourly1);
                 iCal.RecurrenceRestriction = RecurrenceRestrictionType.RestrictHourly;
-                var occurrences = iCal.GetOccurrences(new CalDateTime(2007, 6, 21, 8, 0, 0, _tzid), new CalDateTime(2007, 7, 21, 8, 0, 0, _tzid));
-            }
-            catch (Exception e)
-            {
-                Assert.IsInstanceOf<ArgumentException>(e);
-            }
-            
+                _ = iCal.GetOccurrences(new CalDateTime(2007, 6, 21, 8, 0, 0, _tzid), new CalDateTime(2007, 7, 21, 8, 0, 0, _tzid));
+
+            }, Throws.Exception.TypeOf<ArgumentException>());
         }
 
         /// <summary>
@@ -2583,8 +2573,8 @@ namespace Ical.Net.Tests
 
             var recurringPeriods = rpe.Evaluate(new CalDateTime(start), start, end, false);
 
-            Assert.AreEqual(1, recurringPeriods.Count);
-            Assert.AreEqual(new CalDateTime(2019, 1, 7), recurringPeriods.First().StartTime);
+            Assert.That(recurringPeriods, Has.Count.EqualTo(1));
+            Assert.That(recurringPeriods.First().StartTime, Is.EqualTo(new CalDateTime(2019, 1, 7)));
         }
 
         /// <summary>
@@ -2599,11 +2589,14 @@ namespace Ical.Net.Tests
 
             var recurringPeriods = rpe.Evaluate(new CalDateTime(start), start, end, false).OrderBy(x => x).ToList();
 
-            Assert.AreEqual(4, recurringPeriods.Count);
-            Assert.AreEqual(new CalDateTime(2020, 1, 6), recurringPeriods[0].StartTime);
-            Assert.AreEqual(new CalDateTime(2020, 1, 13), recurringPeriods[1].StartTime);
-            Assert.AreEqual(new CalDateTime(2020, 1, 20), recurringPeriods[2].StartTime);
-            Assert.AreEqual(new CalDateTime(2020, 1, 27), recurringPeriods[3].StartTime);
+            Assert.That(recurringPeriods, Has.Count.EqualTo(4));
+            Assert.Multiple(() =>
+            {
+                Assert.That(recurringPeriods[0].StartTime, Is.EqualTo(new CalDateTime(2020, 1, 6)));
+                Assert.That(recurringPeriods[1].StartTime, Is.EqualTo(new CalDateTime(2020, 1, 13)));
+                Assert.That(recurringPeriods[2].StartTime, Is.EqualTo(new CalDateTime(2020, 1, 20)));
+                Assert.That(recurringPeriods[3].StartTime, Is.EqualTo(new CalDateTime(2020, 1, 27)));
+            });
         }
         
         [Test, Category("Recurrence")]
@@ -2624,7 +2617,7 @@ namespace Ical.Net.Tests
             evt.RecurrenceRules.Add(pattern);
 
             var occurrences = evt.GetOccurrences(new DateTime(2018, 1, 1), DateTime.MaxValue);
-            Assert.AreEqual(10, occurrences.Count, "There should be 10 occurrences of this event.");
+            Assert.That(occurrences, Has.Count.EqualTo(10), "There should be 10 occurrences of this event.");
         }
 
         /// <summary>
@@ -2639,11 +2632,14 @@ namespace Ical.Net.Tests
 
             var recurringPeriods = rpe.Evaluate(new CalDateTime(start), start, end, false).OrderBy(x => x).ToList();
 
-            Assert.AreEqual(4, recurringPeriods.Count);
-            Assert.AreEqual(new CalDateTime(2020, 1, 6), recurringPeriods[0].StartTime);
-            Assert.AreEqual(new CalDateTime(2020, 1, 13), recurringPeriods[1].StartTime);
-            Assert.AreEqual(new CalDateTime(2020, 1, 20), recurringPeriods[2].StartTime);
-            Assert.AreEqual(new CalDateTime(2020, 1, 27), recurringPeriods[3].StartTime);
+            Assert.That(recurringPeriods, Has.Count.EqualTo(4));
+            Assert.Multiple(() =>
+            {
+                Assert.That(recurringPeriods[0].StartTime, Is.EqualTo(new CalDateTime(2020, 1, 6)));
+                Assert.That(recurringPeriods[1].StartTime, Is.EqualTo(new CalDateTime(2020, 1, 13)));
+                Assert.That(recurringPeriods[2].StartTime, Is.EqualTo(new CalDateTime(2020, 1, 20)));
+                Assert.That(recurringPeriods[3].StartTime, Is.EqualTo(new CalDateTime(2020, 1, 27)));
+            });
         }
 
         /// <summary>
@@ -2663,7 +2659,7 @@ namespace Ical.Net.Tests
                 
                 var period = recurringPeriods.ElementAt(recurringPeriods.Count - 1);
 
-                Assert.AreEqual(new CalDateTime(2025, 11, 24, 9, 0, 0), period.StartTime);
+                Assert.That(period.StartTime, Is.EqualTo(new CalDateTime(2025, 11, 24, 9, 0, 0)));
             }
         }
 
@@ -2691,7 +2687,7 @@ namespace Ical.Net.Tests
             evt.RecurrenceRules.Add(pattern);
 
             var occurrences = evt.GetOccurrences(new DateTime(2011, 1, 1), new DateTime(2012, 1, 1));
-            Assert.AreEqual(10, occurrences.Count, "There should be 10 occurrences of this event, one for each month except February and December.");
+            Assert.That(occurrences, Has.Count.EqualTo(10), "There should be 10 occurrences of this event, one for each month except February and December.");
         }
 
         /// <summary>
@@ -2706,8 +2702,8 @@ namespace Ical.Net.Tests
                 var serializer = new RecurrencePatternSerializer();
                 var rp = (RecurrencePattern)serializer.Deserialize(sr);
 
-                Assert.IsNotNull(rp);
-                Assert.AreEqual(new DateTime(2025, 11, 26), rp.Until);
+                Assert.That(rp, Is.Not.Null);
+                Assert.That(rp.Until, Is.EqualTo(new DateTime(2025, 11, 26)));
             }
         }
 
@@ -2737,19 +2733,19 @@ namespace Ical.Net.Tests
                 checkTime = checkTime.AddDays(i);
                 //Valid asking for the exact moment
                 var occurrences = vEvent.GetOccurrences(checkTime, checkTime);
-                Assert.AreEqual(1, occurrences.Count);
+                Assert.That(occurrences, Has.Count.EqualTo(1));
 
                 //Valid if asking for a range starting at the same moment
                 occurrences = vEvent.GetOccurrences(checkTime, checkTime.AddSeconds(1));
-                Assert.AreEqual(1, occurrences.Count);
+                Assert.That(occurrences, Has.Count.EqualTo(1));
 
                 //Valid if asking for a range starting before and ending after
                 occurrences = vEvent.GetOccurrences(checkTime.AddSeconds(-1), checkTime.AddSeconds(1));
-                Assert.AreEqual(1, occurrences.Count);
+                Assert.That(occurrences, Has.Count.EqualTo(1));
 
                 //Not valid if asking for a range starting before but ending at the same moment
                 occurrences = vEvent.GetOccurrences(checkTime.AddSeconds(-1), checkTime);
-                Assert.AreEqual(0, occurrences.Count);
+                Assert.That(occurrences.Count, Is.EqualTo(0));
             }
         }
 
@@ -2764,7 +2760,7 @@ namespace Ical.Net.Tests
             };
 
             var occurrences = vEvent.GetOccurrences(DateTime.Parse("2020-01-10T00:00"), DateTime.Parse("2020-01-11T00:00"));
-            Assert.AreEqual(0, occurrences.Count);
+            Assert.That(occurrences.Count, Is.EqualTo(0));
         }
 
         /// <summary>
@@ -2774,7 +2770,7 @@ namespace Ical.Net.Tests
         public void UsHolidays()
         {
             var iCal = Calendar.Load(IcsFiles.UsHolidays);
-            Assert.IsNotNull(iCal, "iCalendar was not loaded.");
+            Assert.That(iCal, Is.Not.Null, "iCalendar was not loaded.");
             var items = new Dictionary<string, CalDateTime>
             {
                 { "Christmas", new CalDateTime(2006, 12, 25)},
@@ -2810,13 +2806,16 @@ namespace Ical.Net.Tests
                 new CalDateTime(2006, 1, 1),
                 new CalDateTime(2006, 12, 31));
 
-            Assert.AreEqual(items.Count, occurrences.Count, "The number of holidays did not evaluate correctly.");
+            Assert.That(occurrences, Has.Count.EqualTo(items.Count), "The number of holidays did not evaluate correctly.");
             foreach (var o in occurrences)
             {
                 var evt = o.Source as CalendarEvent;
-                Assert.IsNotNull(evt);
-                Assert.IsTrue(items.ContainsKey(evt.Summary), "Holiday text '" + evt.Summary + "' did not match known holidays.");
-                Assert.AreEqual(items[evt.Summary], o.Period.StartTime, "Date/time of holiday '" + evt.Summary + "' did not match.");
+                Assert.That(evt, Is.Not.Null);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(items.ContainsKey(evt.Summary), Is.True, "Holiday text '" + evt.Summary + "' did not match known holidays.");
+                    Assert.That(o.Period.StartTime, Is.EqualTo(items[evt.Summary]), "Date/time of holiday '" + evt.Summary + "' did not match.");
+                });
             }
         }
 
@@ -2839,7 +2838,7 @@ namespace Ical.Net.Tests
             var occurrences = evt.GetOccurrences(CalDateTime.Today.AddDays(1), CalDateTime.Today.AddDays(2));
 
             foreach (var o in occurrences)
-                Assert.IsTrue(o.Period.StartTime.HasTime, "All recurrences of this event should have a time set.");
+                Assert.That(o.Period.StartTime.HasTime, Is.True, "All recurrences of this event should have a time set.");
         }
 
         [Test, Category("Recurrence")]
@@ -2857,7 +2856,7 @@ namespace Ical.Net.Tests
             var toDate = new CalDateTime(DateTime.Parse("3/31/08 12:00:11 AM", us));
 
             var evaluator = pattern.GetService(typeof(IEvaluator)) as IEvaluator;
-            Assert.IsNotNull(evaluator);
+            Assert.That(evaluator, Is.Not.Null);
 
             var occurrences = evaluator.Evaluate(
                 startDate, 
@@ -2866,11 +2865,14 @@ namespace Ical.Net.Tests
                 false)
                 .OrderBy(o => o.StartTime)
                 .ToList();
-            Assert.AreEqual(4, occurrences.Count);
-            Assert.AreEqual(new CalDateTime(DateTime.Parse("03/30/08 11:59:40 PM", us)), occurrences[0].StartTime);
-            Assert.AreEqual(new CalDateTime(DateTime.Parse("03/30/08 11:59:50 PM", us)), occurrences[1].StartTime);
-            Assert.AreEqual(new CalDateTime(DateTime.Parse("03/31/08 12:00:00 AM", us)), occurrences[2].StartTime);
-            Assert.AreEqual(new CalDateTime(DateTime.Parse("03/31/08 12:00:10 AM", us)), occurrences[3].StartTime);
+            Assert.That(occurrences, Has.Count.EqualTo(4));
+            Assert.Multiple(() =>
+            {
+                Assert.That(occurrences[0].StartTime, Is.EqualTo(new CalDateTime(DateTime.Parse("03/30/08 11:59:40 PM", us))));
+                Assert.That(occurrences[1].StartTime, Is.EqualTo(new CalDateTime(DateTime.Parse("03/30/08 11:59:50 PM", us))));
+                Assert.That(occurrences[2].StartTime, Is.EqualTo(new CalDateTime(DateTime.Parse("03/31/08 12:00:00 AM", us))));
+                Assert.That(occurrences[3].StartTime, Is.EqualTo(new CalDateTime(DateTime.Parse("03/31/08 12:00:10 AM", us))));
+            });
         }
 
         [Test, Category("Recurrence")]
@@ -2887,14 +2889,14 @@ namespace Ical.Net.Tests
             var toDate = new CalDateTime(DateTime.Parse("4/1/2008 10:43:23 AM", us));
 
             var evaluator = pattern.GetService(typeof(IEvaluator)) as IEvaluator;
-            Assert.IsNotNull(evaluator);
+            Assert.That(evaluator, Is.Not.Null);
 
             var occurrences = evaluator.Evaluate(
                 startDate, 
                 DateUtil.SimpleDateTimeToMatch(fromDate, startDate), 
                 DateUtil.SimpleDateTimeToMatch(toDate, startDate),
                 false);
-            Assert.AreNotEqual(0, occurrences.Count);
+            Assert.That(occurrences.Count, Is.Not.EqualTo(0));
         }
 
         [Test, Category("Recurrence")]
@@ -2914,16 +2916,16 @@ namespace Ical.Net.Tests
             var end = new CalDateTime(2009, 11, 23, 0, 0, 0);
 
             var occurrences = evt.GetOccurrences(previousDateAndTime, end);
-            Assert.AreEqual(5, occurrences.Count);
+            Assert.That(occurrences, Has.Count.EqualTo(5));
 
             occurrences = evt.GetOccurrences(previousDateOnly, end);
-            Assert.AreEqual(5, occurrences.Count);
+            Assert.That(occurrences, Has.Count.EqualTo(5));
 
             occurrences = evt.GetOccurrences(laterDateOnly, end);
-            Assert.AreEqual(4, occurrences.Count);
+            Assert.That(occurrences, Has.Count.EqualTo(4));
 
             occurrences = evt.GetOccurrences(laterDateAndTime, end);
-            Assert.AreEqual(3, occurrences.Count);
+            Assert.That(occurrences, Has.Count.EqualTo(3));
 
             // Add ByHour "9" and "12"            
             evt.RecurrenceRules[0].ByHour.Add(9);
@@ -2933,16 +2935,16 @@ namespace Ical.Net.Tests
             evt.ClearEvaluation();
 
             occurrences = evt.GetOccurrences(previousDateAndTime, end);
-            Assert.AreEqual(10, occurrences.Count);
+            Assert.That(occurrences, Has.Count.EqualTo(10));
 
             occurrences = evt.GetOccurrences(previousDateOnly, end);
-            Assert.AreEqual(10, occurrences.Count);
+            Assert.That(occurrences, Has.Count.EqualTo(10));
 
             occurrences = evt.GetOccurrences(laterDateOnly, end);
-            Assert.AreEqual(8, occurrences.Count);
+            Assert.That(occurrences, Has.Count.EqualTo(8));
 
             occurrences = evt.GetOccurrences(laterDateAndTime, end);
-            Assert.AreEqual(7, occurrences.Count);
+            Assert.That(occurrences, Has.Count.EqualTo(7));
         }
 
         [Test, Category("Recurrence")]
@@ -2955,13 +2957,11 @@ namespace Ical.Net.Tests
 
             RecurrencePattern recur = new RecurrencePattern();
             evt.RecurrenceRules.Add(recur);
-
-            try
+            
+            Assert.That(() =>
             {
-                var occurrences = evt.GetOccurrences(DateTime.Today.AddDays(1), DateTime.Today.AddDays(2));
-                Assert.Fail("An exception should be thrown when evaluating a recurrence with no specified FREQUENCY");
-            }
-            catch { }
+                _ = evt.GetOccurrences(DateTime.Today.AddDays(1), DateTime.Today.AddDays(2));
+            }, Throws.Exception, "An exception should be thrown when evaluating a recurrence with no specified FREQUENCY");
         }
 
         [Test, Category("Recurrence")]
@@ -2981,7 +2981,8 @@ namespace Ical.Net.Tests
             evt.RecurrenceRules.Add(recur);
 
             var serializer = new RecurrencePatternSerializer();
-            Assert.IsTrue(string.Compare(serializer.SerializeToString(recur), "FREQ=DAILY;COUNT=3;BYDAY=MO,WE,FR", StringComparison.Ordinal) == 0,
+            Assert.That(string.Compare(serializer.SerializeToString(recur), "FREQ=DAILY;COUNT=3;BYDAY=MO,WE,FR", StringComparison.Ordinal) == 0,
+                Is.True,
                 "Serialized recurrence string is incorrect");
         }
 
@@ -2998,7 +2999,7 @@ namespace Ical.Net.Tests
             IDateTime evtEnd = new CalDateTime(2007, 1, 1);
 
             var evaluator = rpattern.GetService(typeof(IEvaluator)) as IEvaluator;
-            Assert.IsNotNull(evaluator);
+            Assert.That(evaluator, Is.Not.Null);
 
             // Add the exception dates
             var periods = evaluator.Evaluate(
@@ -3008,17 +3009,20 @@ namespace Ical.Net.Tests
                 false)
                 .OrderBy(p => p.StartTime)
                 .ToList();
-            Assert.AreEqual(10, periods.Count);
-            Assert.AreEqual(2, periods[0].StartTime.Day);
-            Assert.AreEqual(3, periods[1].StartTime.Day);
-            Assert.AreEqual(9, periods[2].StartTime.Day);
-            Assert.AreEqual(10, periods[3].StartTime.Day);
-            Assert.AreEqual(16, periods[4].StartTime.Day);
-            Assert.AreEqual(17, periods[5].StartTime.Day);
-            Assert.AreEqual(23, periods[6].StartTime.Day);
-            Assert.AreEqual(24, periods[7].StartTime.Day);
-            Assert.AreEqual(30, periods[8].StartTime.Day);
-            Assert.AreEqual(31, periods[9].StartTime.Day);
+            Assert.That(periods, Has.Count.EqualTo(10));
+            Assert.Multiple(() =>
+            {
+                Assert.That(periods[0].StartTime.Day, Is.EqualTo(2));
+                Assert.That(periods[1].StartTime.Day, Is.EqualTo(3));
+                Assert.That(periods[2].StartTime.Day, Is.EqualTo(9));
+                Assert.That(periods[3].StartTime.Day, Is.EqualTo(10));
+                Assert.That(periods[4].StartTime.Day, Is.EqualTo(16));
+                Assert.That(periods[5].StartTime.Day, Is.EqualTo(17));
+                Assert.That(periods[6].StartTime.Day, Is.EqualTo(23));
+                Assert.That(periods[7].StartTime.Day, Is.EqualTo(24));
+                Assert.That(periods[8].StartTime.Day, Is.EqualTo(30));
+                Assert.That(periods[9].StartTime.Day, Is.EqualTo(31));
+            });
         }
 
         [Test, Category("Recurrence")]
@@ -3045,7 +3049,7 @@ END:VCALENDAR";
             var endSearch = new CalDateTime(2016, 12, 31, _tzid);
 
             var occurrences = firstEvent.GetOccurrences(startSearch, endSearch).Select(o => o.Period).ToList();
-            Assert.IsTrue(occurrences.Count == 0);
+            Assert.That(occurrences.Count == 0, Is.True);
         }
 
         [Test, Category("Recurrence")]
@@ -3079,13 +3083,13 @@ END:VCALENDAR";
                 .ToList();
 
             var firstExpectedOccurrence = new CalDateTime(DateTime.Parse("2016-08-29T08:00:00"), _tzid);
-            Assert.AreEqual(firstExpectedOccurrence, occurrences.First().StartTime);
+            Assert.That(occurrences.First().StartTime, Is.EqualTo(firstExpectedOccurrence));
 
             var firstExpectedRDate = new CalDateTime(DateTime.Parse("2016-08-30T10:00:00"), _tzid);
-            Assert.IsTrue(occurrences[1].StartTime.Equals(firstExpectedRDate));
+            Assert.That(occurrences[1].StartTime.Equals(firstExpectedRDate), Is.True);
 
             var secondExpectedRDate = new CalDateTime(DateTime.Parse("2016-08-31T10:00:00"), _tzid);
-            Assert.IsTrue(occurrences[2].StartTime.Equals(secondExpectedRDate));
+            Assert.That(occurrences[2].StartTime.Equals(secondExpectedRDate), Is.True);
         }
 
         [Test]
@@ -3128,7 +3132,7 @@ END:VCALENDAR";
             var calendar = new Calendar();
             calendar.Events.Add(e);
 
-            Assert.AreEqual(e, firstEvent);
+            Assert.That(firstEvent, Is.EqualTo(e));
 
             var startSearch = new CalDateTime(DateTime.Parse("2016-07-01T00:00:00"), "UTC");
             var endSearch = new CalDateTime(DateTime.Parse("2016-08-31T07:00:00"), "UTC");
@@ -3139,7 +3143,7 @@ END:VCALENDAR";
                     .OrderBy(p => p.StartTime)
                     .ToList();
 
-            Assert.IsFalse(occurrences.Last().StartTime.Equals(lastExpected));
+            Assert.That(occurrences.Last().StartTime.Equals(lastExpected), Is.False);
 
             //Create 1 second of overlap
             endSearch = new CalDateTime(endSearch.Value.AddSeconds(1), "UTC");
@@ -3148,7 +3152,7 @@ END:VCALENDAR";
                 .OrderBy(p => p.StartTime)
                 .ToList();
 
-            Assert.IsTrue(occurrences.Last().StartTime.Equals(lastExpected));
+            Assert.That(occurrences.Last().StartTime.Equals(lastExpected), Is.True);
         }
 
         [Test, Ignore("Turn on in v3")]
@@ -3228,13 +3232,19 @@ END:VCALENDAR";
 
             var expectedSept1Start = new CalDateTime(DateTime.Parse("2016-09-01T16:30:00"), "Europe/Bucharest");
             var expectedSept1End = new CalDateTime(DateTime.Parse("2016-09-01T22:00:00"), "Europe/Bucharest");
-            Assert.AreEqual(expectedSept1Start, orderedOccurrences[3].StartTime);
-            Assert.AreEqual(expectedSept1End, orderedOccurrences[3].EndTime);
+            Assert.Multiple(() =>
+            {
+                Assert.That(orderedOccurrences[3].StartTime, Is.EqualTo(expectedSept1Start));
+                Assert.That(orderedOccurrences[3].EndTime, Is.EqualTo(expectedSept1End));
+            });
 
             var expectedSept3Start = new CalDateTime(DateTime.Parse("2016-09-03T07:00:00"), "Europe/Bucharest");
             var expectedSept3End = new CalDateTime(DateTime.Parse("2016-09-01T12:30:00"), "Europe/Bucharest");
-            Assert.AreEqual(expectedSept3Start, orderedOccurrences[5].StartTime);
-            Assert.AreEqual(expectedSept3End, orderedOccurrences[5].EndTime);
+            Assert.Multiple(() =>
+            {
+                Assert.That(orderedOccurrences[5].StartTime, Is.EqualTo(expectedSept3Start));
+                Assert.That(orderedOccurrences[5].EndTime, Is.EqualTo(expectedSept3End));
+            });
         }
 
         [Test]
@@ -3244,21 +3254,21 @@ END:VCALENDAR";
             var searchEnd = _now.AddDays(7);
             var e = GetEventWithRecurrenceRules();
             var occurrences = e.GetOccurrences(searchStart, searchEnd);
-            Assert.IsTrue(occurrences.Count == 5);
+            Assert.That(occurrences.Count == 5, Is.True);
 
             var exDate = _now.AddDays(1);
             var period = new Period(new CalDateTime(exDate));
             var periodList = new PeriodList { period };
             e.ExceptionDates.Add(periodList);
             occurrences = e.GetOccurrences(searchStart, searchEnd);
-            Assert.IsTrue(occurrences.Count == 4);
+            Assert.That(occurrences.Count == 4, Is.True);
 
             //Specifying just a date should "black out" that date
             var excludeTwoDaysFromNow = _now.AddDays(2).Date;
             period = new Period(new CalDateTime(excludeTwoDaysFromNow));
             periodList.Add(period);
             occurrences = e.GetOccurrences(searchStart, searchEnd);
-            Assert.IsTrue(occurrences.Count == 3);
+            Assert.That(occurrences.Count == 3, Is.True);
         }
 
         private static readonly DateTime _now = DateTime.Now;
@@ -3296,12 +3306,12 @@ END:VCALENDAR";
             var firstExclusion = new CalDateTime(start.AddDays(4));
             e.ExceptionDates = new List<PeriodList> { new PeriodList { new Period(firstExclusion) } };
             var serialized = SerializationHelpers.SerializeToString(e);
-            Assert.AreEqual(1, Regex.Matches(serialized, "EXDATE:").Count);
+            Assert.That(Regex.Matches(serialized, "EXDATE:"), Has.Count.EqualTo(1));
 
             var secondExclusion = new CalDateTime(start.AddDays(5));
             e.ExceptionDates.First().Add(new Period(secondExclusion));
             serialized = SerializationHelpers.SerializeToString(e);
-            Assert.AreEqual(1, Regex.Matches(serialized, "EXDATE:").Count);
+            Assert.That(Regex.Matches(serialized, "EXDATE:"), Has.Count.EqualTo(1));
         }
 
         [Test]
@@ -3325,11 +3335,11 @@ END:VCALENDAR";
 
             var serialized = SerializationHelpers.SerializeToString(e);
             const string expected = "TZID=Europe/Stockholm";
-            Assert.AreEqual(3, Regex.Matches(serialized, expected).Count);
+            Assert.That(Regex.Matches(serialized, expected), Has.Count.EqualTo(3));
 
             e.ExceptionDates.First().Add(new Period(new CalDateTime(_now.AddDays(2))));
             serialized = SerializationHelpers.SerializeToString(e);
-            Assert.AreEqual(3, Regex.Matches(serialized, expected).Count);
+            Assert.That(Regex.Matches(serialized, expected), Has.Count.EqualTo(3));
         }
 
         [Test, Category("Recurrence")]
@@ -3349,7 +3359,7 @@ END:VCALENDAR";
 
                 //Valid if asking for a range starting at the same moment
                 var occurrences = vEvent.GetOccurrences(checkTime, checkTime.AddDays(1));
-                Assert.AreEqual(i == 0 ? 1 : 0, occurrences.Count);
+                Assert.That(occurrences, Has.Count.EqualTo(i == 0 ? 1 : 0));
             }
         }
 
@@ -3372,19 +3382,19 @@ END:VCALENDAR";
             var testingTime = new DateTime(2019, 6, 7, 9, 0, 0);
 
             var occurrences = vEvent.GetOccurrences(testingTime, testingTime);
-            Assert.AreEqual(1, occurrences.Count);
+            Assert.That(occurrences, Has.Count.EqualTo(1));
 
             // One second before end time
             testingTime = new DateTime(2019, 6, 7, 16, 59, 59);
 
             occurrences = vEvent.GetOccurrences(testingTime, testingTime);
-            Assert.AreEqual(1, occurrences.Count);
+            Assert.That(occurrences, Has.Count.EqualTo(1));
 
             // Exactly on end time
             testingTime = new DateTime(2019, 6, 7, 17, 0, 0);
 
             occurrences = vEvent.GetOccurrences(testingTime, testingTime);
-            Assert.AreEqual(0, occurrences.Count);
+            Assert.That(occurrences.Count, Is.EqualTo(0));
         }
 
         private static RecurrencePattern GetSimpleRecurrencePattern(int count) => new RecurrencePattern(FrequencyType.Daily, 1) { Count = count, };
@@ -3404,7 +3414,7 @@ END:VCALENDAR";
         {
             var five = GetSimpleRecurrencePattern(5);
             var ten = GetSimpleRecurrencePattern(10);
-            Assert.AreNotEqual(five, ten);
+            Assert.That(ten, Is.Not.EqualTo(five));
             var eventA = GetSimpleEvent();
             eventA.RecurrenceRules.Add(five);
             eventA.RecurrenceRules.Add(ten);
@@ -3413,7 +3423,7 @@ END:VCALENDAR";
             eventB.RecurrenceRules.Add(ten);
             eventB.RecurrenceRules.Add(five);
 
-            Assert.AreEqual(eventA, eventB);
+            Assert.That(eventB, Is.EqualTo(eventA));
 
             const string aString = @"BEGIN:VCALENDAR
 PRODID:-//github.com/rianjs/ical.net//NONSGML ical.net 2.2//EN
@@ -3472,13 +3482,13 @@ END:VCALENDAR";
 
             //GetHashCode tests also tests Equals()
             var calendarSet = new HashSet<Calendar>(calendarList);
-            Assert.AreEqual(1, calendarSet.Count);
+            Assert.That(calendarSet, Has.Count.EqualTo(1));
             var eventSet = new HashSet<CalendarEvent>(eventList);
-            Assert.AreEqual(1, eventSet.Count);
+            Assert.That(eventSet, Has.Count.EqualTo(1));
 
             var newEventList = new HashSet<CalendarEvent>();
             newEventList.UnionWith(eventList);
-            Assert.AreEqual(1, newEventList.Count);
+            Assert.That(newEventList, Has.Count.EqualTo(1));
         }
 
         [Test]
@@ -3532,36 +3542,38 @@ END:VCALENDAR";
 
             //Tautologies...
             var collectionA = CalendarCollection.Load(icalA);
-            Assert.AreEqual(collectionA, collectionA);
-            Assert.AreEqual(collectionA.GetHashCode(), collectionA.GetHashCode());
+            Assert.That(collectionA, Is.EqualTo(collectionA));
+            Assert.That(collectionA.GetHashCode(), Is.EqualTo(collectionA.GetHashCode()));
             var calendarA = collectionA.First();
-            Assert.AreEqual(calendarA, calendarA);
-            Assert.AreEqual(calendarA.GetHashCode(), calendarA.GetHashCode());
+            Assert.That(calendarA, Is.EqualTo(calendarA));
+            Assert.That(calendarA.GetHashCode(), Is.EqualTo(calendarA.GetHashCode()));
             var eventA = calendarA.Events.First();
-            Assert.AreEqual(eventA, eventA);
-            Assert.AreEqual(eventA.GetHashCode(), eventA.GetHashCode());
+            Assert.That(eventA, Is.EqualTo(eventA));
+            Assert.That(eventA.GetHashCode(), Is.EqualTo(eventA.GetHashCode()));
 
             var collectionB = CalendarCollection.Load(icalB);
-            Assert.AreEqual(collectionB, collectionB);
-            Assert.AreEqual(collectionB.GetHashCode(), collectionB.GetHashCode());
+            Assert.That(collectionB, Is.EqualTo(collectionB));
+            Assert.That(collectionB.GetHashCode(), Is.EqualTo(collectionB.GetHashCode()));
             var calendarB = collectionB.First();
-            Assert.AreEqual(calendarB, calendarB);
-            Assert.AreEqual(calendarB.GetHashCode(), calendarB.GetHashCode());
+            Assert.That(calendarB, Is.EqualTo(calendarB));
+            Assert.That(calendarB.GetHashCode(), Is.EqualTo(calendarB.GetHashCode()));
             var eventB = calendarB.Events.First();
-            Assert.AreEqual(eventB, eventB);
-            Assert.AreEqual(eventB.GetHashCode(), eventB.GetHashCode());
-
-            //Comparing the two...
-            Assert.AreEqual(collectionA, collectionB);
-            Assert.AreEqual(collectionA.GetHashCode(), collectionB.GetHashCode());
-            Assert.AreEqual(calendarA, calendarB);
-            Assert.AreEqual(calendarA.GetHashCode(), calendarB.GetHashCode());
-            Assert.AreEqual(eventA, eventB);
-            Assert.AreEqual(eventA.GetHashCode(), eventB.GetHashCode());
+            
+            Assert.Multiple(() =>
+            {
+                //Comparing the two...
+                Assert.That(collectionB, Is.EqualTo(collectionA));
+                Assert.That(collectionB.GetHashCode(), Is.EqualTo(collectionA.GetHashCode()));
+                Assert.That(calendarB, Is.EqualTo(calendarA));
+                Assert.That(calendarB.GetHashCode(), Is.EqualTo(calendarA.GetHashCode()));
+                Assert.That(eventB, Is.EqualTo(eventA));
+                Assert.That(eventB.GetHashCode(), Is.EqualTo(eventA.GetHashCode()));
+            });
+            
 
             var exDatesA = eventA.ExceptionDates;
             var exDatesB = eventB.ExceptionDates;
-            Assert.AreEqual(exDatesA, exDatesB);
+            Assert.That(exDatesB, Is.EqualTo(exDatesA));
 
         }
 
@@ -3596,14 +3608,14 @@ END:VCALENDAR";
                 ? $"{contains}{SerializationConstants.LineBreak}"
                 : $"{contains}Z{SerializationConstants.LineBreak}";
 
-            Assert.IsTrue(serialized.Contains(expectedContains));
+            Assert.That(serialized.Contains(expectedContains), Is.True);
 
             var deserializedKind = Calendar.Load(serialized).Events.First().RecurrenceRules.First().Until.Kind;
 
-            Assert.AreEqual(expectedKind, deserializedKind);
+            Assert.That(deserializedKind, Is.EqualTo(expectedKind));
         }
 
-        public static IEnumerable<ITestCaseData> UntilTimeZoneSerializationTestCases()
+        public static IEnumerable UntilTimeZoneSerializationTestCases()
         {
             yield return new TestCaseData("America/New_York", DateTimeKind.Local)
                 .SetName("IANA time time zone results in a local DateTimeKind");
@@ -3641,7 +3653,7 @@ END:VCALENDAR
             var endSearch = new CalDateTime(DateTime.Parse("2018-07-01T00:00:00"), timeZoneId);
 
             var occurrences = firstEvent.GetOccurrences(startSearch, endSearch);
-            Assert.AreEqual(5, occurrences.Count);
+            Assert.That(occurrences, Has.Count.EqualTo(5));
         }
     }
 }

--- a/Ical.Net.Tests/SimpleDeserializationTests.cs
+++ b/Ical.Net.Tests/SimpleDeserializationTests.cs
@@ -20,32 +20,41 @@ namespace Ical.Net.Tests
         public void Attendee1()
         {
             var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Attendee1)).Cast<Calendar>().Single();
-            Assert.AreEqual(1, iCal.Events.Count);
+            Assert.That(iCal.Events, Has.Count.EqualTo(1));
 
             var evt = iCal.Events.First();
             // Ensure there are 2 attendees
-            Assert.AreEqual(2, evt.Attendees.Count);
+            Assert.That(evt.Attendees, Has.Count.EqualTo(2));
 
             var attendee1 = evt.Attendees;
             var attendee2 = evt.Attendees[1];
 
-            // Values
-            Assert.AreEqual(new Uri("mailto:joecool@example.com"), attendee1[0].Value);
-            Assert.AreEqual(new Uri("mailto:ildoit@example.com"), attendee2.Value);
-
-            // MEMBERS
-            Assert.AreEqual(1, attendee1[0].Members.Count);
-            Assert.AreEqual(0, attendee2.Members.Count);
-            Assert.AreEqual(new Uri("mailto:DEV-GROUP@example.com"), attendee1[0].Members[0]);
-
-            // DELEGATED-FROM
-            Assert.AreEqual(0, attendee1[0].DelegatedFrom.Count);
-            Assert.AreEqual(1, attendee2.DelegatedFrom.Count);
-            Assert.AreEqual(new Uri("mailto:immud@example.com"), attendee2.DelegatedFrom[0]);
-
-            // DELEGATED-TO
-            Assert.AreEqual(0, attendee1[0].DelegatedTo.Count);
-            Assert.AreEqual(0, attendee2.DelegatedTo.Count);
+            Assert.Multiple(() =>
+            {
+                // Values
+                Assert.That(attendee1[0].Value, Is.EqualTo(new Uri("mailto:joecool@example.com")));
+                Assert.That(attendee2.Value, Is.EqualTo(new Uri("mailto:ildoit@example.com")));
+            });
+            Assert.Multiple(() =>
+            {
+                // MEMBERS
+                Assert.That(attendee1[0].Members, Has.Count.EqualTo(1));
+                Assert.That(attendee2.Members.Count, Is.EqualTo(0));
+                Assert.That(attendee1[0].Members[0], Is.EqualTo(new Uri("mailto:DEV-GROUP@example.com").ToString()));
+            });
+            Assert.Multiple(() =>
+            {
+                // DELEGATED-FROM
+                Assert.That(attendee1[0].DelegatedFrom.Count, Is.EqualTo(0));
+                Assert.That(attendee2.DelegatedFrom, Has.Count.EqualTo(1));
+                Assert.That(attendee2.DelegatedFrom[0], Is.EqualTo(new Uri("mailto:immud@example.com").ToString()));
+            });
+            Assert.Multiple(() =>
+            {
+                // DELEGATED-TO
+                Assert.That(attendee1[0].DelegatedTo.Count, Is.EqualTo(0));
+                Assert.That(attendee2.DelegatedTo.Count, Is.EqualTo(0));
+            });
         }
 
         /// <summary>
@@ -57,22 +66,28 @@ namespace Ical.Net.Tests
         public void Attendee2()
         {
             var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Attendee2)).Cast<Calendar>().Single();
-            Assert.AreEqual(1, iCal.Events.Count);
+            Assert.That(iCal.Events, Has.Count.EqualTo(1));
 
             var evt = iCal.Events.First();
             // Ensure there is 1 attendee
-            Assert.AreEqual(1, evt.Attendees.Count);
+            Assert.That(evt.Attendees, Has.Count.EqualTo(1));
 
             var attendee1 = evt.Attendees;
 
-            // Values
-            Assert.AreEqual(new Uri("mailto:joecool@example.com"), attendee1[0].Value);
+            Assert.Multiple(() =>
+            {
+                // Values
+                Assert.That(attendee1[0].Value, Is.EqualTo(new Uri("mailto:joecool@example.com")));
 
-            // MEMBERS
-            Assert.AreEqual(3, attendee1[0].Members.Count);
-            Assert.AreEqual(new Uri("mailto:DEV-GROUP@example.com"), attendee1[0].Members[0]);
-            Assert.AreEqual(new Uri("mailto:ANOTHER-GROUP@example.com"), attendee1[0].Members[1]);
-            Assert.AreEqual(new Uri("mailto:THIRD-GROUP@example.com"), attendee1[0].Members[2]);
+                // MEMBERS
+                Assert.That(attendee1[0].Members, Has.Count.EqualTo(3));
+            });
+            Assert.Multiple(() =>
+            {
+                Assert.That(attendee1[0].Members[0], Is.EqualTo(new Uri("mailto:DEV-GROUP@example.com").ToString()));
+                Assert.That(attendee1[0].Members[1], Is.EqualTo(new Uri("mailto:ANOTHER-GROUP@example.com").ToString()));
+                Assert.That(attendee1[0].Members[2], Is.EqualTo(new Uri("mailto:THIRD-GROUP@example.com").ToString()));
+            });
         }
 
         /// <summary>
@@ -84,8 +99,11 @@ namespace Ical.Net.Tests
         public void Bug2033495()
         {
             var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Bug2033495)).Cast<Calendar>().Single();
-            Assert.AreEqual(1, iCal.Events.Count);
-            Assert.AreEqual(iCal.Properties["X-LOTUS-CHILD_UID"].Value, "XXX");
+            Assert.Multiple(() =>
+            {
+                Assert.That(iCal.Events, Has.Count.EqualTo(1));
+                Assert.That(iCal.Properties["X-LOTUS-CHILD_UID"].Value, Is.EqualTo("XXX"));
+            });
         }
 
         /// <summary>
@@ -96,16 +114,22 @@ namespace Ical.Net.Tests
         public void Bug2938007()
         {
             var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Bug2938007)).Cast<Calendar>().Single();
-            Assert.AreEqual(1, iCal.Events.Count);
+            Assert.That(iCal.Events, Has.Count.EqualTo(1));
 
             var evt = iCal.Events.First();
-            Assert.AreEqual(true, evt.Start.HasTime);
-            Assert.AreEqual(true, evt.End.HasTime);
+            Assert.Multiple(() =>
+            {
+                Assert.That(evt.Start.HasTime, Is.EqualTo(true));
+                Assert.That(evt.End.HasTime, Is.EqualTo(true));
+            });
 
             foreach (var o in evt.GetOccurrences(new CalDateTime(2010, 1, 17, 0, 0, 0), new CalDateTime(2010, 2, 1, 0, 0, 0)))
             {
-                Assert.AreEqual(true, o.Period.StartTime.HasTime);
-                Assert.AreEqual(true, o.Period.EndTime.HasTime);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(o.Period.StartTime.HasTime, Is.EqualTo(true));
+                    Assert.That(o.Period.EndTime.HasTime, Is.EqualTo(true));
+                });
             }
         }
 
@@ -122,7 +146,7 @@ namespace Ical.Net.Tests
             var ms = new MemoryStream();
             serializer.Serialize(calendar, ms, Encoding.UTF8);
 
-            Assert.IsTrue(ms.CanWrite);
+            Assert.That(ms.CanWrite, Is.True);
         }
 
         /// <summary>
@@ -132,7 +156,7 @@ namespace Ical.Net.Tests
         public void CaseInsensitive4()
         {
             var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.CaseInsensitive4)).Cast<Calendar>().Single();
-            Assert.AreEqual("2.5", iCal.Version);
+            Assert.That(iCal.Version, Is.EqualTo("2.5"));
         }
 
         [Test, Category("Deserialization")]
@@ -157,23 +181,26 @@ namespace Ical.Net.Tests
             }
 
             foreach (string item in items)
-                Assert.IsTrue(found.ContainsKey(item), "Event should contain CATEGORY '" + item + "', but it was not found.");
+                Assert.That(found.ContainsKey(item), Is.True, "Event should contain CATEGORY '" + item + "', but it was not found.");
         }
 
         [Test, Category("Deserialization")]
         public void EmptyLines1()
         {
             var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.EmptyLines1)).Cast<Calendar>().Single();
-            Assert.AreEqual(2, iCal.Events.Count, "iCalendar should have 2 events");
+            Assert.That(iCal.Events, Has.Count.EqualTo(2), "iCalendar should have 2 events");
         }
 
         [Test, Category("Deserialization")]
         public void EmptyLines2()
         {
             var calendars = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.EmptyLines2)).Cast<Calendar>().ToList();
-            Assert.AreEqual(2, calendars.Count);
-            Assert.AreEqual(2, calendars[0].Events.Count, "iCalendar should have 2 events");
-            Assert.AreEqual(2, calendars[1].Events.Count, "iCalendar should have 2 events");
+            Assert.That(calendars, Has.Count.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(calendars[0].Events, Has.Count.EqualTo(2), "iCalendar should have 2 events");
+                Assert.That(calendars[1].Events, Has.Count.EqualTo(2), "iCalendar should have 2 events");
+            });
         }
 
         /// <summary>
@@ -184,7 +211,7 @@ namespace Ical.Net.Tests
         public void EmptyLines3()
         {
             var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.EmptyLines3)).Cast<Calendar>().Single();
-            Assert.AreEqual(1, iCal.Todos.Count, "iCalendar should have 1 todo");
+            Assert.That(iCal.Todos, Has.Count.EqualTo(1), "iCalendar should have 1 todo");
         }
 
         /// <summary>
@@ -194,7 +221,7 @@ namespace Ical.Net.Tests
         public void EmptyLines4()
         {
             var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.EmptyLines4)).Cast<Calendar>().Single();
-            Assert.AreEqual(28, iCal.Events.Count);
+            Assert.That(iCal.Events, Has.Count.EqualTo(28));
         }
 
         [Test]
@@ -204,7 +231,9 @@ namespace Ical.Net.Tests
             ProgramTest.TestCal(iCal);
             var evt = iCal.Events.First();
 
-            Assert.AreEqual(
+            Assert.That(
+evt.Attachments[0].ToString(),
+                Is.EqualTo("This is a test to try out base64 encoding without being too large.\r\n" +
 "This is a test to try out base64 encoding without being too large.\r\n" +
 "This is a test to try out base64 encoding without being too large.\r\n" +
 "This is a test to try out base64 encoding without being too large.\r\n" +
@@ -215,9 +244,7 @@ namespace Ical.Net.Tests
 "This is a test to try out base64 encoding without being too large.\r\n" +
 "This is a test to try out base64 encoding without being too large.\r\n" +
 "This is a test to try out base64 encoding without being too large.\r\n" +
-"This is a test to try out base64 encoding without being too large.\r\n" +
-"This is a test to try out base64 encoding without being too large.",
-                evt.Attachments[0].ToString(),
+"This is a test to try out base64 encoding without being too large."),
                 "Attached value does not match.");
         }
 
@@ -228,8 +255,11 @@ namespace Ical.Net.Tests
             ProgramTest.TestCal(iCal);
             var evt = iCal.Events.First();
 
-            Assert.AreEqual("uuid1153170430406", evt.Uid, "UID should be 'uuid1153170430406'; it is " + evt.Uid);
-            Assert.AreEqual(1, evt.Sequence, "SEQUENCE should be 1; it is " + evt.Sequence);
+            Assert.Multiple(() =>
+            {
+                Assert.That(evt.Uid, Is.EqualTo("uuid1153170430406"), "UID should be 'uuid1153170430406'; it is " + evt.Uid);
+                Assert.That(evt.Sequence, Is.EqualTo(1), "SEQUENCE should be 1; it is " + evt.Sequence);
+            });
         }
 
         [Test, Category("Deserialization")]
@@ -266,9 +296,9 @@ END:VEVENT
 END:VCALENDAR
 ");
             var iCal = SimpleDeserializer.Default.Deserialize(sr).Cast<Calendar>().Single();
-            Assert.IsTrue(iCal.Events.Count == 2, "There should be 2 events in the parsed calendar");
-            Assert.IsNotNull(iCal.Events["fd940618-45e2-4d19-b118-37fd7a8e3906"], "Event fd940618-45e2-4d19-b118-37fd7a8e3906 should exist in the calendar");
-            Assert.IsNotNull(iCal.Events["ebfbd3e3-cc1e-4a64-98eb-ced2598b3908"], "Event ebfbd3e3-cc1e-4a64-98eb-ced2598b3908 should exist in the calendar");
+            Assert.That(iCal.Events.Count == 2, Is.True, "There should be 2 events in the parsed calendar");
+            Assert.That(iCal.Events["fd940618-45e2-4d19-b118-37fd7a8e3906"], Is.Not.Null, "Event fd940618-45e2-4d19-b118-37fd7a8e3906 should exist in the calendar");
+            Assert.That(iCal.Events["ebfbd3e3-cc1e-4a64-98eb-ced2598b3908"], Is.Not.Null, "Event ebfbd3e3-cc1e-4a64-98eb-ced2598b3908 should exist in the calendar");
         }
 
         [Test]
@@ -278,8 +308,11 @@ END:VCALENDAR
             ProgramTest.TestCal(iCal);
             var evt = iCal.Events.First();
 
-            Assert.AreEqual(37.386013, evt.GeographicLocation.Latitude, "Latitude should be 37.386013; it is not.");
-            Assert.AreEqual(-122.082932, evt.GeographicLocation.Longitude, "Longitude should be -122.082932; it is not.");
+            Assert.Multiple(() =>
+            {
+                Assert.That(evt.GeographicLocation.Latitude, Is.EqualTo(37.386013), "Latitude should be 37.386013; it is not.");
+                Assert.That(evt.GeographicLocation.Longitude, Is.EqualTo(-122.082932), "Longitude should be -122.082932; it is not.");
+            });
         }
 
         [Test, Category("Deserialization")]
@@ -288,7 +321,7 @@ END:VCALENDAR
             var tzId = "Europe/Berlin";
             var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Google1)).Cast<Calendar>().Single();
             var evt = iCal.Events["594oeajmftl3r9qlkb476rpr3c@google.com"];
-            Assert.IsNotNull(evt);
+            Assert.That(evt, Is.Not.Null);
 
             IDateTime dtStart = new CalDateTime(2006, 12, 18, tzId);
             IDateTime dtEnd = new CalDateTime(2006, 12, 23, tzId);
@@ -304,9 +337,9 @@ END:VCALENDAR
             };
 
             for (var i = 0; i < dateTimes.Length; i++)
-                Assert.AreEqual(dateTimes[i], occurrences[i].Period.StartTime, "Event should occur at " + dateTimes[i]);
+                Assert.That(occurrences[i].Period.StartTime, Is.EqualTo(dateTimes[i]), "Event should occur at " + dateTimes[i]);
 
-            Assert.AreEqual(dateTimes.Length, occurrences.Count, "There should be exactly " + dateTimes.Length + " occurrences; there were " + occurrences.Count);
+            Assert.That(occurrences, Has.Count.EqualTo(dateTimes.Length), "There should be exactly " + dateTimes.Length + " occurrences; there were " + occurrences.Count);
         }
 
         /// <summary>
@@ -316,23 +349,26 @@ END:VCALENDAR
         public void RecurrenceDates1()
         {
             var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.RecurrenceDates1)).Cast<Calendar>().Single();
-            Assert.AreEqual(1, iCal.Events.Count);
-            Assert.AreEqual(3, iCal.Events.First().RecurrenceDates.Count);
+            Assert.That(iCal.Events, Has.Count.EqualTo(1));
+            Assert.That(iCal.Events.First().RecurrenceDates, Has.Count.EqualTo(3));
 
-            Assert.AreEqual((CalDateTime)new DateTime(1997, 7, 14, 12, 30, 0, DateTimeKind.Utc), iCal.Events.First().RecurrenceDates[0][0].StartTime);
-            Assert.AreEqual((CalDateTime)new DateTime(1996, 4, 3, 2, 0, 0, DateTimeKind.Utc), iCal.Events.First().RecurrenceDates[1][0].StartTime);
-            Assert.AreEqual((CalDateTime)new DateTime(1996, 4, 3, 4, 0, 0, DateTimeKind.Utc), iCal.Events.First().RecurrenceDates[1][0].EndTime);
-            Assert.AreEqual(new CalDateTime(1997, 1, 1), iCal.Events.First().RecurrenceDates[2][0].StartTime);
-            Assert.AreEqual(new CalDateTime(1997, 1, 20), iCal.Events.First().RecurrenceDates[2][1].StartTime);
-            Assert.AreEqual(new CalDateTime(1997, 2, 17), iCal.Events.First().RecurrenceDates[2][2].StartTime);
-            Assert.AreEqual(new CalDateTime(1997, 4, 21), iCal.Events.First().RecurrenceDates[2][3].StartTime);
-            Assert.AreEqual(new CalDateTime(1997, 5, 26), iCal.Events.First().RecurrenceDates[2][4].StartTime);
-            Assert.AreEqual(new CalDateTime(1997, 7, 4), iCal.Events.First().RecurrenceDates[2][5].StartTime);
-            Assert.AreEqual(new CalDateTime(1997, 9, 1), iCal.Events.First().RecurrenceDates[2][6].StartTime);
-            Assert.AreEqual(new CalDateTime(1997, 10, 14), iCal.Events.First().RecurrenceDates[2][7].StartTime);
-            Assert.AreEqual(new CalDateTime(1997, 11, 28), iCal.Events.First().RecurrenceDates[2][8].StartTime);
-            Assert.AreEqual(new CalDateTime(1997, 11, 29), iCal.Events.First().RecurrenceDates[2][9].StartTime);
-            Assert.AreEqual(new CalDateTime(1997, 12, 25), iCal.Events.First().RecurrenceDates[2][10].StartTime);
+            Assert.Multiple(() =>
+            {
+                Assert.That(iCal.Events.First().RecurrenceDates[0][0].StartTime, Is.EqualTo((CalDateTime)new DateTime(1997, 7, 14, 12, 30, 0, DateTimeKind.Utc)));
+                Assert.That(iCal.Events.First().RecurrenceDates[1][0].StartTime, Is.EqualTo((CalDateTime)new DateTime(1996, 4, 3, 2, 0, 0, DateTimeKind.Utc)));
+                Assert.That(iCal.Events.First().RecurrenceDates[1][0].EndTime, Is.EqualTo((CalDateTime)new DateTime(1996, 4, 3, 4, 0, 0, DateTimeKind.Utc)));
+                Assert.That(iCal.Events.First().RecurrenceDates[2][0].StartTime, Is.EqualTo(new CalDateTime(1997, 1, 1)));
+                Assert.That(iCal.Events.First().RecurrenceDates[2][1].StartTime, Is.EqualTo(new CalDateTime(1997, 1, 20)));
+                Assert.That(iCal.Events.First().RecurrenceDates[2][2].StartTime, Is.EqualTo(new CalDateTime(1997, 2, 17)));
+                Assert.That(iCal.Events.First().RecurrenceDates[2][3].StartTime, Is.EqualTo(new CalDateTime(1997, 4, 21)));
+                Assert.That(iCal.Events.First().RecurrenceDates[2][4].StartTime, Is.EqualTo(new CalDateTime(1997, 5, 26)));
+                Assert.That(iCal.Events.First().RecurrenceDates[2][5].StartTime, Is.EqualTo(new CalDateTime(1997, 7, 4)));
+                Assert.That(iCal.Events.First().RecurrenceDates[2][6].StartTime, Is.EqualTo(new CalDateTime(1997, 9, 1)));
+                Assert.That(iCal.Events.First().RecurrenceDates[2][7].StartTime, Is.EqualTo(new CalDateTime(1997, 10, 14)));
+                Assert.That(iCal.Events.First().RecurrenceDates[2][8].StartTime, Is.EqualTo(new CalDateTime(1997, 11, 28)));
+                Assert.That(iCal.Events.First().RecurrenceDates[2][9].StartTime, Is.EqualTo(new CalDateTime(1997, 11, 29)));
+                Assert.That(iCal.Events.First().RecurrenceDates[2][10].StartTime, Is.EqualTo(new CalDateTime(1997, 12, 25)));
+            });
         }
 
         /// <summary>
@@ -342,32 +378,44 @@ END:VCALENDAR
         public void RequestStatus1()
         {
             var iCal = Calendar.Load(IcsFiles.RequestStatus1);
-            Assert.AreEqual(1, iCal.Events.Count);
-            Assert.AreEqual(4, iCal.Events.First().RequestStatuses.Count);
+            Assert.That(iCal.Events, Has.Count.EqualTo(1));
+            Assert.That(iCal.Events.First().RequestStatuses, Has.Count.EqualTo(4));
 
             var rs = iCal.Events.First().RequestStatuses[0];
-            Assert.AreEqual(2, rs.StatusCode.Primary);
-            Assert.AreEqual(0, rs.StatusCode.Secondary);
-            Assert.AreEqual("Success", rs.Description);
-            Assert.IsNull(rs.ExtraData);
+            Assert.Multiple(() =>
+            {
+                Assert.That(rs.StatusCode.Primary, Is.EqualTo(2));
+                Assert.That(rs.StatusCode.Secondary, Is.EqualTo(0));
+                Assert.That(rs.Description, Is.EqualTo("Success"));
+            });
+            Assert.That(rs.ExtraData, Is.Null);
 
             rs = iCal.Events.First().RequestStatuses[1];
-            Assert.AreEqual(3, rs.StatusCode.Primary);
-            Assert.AreEqual(1, rs.StatusCode.Secondary);
-            Assert.AreEqual("Invalid property value", rs.Description);
-            Assert.AreEqual("DTSTART:96-Apr-01", rs.ExtraData);
+            Assert.Multiple(() =>
+            {
+                Assert.That(rs.StatusCode.Primary, Is.EqualTo(3));
+                Assert.That(rs.StatusCode.Secondary, Is.EqualTo(1));
+                Assert.That(rs.Description, Is.EqualTo("Invalid property value"));
+                Assert.That(rs.ExtraData, Is.EqualTo("DTSTART:96-Apr-01"));
+            });
 
             rs = iCal.Events.First().RequestStatuses[2];
-            Assert.AreEqual(2, rs.StatusCode.Primary);
-            Assert.AreEqual(8, rs.StatusCode.Secondary);
-            Assert.AreEqual(" Success, repeating event ignored. Scheduled as a single event.", rs.Description);
-            Assert.AreEqual("RRULE:FREQ=WEEKLY;INTERVAL=2", rs.ExtraData);
+            Assert.Multiple(() =>
+            {
+                Assert.That(rs.StatusCode.Primary, Is.EqualTo(2));
+                Assert.That(rs.StatusCode.Secondary, Is.EqualTo(8));
+                Assert.That(rs.Description, Is.EqualTo(" Success, repeating event ignored. Scheduled as a single event."));
+                Assert.That(rs.ExtraData, Is.EqualTo("RRULE:FREQ=WEEKLY;INTERVAL=2"));
+            });
 
             rs = iCal.Events.First().RequestStatuses[3];
-            Assert.AreEqual(4, rs.StatusCode.Primary);
-            Assert.AreEqual(1, rs.StatusCode.Secondary);
-            Assert.AreEqual("Event conflict. Date/time is busy.", rs.Description);
-            Assert.IsNull(rs.ExtraData);
+            Assert.Multiple(() =>
+            {
+                Assert.That(rs.StatusCode.Primary, Is.EqualTo(4));
+                Assert.That(rs.StatusCode.Secondary, Is.EqualTo(1));
+                Assert.That(rs.Description, Is.EqualTo("Event conflict. Date/time is busy."));
+            });
+            Assert.That(rs.ExtraData, Is.Null);
         }
 
         /// <summary>
@@ -380,16 +428,16 @@ END:VCALENDAR
             var value = @"test\with\;characters";
             var unescaped = (string)serializer.Deserialize(new StringReader(value));
 
-            Assert.AreEqual(@"test\with;characters", unescaped, "String unescaping was incorrect.");
+            Assert.That(unescaped, Is.EqualTo(@"test\with;characters"), "String unescaping was incorrect.");
 
             value = @"C:\Path\To\My\New\Information";
             unescaped = (string)serializer.Deserialize(new StringReader(value));
-            Assert.AreEqual("C:\\Path\\To\\My\new\\Information", unescaped, "String unescaping was incorrect.");
+            Assert.That(unescaped, Is.EqualTo("C:\\Path\\To\\My\new\\Information"), "String unescaping was incorrect.");
 
             value = @"\""This\r\nis\Na\, test\""\;\\;,";
             unescaped = (string)serializer.Deserialize(new StringReader(value));
 
-            Assert.AreEqual("\"This\\r\nis\na, test\";\\;,", unescaped, "String unescaping was incorrect.");
+            Assert.That(unescaped, Is.EqualTo("\"This\\r\nis\na, test\";\\;,"), "String unescaping was incorrect.");
         }
 
         [Test, Category("Deserialization")]
@@ -397,10 +445,10 @@ END:VCALENDAR
         {
             var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Transparency2)).Cast<Calendar>().Single();
 
-            Assert.AreEqual(1, iCal.Events.Count);
+            Assert.That(iCal.Events, Has.Count.EqualTo(1));
             var evt = iCal.Events.First();
 
-            Assert.AreEqual(TransparencyType.Transparent, evt.Transparency);
+            Assert.That(evt.Transparency, Is.EqualTo(TransparencyType.Transparent));
         }
 
         /// <summary>
@@ -411,44 +459,50 @@ END:VCALENDAR
         public void DateTime1()
         {
             var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.DateTime1)).Cast<Calendar>().Single();
-            Assert.AreEqual(6, iCal.Events.Count);
+            Assert.That(iCal.Events, Has.Count.EqualTo(6));
 
             var evt = iCal.Events["nc2o66s0u36iesitl2l0b8inn8@google.com"];
-            Assert.IsNotNull(evt);
+            Assert.That(evt, Is.Not.Null);
 
             // The "Created" date is out-of-bounds.  It should be coerced to the
             // closest representable date/time.
-            Assert.AreEqual(DateTime.MinValue, evt.Created.Value);
+            Assert.That(evt.Created.Value, Is.EqualTo(DateTime.MinValue));
         }
 
         [Test, Category("Deserialization"), Ignore("Ignore until @thoemy commits the EventStatus.ics file")]
         public void EventStatus()
         {
             var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.EventStatus)).Cast<Calendar>().Single();
-            Assert.AreEqual(4, iCal.Events.Count);
-        
-            Assert.AreEqual("No status", iCal.Events[0].Summary);
-            Assert.IsNull(iCal.Events[0].Status);
-            Assert.IsTrue(iCal.Events[0].IsActive);
-        
-            Assert.AreEqual("Confirmed", iCal.Events[1].Summary);
-            Assert.AreEqual("CONFIRMED", iCal.Events[1].Status);
-            Assert.IsTrue(iCal.Events[1].IsActive);
-        
-            Assert.AreEqual("Cancelled", iCal.Events[2].Summary);
-            Assert.AreEqual("CANCELLED", iCal.Events[2].Status);
-            Assert.IsFalse(iCal.Events[2].IsActive);
-        
-            Assert.AreEqual("Tentative", iCal.Events[3].Summary);
-            Assert.AreEqual("TENTATIVE", iCal.Events[3].Status);
-            Assert.IsTrue(iCal.Events[3].IsActive);
+            Assert.That(iCal.Events, Has.Count.EqualTo(4));
+
+            Assert.That(iCal.Events[0].Summary, Is.EqualTo("No status"));
+            Assert.That(iCal.Events[0].Status, Is.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(iCal.Events[0].IsActive, Is.True);
+
+                Assert.That(iCal.Events[1].Summary, Is.EqualTo("Confirmed"));
+                Assert.That(iCal.Events[1].Status, Is.EqualTo("CONFIRMED"));
+                Assert.That(iCal.Events[1].IsActive, Is.True);
+
+                Assert.That(iCal.Events[2].Summary, Is.EqualTo("Cancelled"));
+                Assert.That(iCal.Events[2].Status, Is.EqualTo("CANCELLED"));
+            });
+            Assert.That(iCal.Events[2].IsActive, Is.False);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(iCal.Events[3].Summary, Is.EqualTo("Tentative"));
+                Assert.That(iCal.Events[3].Status, Is.EqualTo("TENTATIVE"));
+                Assert.That(iCal.Events[3].IsActive, Is.True);
+            });
         }
         
         [Test, Category("Deserialization")]
         public void Language4()
         {
             var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Language4)).Cast<Calendar>().Single();
-            Assert.IsNotNull(iCal);
+            Assert.That(iCal, Is.Not.Null);
         }
 
         [Test, Category("Deserialization")]
@@ -456,7 +510,7 @@ END:VCALENDAR
         {
             var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Outlook2007LineFolds)).Cast<Calendar>().Single();
             var events = iCal.GetOccurrences(new CalDateTime(2009, 06, 20), new CalDateTime(2009, 06, 22));
-            Assert.AreEqual(1, events.Count);
+            Assert.That(events, Has.Count.EqualTo(1));
         }
 
         [Test, Category("Deserialization")]
@@ -465,7 +519,7 @@ END:VCALENDAR
             var longName = "The Exceptionally Long Named Meeting Room Whose Name Wraps Over Several Lines When Exported From Leading Calendar and Office Software Application Microsoft Office 2007";
             var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Outlook2007LineFolds)).Cast<Calendar>().Single();
             var events = iCal.GetOccurrences<CalendarEvent>(new CalDateTime(2009, 06, 20), new CalDateTime(2009, 06, 22)).OrderBy(o => o.Period.StartTime).ToList();
-            Assert.AreEqual(longName, ((CalendarEvent)events[0].Source).Location);
+            Assert.That(((CalendarEvent)events[0].Source).Location, Is.EqualTo(longName));
         }
 
         /// <summary>
@@ -478,9 +532,12 @@ END:VCALENDAR
 
             var evt = iCal.Events.First();
             IList<CalendarParameter> parms = evt.Properties["DTSTART"].Parameters.AllOf("VALUE").ToList();
-            Assert.AreEqual(2, parms.Count);
-            Assert.AreEqual("DATE", parms[0].Values.First());
-            Assert.AreEqual("OTHER", parms[1].Values.First());
+            Assert.That(parms, Has.Count.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(parms[0].Values.First(), Is.EqualTo("DATE"));
+                Assert.That(parms[1].Values.First(), Is.EqualTo("OTHER"));
+            });
         }
 
         /// <summary>
@@ -490,7 +547,7 @@ END:VCALENDAR
         public void Parameter2()
         {
             var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Parameter2)).Cast<Calendar>().Single();
-            Assert.AreEqual(2, iCal.Events.Count);
+            Assert.That(iCal.Events, Has.Count.EqualTo(2));
         }
 
         /// <summary>
@@ -499,16 +556,11 @@ END:VCALENDAR
         [Test, Category("Deserialization")]
         public void Parse1()
         {
-            try
+            Assert.That(() =>
             {
                 var content = IcsFiles.Parse1;
                 var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(content)).Cast<Calendar>().Single();
-                Assert.IsNotNull(iCal);
-            }
-            catch (Exception e)
-            {
-                Assert.IsInstanceOf<SerializationException>(e);
-            }
+            }, Throws.Exception.TypeOf<SerializationException>());
         }
 
         /// <summary>
@@ -520,10 +572,10 @@ END:VCALENDAR
             var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Property1)).Cast<Calendar>().Single();
 
             IList<ICalendarProperty> props = iCal.Properties.AllOf("VERSION").ToList();
-            Assert.AreEqual(2, props.Count);
+            Assert.That(props, Has.Count.EqualTo(2));
 
             for (var i = 0; i < props.Count; i++)
-                Assert.AreEqual("2." + i, props[i].Value);
+                Assert.That(props[i].Value, Is.EqualTo("2." + i));
         }
     }
 }

--- a/Ical.Net.Tests/SymmetricSerializationTests.cs
+++ b/Ical.Net.Tests/SymmetricSerializationTests.cs
@@ -4,6 +4,7 @@ using Ical.Net.Serialization;
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -32,9 +33,12 @@ namespace Ical.Net.Tests
 
             var onlyEvent = unserializedCalendar.Events.Single();
 
-            Assert.AreEqual(originalEvent.GetHashCode(), onlyEvent.GetHashCode());
-            Assert.AreEqual(originalEvent, onlyEvent);
-            Assert.AreEqual(iCalendar, unserializedCalendar);
+            Assert.Multiple(() =>
+            {
+                Assert.That(onlyEvent.GetHashCode(), Is.EqualTo(originalEvent.GetHashCode()));
+                Assert.That(onlyEvent, Is.EqualTo(originalEvent));
+                Assert.That(unserializedCalendar, Is.EqualTo(iCalendar));
+            });
         }
 
         public static IEnumerable<ITestCaseData> Event_TestCases()
@@ -72,9 +76,12 @@ namespace Ical.Net.Tests
             var serializedCalendar = serializer.SerializeToString(originalCalendar);
             var unserializedCalendar = Calendar.Load(serializedCalendar);
 
-            CollectionAssert.AreEqual(originalCalendar.TimeZones, unserializedCalendar.TimeZones);
-            Assert.AreEqual(originalCalendar, unserializedCalendar);
-            Assert.AreEqual(originalCalendar.GetHashCode(), unserializedCalendar.GetHashCode());
+            Assert.Multiple(() =>
+            {
+                Assert.That(unserializedCalendar.TimeZones, Is.EqualTo(originalCalendar.TimeZones).AsCollection);
+                Assert.That(unserializedCalendar, Is.EqualTo(originalCalendar));
+            });
+            Assert.That(unserializedCalendar.GetHashCode(), Is.EqualTo(originalCalendar.GetHashCode()));
         }
 
         [Test, TestCaseSource(nameof(AttendeeSerialization_TestCases))]
@@ -89,9 +96,12 @@ namespace Ical.Net.Tests
             var serialized = SerializeToString(calendar);
             var unserialized = UnserializeCalendar(serialized);
 
-            Assert.AreEqual(calendar.GetHashCode(), unserialized.GetHashCode());
-            Assert.IsTrue(calendar.Events.SequenceEqual(unserialized.Events));
-            Assert.AreEqual(calendar, unserialized);
+            Assert.Multiple(() =>
+            {
+                Assert.That(unserialized.GetHashCode(), Is.EqualTo(calendar.GetHashCode()));
+                Assert.That(calendar.Events.SequenceEqual(unserialized.Events), Is.True);
+                Assert.That(unserialized, Is.EqualTo(calendar));
+            });
         }
 
         public static IEnumerable<ITestCaseData> AttendeeSerialization_TestCases()
@@ -141,12 +151,15 @@ namespace Ical.Net.Tests
                 .Select(a => Encoding.UTF8.GetString(a.Data))
                 .First();
 
-            Assert.AreEqual(expectedAttachment, unserializedAttachment);
-            Assert.AreEqual(calendar.GetHashCode(), unserialized.GetHashCode());
-            Assert.AreEqual(calendar, unserialized);
+            Assert.Multiple(() =>
+            {
+                Assert.That(unserializedAttachment, Is.EqualTo(expectedAttachment));
+                Assert.That(unserialized.GetHashCode(), Is.EqualTo(calendar.GetHashCode()));
+                Assert.That(unserialized, Is.EqualTo(calendar));
+            });
         }
 
-        public static IEnumerable<ITestCaseData> BinaryAttachment_TestCases()
+        public static IEnumerable BinaryAttachment_TestCases()
         {
             const string shortString = "This is a string.";
             yield return new TestCaseData(shortString, shortString)
@@ -184,12 +197,15 @@ namespace Ical.Net.Tests
                 .Select(a => a.Uri)
                 .Single();
 
-            Assert.AreEqual(expectedUri, unserializedUri);
-            Assert.AreEqual(calendar.GetHashCode(), unserialized.GetHashCode());
-            Assert.AreEqual(calendar, unserialized);
+            Assert.Multiple(() =>
+            {
+                Assert.That(unserializedUri, Is.EqualTo(expectedUri));
+                Assert.That(unserialized.GetHashCode(), Is.EqualTo(calendar.GetHashCode()));
+                Assert.That(unserialized, Is.EqualTo(calendar));
+            });
         }
 
-        public static IEnumerable<ITestCaseData> UriAttachment_TestCases()
+        public static IEnumerable UriAttachment_TestCases()
         {
             yield return new TestCaseData("http://www.google.com", new Uri("http://www.google.com")).SetName("HTTP URL");
             yield return new TestCaseData("mailto:rstockbower@gmail.com", new Uri("mailto:rstockbower@gmail.com")).SetName("mailto: URL");
@@ -208,10 +224,10 @@ namespace Ical.Net.Tests
 
             var serialized = SerializeToString(c);
             var categoriesCount = Regex.Matches(serialized, "CATEGORIES").Count;
-            Assert.AreEqual(1, categoriesCount);
+            Assert.That(categoriesCount, Is.EqualTo(1));
 
             var deserialized = UnserializeCalendar(serialized);
-            Assert.AreEqual(vEvent, deserialized);
+            Assert.That(deserialized, Is.EqualTo(c));
         }
     }
 }

--- a/Ical.Net.Tests/TextUtilTests.cs
+++ b/Ical.Net.Tests/TextUtilTests.cs
@@ -1,7 +1,6 @@
-﻿using Ical.Net.Utility;
+﻿using System.Collections;
+using Ical.Net.Utility;
 using NUnit.Framework;
-using NUnit.Framework.Interfaces;
-using System.Collections.Generic;
 
 namespace Ical.Net.Tests
 {
@@ -10,7 +9,7 @@ namespace Ical.Net.Tests
         [Test, TestCaseSource(nameof(FoldLines_TestCases))]
         public string FoldLines_Tests(string incoming) => TextUtil.FoldLines(incoming);
 
-        public static IEnumerable<ITestCaseData> FoldLines_TestCases()
+        public static IEnumerable FoldLines_TestCases()
         {
             yield return new TestCaseData("Short")
                 .Returns("Short" + SerializationConstants.LineBreak)

--- a/Ical.Net.Tests/TodoTest.cs
+++ b/Ical.Net.Tests/TodoTest.cs
@@ -1,6 +1,6 @@
+﻿using System.Collections;
 using Ical.Net.DataTypes;
 using NUnit.Framework;
-using NUnit.Framework.Interfaces;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -22,11 +22,11 @@ namespace Ical.Net.Tests
             {
                 var dt = calDateTime.Key;
                 dt.TzId = _tzid;
-                Assert.AreEqual(calDateTime.Value, todo[0].IsActive(dt));
+                Assert.That(todo[0].IsActive(dt), Is.EqualTo(calDateTime.Value));
             }
         }
 
-        public static IEnumerable<ITestCaseData> ActiveTodo_TestCases()
+        public static IEnumerable ActiveTodo_TestCases()
         {
             var testVals = new List<KeyValuePair<CalDateTime, bool>>
             {
@@ -172,11 +172,11 @@ namespace Ical.Net.Tests
             {
                 var dt = calDateTime.Key;
                 dt.TzId = _tzid;
-                Assert.AreEqual(calDateTime.Value, todo[0].IsCompleted(dt));
+                Assert.That(todo[0].IsCompleted(dt), Is.EqualTo(calDateTime.Value));
             }
         }
 
-        public static IEnumerable<ITestCaseData> CompletedTodo_TestCases()
+        public static IEnumerable CompletedTodo_TestCases()
         {
             var testVals = new List<KeyValuePair<CalDateTime, bool>>
             {
@@ -211,9 +211,9 @@ namespace Ical.Net.Tests
                 new CalDateTime(2006, 7, 1, 9, 0, 0),
                 new CalDateTime(2007, 7, 1, 9, 0, 0)).OrderBy(o => o.Period.StartTime).ToList();
 
-            Assert.AreEqual(
-                items.Count,
-                occurrences.Count);
+            Assert.That(
+                occurrences,
+Has.Count.EqualTo(items.Count));
         }
     }
 }

--- a/Ical.Net.Tests/VTimeZoneTest.cs
+++ b/Ical.Net.Tests/VTimeZoneTest.cs
@@ -28,8 +28,11 @@ namespace Ical.Net.Tests
             var serializer = new CalendarSerializer();
             var serialized = serializer.SerializeToString(iCal);
 
-            Assert.IsTrue(serialized.Contains("TZID:America/Phoenix"), "Time zone not found in serialization");
-            Assert.IsTrue(serialized.Contains("DTSTART:19670430T020000"), "Daylight savings for Phoenix was not serialized properly.");
+            Assert.Multiple(() =>
+            {
+                Assert.That(serialized.Contains("TZID:America/Phoenix"), Is.True, "Time zone not found in serialization");
+                Assert.That(serialized.Contains("DTSTART:19670430T020000"), Is.True, "Daylight savings for Phoenix was not serialized properly.");
+            });
         }
 
         [Test, Category("VTimeZone")]
@@ -39,8 +42,11 @@ namespace Ical.Net.Tests
             var serializer = new CalendarSerializer();
             var serialized = serializer.SerializeToString(iCal);
 
-            Assert.IsTrue(serialized.Contains("TZID:America/Phoenix"), "Time zone not found in serialization");
-            Assert.IsFalse(serialized.Contains("BEGIN:DAYLIGHT"), "Daylight savings should not exist for Phoenix.");
+            Assert.Multiple(() =>
+            {
+                Assert.That(serialized.Contains("TZID:America/Phoenix"), Is.True, "Time zone not found in serialization");
+                Assert.That(serialized.Contains("BEGIN:DAYLIGHT"), Is.False, "Daylight savings should not exist for Phoenix.");
+            });
         }
 
         [Test, Category("VTimeZone")]
@@ -50,10 +56,13 @@ namespace Ical.Net.Tests
             var serializer = new CalendarSerializer();
             var serialized = serializer.SerializeToString(iCal);
 
-            Assert.IsTrue(serialized.Contains("TZID:US Mountain Standard Time"), "Time zone not found in serialization");
-            Assert.IsTrue(serialized.Contains("BEGIN:STANDARD"));
-            Assert.IsTrue(serialized.Contains("BEGIN:DAYLIGHT"));
-            Assert.IsTrue(serialized.Contains("X-LIC-LOCATION"), "X-LIC-LOCATION was not serialized");
+            Assert.Multiple(() =>
+            {
+                Assert.That(serialized.Contains("TZID:US Mountain Standard Time"), Is.True, "Time zone not found in serialization");
+                Assert.That(serialized.Contains("BEGIN:STANDARD"), Is.True);
+                Assert.That(serialized.Contains("BEGIN:DAYLIGHT"), Is.True);
+                Assert.That(serialized.Contains("X-LIC-LOCATION"), Is.True, "X-LIC-LOCATION was not serialized");
+            });
         }
 
         [Test, Category("VTimeZone")]
@@ -71,7 +80,7 @@ namespace Ical.Net.Tests
             var serializer = new CalendarSerializer();
             var serialized = serializer.SerializeToString(iCal);
 
-            Assert.IsTrue(serialized.Contains("TZID:Central America Standard Time"), "Time zone not found in serialization");
+            Assert.That(serialized.Contains("TZID:Central America Standard Time"), Is.True, "Time zone not found in serialization");
         }
 
         [Test, Category("VTimeZone")]
@@ -81,7 +90,7 @@ namespace Ical.Net.Tests
             var serializer = new CalendarSerializer();
             var serialized = serializer.SerializeToString(iCal);
 
-            Assert.IsTrue(serialized.Contains("TZID:Eastern Standard Time"), "Time zone not found in serialization");
+            Assert.That(serialized.Contains("TZID:Eastern Standard Time"), Is.True, "Time zone not found in serialization");
         }
 
         [Test, Category("VTimeZone")]
@@ -91,20 +100,25 @@ namespace Ical.Net.Tests
             var serializer = new CalendarSerializer();
             var serialized = serializer.SerializeToString(iCal);
 
-            Assert.IsTrue(serialized.Contains("TZID:Europe/Moscow"), "Time zone not found in serialization");
-            Assert.IsTrue(serialized.Contains("BEGIN:STANDARD"), "The standard timezone info was not serialized");
-            Assert.IsTrue(serialized.Contains("BEGIN:DAYLIGHT"), "The daylight timezone info was not serialized");
-
-            Assert.IsTrue(serialized.Contains("TZNAME:MSD"), "MSD was not serialized");
-            Assert.IsTrue(serialized.Contains("TZNAME:MSK"), "MSK info was not serialized");
-            Assert.IsTrue(serialized.Contains("TZNAME:MSD"), "MSD was not serialized");
-            Assert.IsTrue(serialized.Contains("TZNAME:MST"), "MST was not serialized");
-            Assert.IsTrue(serialized.Contains("TZNAME:MMT"), "MMT was not serialized");
-            Assert.IsTrue(serialized.Contains("TZOFFSETFROM:+023017"), "TZOFFSETFROM:+023017 was not serialized");
-            Assert.IsTrue(serialized.Contains("TZOFFSETTO:+023017"), "TZOFFSETTO:+023017 was not serialized");
-            Assert.IsTrue(serialized.Contains("DTSTART:19180916T010000"), "DTSTART:19180916T010000 was not serialized");
-            Assert.IsTrue(serialized.Contains("DTSTART:19171228T000000"), "DTSTART:19171228T000000 was not serialized");
-            Assert.IsTrue(serialized.Contains("RDATE:19991031T030000"), "RDATE:19991031T030000 was not serialized");
+            Assert.Multiple(() =>
+            {
+                Assert.That(serialized.Contains("TZID:Europe/Moscow"), Is.True, "Time zone not found in serialization");
+                Assert.That(serialized.Contains("BEGIN:STANDARD"), Is.True, "The standard timezone info was not serialized");
+                Assert.That(serialized.Contains("BEGIN:DAYLIGHT"), Is.True, "The daylight timezone info was not serialized");
+            });
+            Assert.Multiple(() =>
+            {
+                Assert.That(serialized.Contains("TZNAME:MSD"), Is.True, "MSD was not serialized");
+                Assert.That(serialized.Contains("TZNAME:MSK"), Is.True, "MSK info was not serialized");
+                Assert.That(serialized.Contains("TZNAME:MSD"), Is.True, "MSD was not serialized");
+                Assert.That(serialized.Contains("TZNAME:MST"), Is.True, "MST was not serialized");
+                Assert.That(serialized.Contains("TZNAME:MMT"), Is.True, "MMT was not serialized");
+                Assert.That(serialized.Contains("TZOFFSETFROM:+023017"), Is.True, "TZOFFSETFROM:+023017 was not serialized");
+                Assert.That(serialized.Contains("TZOFFSETTO:+023017"), Is.True, "TZOFFSETTO:+023017 was not serialized");
+                Assert.That(serialized.Contains("DTSTART:19180916T010000"), Is.True, "DTSTART:19180916T010000 was not serialized");
+                Assert.That(serialized.Contains("DTSTART:19171228T000000"), Is.True, "DTSTART:19171228T000000 was not serialized");
+                Assert.That(serialized.Contains("RDATE:19991031T030000"), Is.True, "RDATE:19991031T030000 was not serialized");
+            });
         }
 
         [Test, Category("VTimeZone")]
@@ -114,20 +128,23 @@ namespace Ical.Net.Tests
             var serializer = new CalendarSerializer();
             var serialized = serializer.SerializeToString(iCal);
 
-            Assert.IsTrue(serialized.Contains("TZID:America/Chicago"), "Time zone not found in serialization");
-            Assert.IsTrue(serialized.Contains("BEGIN:STANDARD"), "The standard timezone info was not serialized");
-            Assert.IsTrue(serialized.Contains("BEGIN:DAYLIGHT"), "The daylight timezone info was not serialized");
-            Assert.IsTrue(serialized.Contains("TZNAME:CDT"), "CDT was not serialized");
-            Assert.IsTrue(serialized.Contains("TZNAME:CST"), "CST was not serialized");
-            Assert.IsTrue(serialized.Contains("TZNAME:EST"), "EST was not serialized");
-            Assert.IsTrue(serialized.Contains("TZNAME:CWT"), "CWT was not serialized");
-            Assert.IsTrue(serialized.Contains("TZNAME:CPT"), "CPT was not serialized");
-            Assert.IsTrue(serialized.Contains("DTSTART:19181027T020000"), "DTSTART:19181027T020000 was not serialized");
-            Assert.IsTrue(serialized.Contains("DTSTART:19450814T180000"), "DTSTART:19450814T180000 was not serialized");
-            Assert.IsTrue(serialized.Contains("DTSTART:19420209T020000"), "DTSTART:19420209T020000 was not serialized");
-            Assert.IsTrue(serialized.Contains("DTSTART:19360301T020000"), "DTSTART:19360301T020000 was not serialized");
-            Assert.IsTrue(serialized.Contains("DTSTART:20070311T020000"), "DTSTART:20070311T020000 was not serialized");
-            Assert.IsTrue(serialized.Contains("DTSTART:20071104T020000"), "DTSTART:20071104T020000 was not serialized");
+            Assert.Multiple(() =>
+            {
+                Assert.That(serialized.Contains("TZID:America/Chicago"), Is.True, "Time zone not found in serialization");
+                Assert.That(serialized.Contains("BEGIN:STANDARD"), Is.True, "The standard timezone info was not serialized");
+                Assert.That(serialized.Contains("BEGIN:DAYLIGHT"), Is.True, "The daylight timezone info was not serialized");
+                Assert.That(serialized.Contains("TZNAME:CDT"), Is.True, "CDT was not serialized");
+                Assert.That(serialized.Contains("TZNAME:CST"), Is.True, "CST was not serialized");
+                Assert.That(serialized.Contains("TZNAME:EST"), Is.True, "EST was not serialized");
+                Assert.That(serialized.Contains("TZNAME:CWT"), Is.True, "CWT was not serialized");
+                Assert.That(serialized.Contains("TZNAME:CPT"), Is.True, "CPT was not serialized");
+                Assert.That(serialized.Contains("DTSTART:19181027T020000"), Is.True, "DTSTART:19181027T020000 was not serialized");
+                Assert.That(serialized.Contains("DTSTART:19450814T180000"), Is.True, "DTSTART:19450814T180000 was not serialized");
+                Assert.That(serialized.Contains("DTSTART:19420209T020000"), Is.True, "DTSTART:19420209T020000 was not serialized");
+                Assert.That(serialized.Contains("DTSTART:19360301T020000"), Is.True, "DTSTART:19360301T020000 was not serialized");
+                Assert.That(serialized.Contains("DTSTART:20070311T020000"), Is.True, "DTSTART:20070311T020000 was not serialized");
+                Assert.That(serialized.Contains("DTSTART:20071104T020000"), Is.True, "DTSTART:20071104T020000 was not serialized");
+            });
         }
 
         [Test, Category("VTimeZone")]
@@ -137,17 +154,20 @@ namespace Ical.Net.Tests
             var serializer = new CalendarSerializer();
             var serialized = serializer.SerializeToString(iCal);
 
-            Assert.IsTrue(serialized.Contains("TZID:America/Los_Angeles"), "Time zone not found in serialization");
-            Assert.IsTrue(serialized.Contains("BEGIN:STANDARD"), "The standard timezone info was not serialized");
-            Assert.IsTrue(serialized.Contains("BEGIN:DAYLIGHT"), "The daylight timezone info was not serialized");
-            Assert.IsTrue(serialized.Contains("BYDAY=2SU"), "BYDAY=2SU was not serialized");
-            Assert.IsTrue(serialized.Contains("TZNAME:PDT"), "PDT was not serialized");
-            Assert.IsTrue(serialized.Contains("TZNAME:PST"), "PST was not serialized");
-            Assert.IsTrue(serialized.Contains("TZNAME:PPT"), "PPT was not serialized");
-            Assert.IsTrue(serialized.Contains("TZNAME:PWT"), "PWT was not serialized");
-            Assert.IsTrue(serialized.Contains("DTSTART:19180331T020000"), "DTSTART:19180331T020000 was not serialized");
-            Assert.IsTrue(serialized.Contains("DTSTART:20071104T020000"), "DTSTART:20071104T020000 was not serialized");
-            Assert.IsTrue(serialized.Contains("DTSTART:20070311T020000"), "DTSTART:20070311T020000 was not serialized");
+            Assert.Multiple(() =>
+            {
+                Assert.That(serialized.Contains("TZID:America/Los_Angeles"), Is.True, "Time zone not found in serialization");
+                Assert.That(serialized.Contains("BEGIN:STANDARD"), Is.True, "The standard timezone info was not serialized");
+                Assert.That(serialized.Contains("BEGIN:DAYLIGHT"), Is.True, "The daylight timezone info was not serialized");
+                Assert.That(serialized.Contains("BYDAY=2SU"), Is.True, "BYDAY=2SU was not serialized");
+                Assert.That(serialized.Contains("TZNAME:PDT"), Is.True, "PDT was not serialized");
+                Assert.That(serialized.Contains("TZNAME:PST"), Is.True, "PST was not serialized");
+                Assert.That(serialized.Contains("TZNAME:PPT"), Is.True, "PPT was not serialized");
+                Assert.That(serialized.Contains("TZNAME:PWT"), Is.True, "PWT was not serialized");
+                Assert.That(serialized.Contains("DTSTART:19180331T020000"), Is.True, "DTSTART:19180331T020000 was not serialized");
+                Assert.That(serialized.Contains("DTSTART:20071104T020000"), Is.True, "DTSTART:20071104T020000 was not serialized");
+                Assert.That(serialized.Contains("DTSTART:20070311T020000"), Is.True, "DTSTART:20070311T020000 was not serialized");
+            });
 
             //Assert.IsTrue(serialized.Contains("TZURL:http://tzurl.org/zoneinfo/America/Los_Angeles"), "TZURL:http://tzurl.org/zoneinfo/America/Los_Angeles was not serialized");
             //Assert.IsTrue(serialized.Contains("RDATE:19600424T010000"), "RDATE:19600424T010000 was not serialized");  // NodaTime doesn't match with what tzurl has
@@ -160,11 +180,14 @@ namespace Ical.Net.Tests
             var serializer = new CalendarSerializer();
             var serialized = serializer.SerializeToString(iCal);
 
-            Assert.IsTrue(serialized.Contains("TZID:Europe/Oslo"), "Time zone not found in serialization");
-            Assert.IsTrue(serialized.Contains("BEGIN:STANDARD"), "The standard timezone info was not serialized");
-            Assert.IsTrue(serialized.Contains("BEGIN:DAYLIGHT"), "The daylight timezone info was not serialized");
-            Assert.IsTrue(serialized.Contains("BYDAY=-1SU;BYMONTH=3"), "BYDAY=-1SU;BYMONTH=3 was not serialized");
-            Assert.IsTrue(serialized.Contains("BYDAY=-1SU;BYMONTH=10"), "BYDAY=-1SU;BYMONTH=10 was not serialized");
+            Assert.Multiple(() =>
+            {
+                Assert.That(serialized.Contains("TZID:Europe/Oslo"), Is.True, "Time zone not found in serialization");
+                Assert.That(serialized.Contains("BEGIN:STANDARD"), Is.True, "The standard timezone info was not serialized");
+                Assert.That(serialized.Contains("BEGIN:DAYLIGHT"), Is.True, "The daylight timezone info was not serialized");
+                Assert.That(serialized.Contains("BYDAY=-1SU;BYMONTH=3"), Is.True, "BYDAY=-1SU;BYMONTH=3 was not serialized");
+                Assert.That(serialized.Contains("BYDAY=-1SU;BYMONTH=10"), Is.True, "BYDAY=-1SU;BYMONTH=10 was not serialized");
+            });
 
         }
 
@@ -175,19 +198,22 @@ namespace Ical.Net.Tests
             var serializer = new CalendarSerializer();
             var serialized = serializer.SerializeToString(iCal);
 
-            Assert.IsTrue(serialized.Contains("TZID:America/Anchorage"), "Time zone not found in serialization");
-            Assert.IsTrue(serialized.Contains("BEGIN:STANDARD"), "The standard timezone info was not serialized");
-            Assert.IsTrue(serialized.Contains("BEGIN:DAYLIGHT"), "The daylight timezone info was not serialized");
-            Assert.IsTrue(serialized.Contains("TZNAME:AHST"), "AHST was not serialized");
-            Assert.IsTrue(serialized.Contains("TZNAME:AHDT"), "AHDT was not serialized");
-            Assert.IsTrue(serialized.Contains("TZNAME:AKST"), "AKST was not serialized");
-            Assert.IsTrue(serialized.Contains("TZNAME:YST"), "YST was not serialized");
-            Assert.IsTrue(serialized.Contains("TZNAME:AHDT"), "AHDT was not serialized");
-            Assert.IsTrue(serialized.Contains("TZNAME:LMT"), "LMT was not serialized");
-            Assert.IsTrue(serialized.Contains("RDATE:19731028T020000"), "RDATE:19731028T020000 was not serialized");
-            Assert.IsTrue(serialized.Contains("RDATE:19801026T020000"), "RDATE:19801026T020000 was not serialized");
-            Assert.IsTrue(serialized.Contains("DTSTART:19420209T020000"), "DTSTART:19420209T020000 was not serialized");
-            Assert.IsFalse(serialized.Contains("RDATE:19670401/P1D"), "RDate was not properly serialized for vtimezone, should be RDATE:19670401T000000");
+            Assert.Multiple(() =>
+            {
+                Assert.That(serialized.Contains("TZID:America/Anchorage"), Is.True, "Time zone not found in serialization");
+                Assert.That(serialized.Contains("BEGIN:STANDARD"), Is.True, "The standard timezone info was not serialized");
+                Assert.That(serialized.Contains("BEGIN:DAYLIGHT"), Is.True, "The daylight timezone info was not serialized");
+                Assert.That(serialized.Contains("TZNAME:AHST"), Is.True, "AHST was not serialized");
+                Assert.That(serialized.Contains("TZNAME:AHDT"), Is.True, "AHDT was not serialized");
+                Assert.That(serialized.Contains("TZNAME:AKST"), Is.True, "AKST was not serialized");
+                Assert.That(serialized.Contains("TZNAME:YST"), Is.True, "YST was not serialized");
+                Assert.That(serialized.Contains("TZNAME:AHDT"), Is.True, "AHDT was not serialized");
+                Assert.That(serialized.Contains("TZNAME:LMT"), Is.True, "LMT was not serialized");
+                Assert.That(serialized.Contains("RDATE:19731028T020000"), Is.True, "RDATE:19731028T020000 was not serialized");
+                Assert.That(serialized.Contains("RDATE:19801026T020000"), Is.True, "RDATE:19801026T020000 was not serialized");
+                Assert.That(serialized.Contains("DTSTART:19420209T020000"), Is.True, "DTSTART:19420209T020000 was not serialized");
+                Assert.That(serialized.Contains("RDATE:19670401/P1D"), Is.False, "RDate was not properly serialized for vtimezone, should be RDATE:19670401T000000");
+            });
         }
 
         [Test, Category("VTimeZone")]
@@ -197,18 +223,21 @@ namespace Ical.Net.Tests
             var serializer = new CalendarSerializer();
             var serialized = serializer.SerializeToString(iCal);
 
-            Assert.IsTrue(serialized.Contains("TZID:America/Eirunepe"), "Time zone not found in serialization");
-            Assert.IsTrue(serialized.Contains("BEGIN:STANDARD"), "The standard timezone info was not serialized");
-            Assert.IsTrue(serialized.Contains("BEGIN:DAYLIGHT"), "The daylight timezone info was not serialized");
-            Assert.IsTrue(serialized.Contains("TZNAME:-04"), "-04 was not serialized");
-            Assert.IsTrue(serialized.Contains("TZNAME:-05"), "-05 was not serialized");
-            Assert.IsTrue(serialized.Contains("DTSTART:19311003T110000"), "DTSTART:19311003T110000 was not serialized");
-            Assert.IsTrue(serialized.Contains("DTSTART:19320401T000000"), "DTSTART:19320401T000000 was not serialized");
-            Assert.IsTrue(serialized.Contains("DTSTART:20080624T000000"), "DTSTART:20080624T000000 was not serialized");
-            Assert.IsTrue(serialized.Contains("DTSTART:19501201T000000"), "DTSTART:19501201T000000 was not serialized");
+            Assert.Multiple(() =>
+            {
+                Assert.That(serialized.Contains("TZID:America/Eirunepe"), Is.True, "Time zone not found in serialization");
+                Assert.That(serialized.Contains("BEGIN:STANDARD"), Is.True, "The standard timezone info was not serialized");
+                Assert.That(serialized.Contains("BEGIN:DAYLIGHT"), Is.True, "The daylight timezone info was not serialized");
+                Assert.That(serialized.Contains("TZNAME:-04"), Is.True, "-04 was not serialized");
+                Assert.That(serialized.Contains("TZNAME:-05"), Is.True, "-05 was not serialized");
+                Assert.That(serialized.Contains("DTSTART:19311003T110000"), Is.True, "DTSTART:19311003T110000 was not serialized");
+                Assert.That(serialized.Contains("DTSTART:19320401T000000"), Is.True, "DTSTART:19320401T000000 was not serialized");
+                Assert.That(serialized.Contains("DTSTART:20080624T000000"), Is.True, "DTSTART:20080624T000000 was not serialized");
+                Assert.That(serialized.Contains("DTSTART:19501201T000000"), Is.True, "DTSTART:19501201T000000 was not serialized");
+            });
 
             // Should not contain the following
-            Assert.IsFalse(serialized.Contains("RDATE:19501201T000000/P1D"), "The RDATE was not serialized correctly, should be RDATE:19501201T000000");
+            Assert.That(serialized.Contains("RDATE:19501201T000000/P1D"), Is.False, "The RDATE was not serialized correctly, should be RDATE:19501201T000000");
         }
 
         [Test, Category("VTimeZone")]
@@ -218,14 +247,17 @@ namespace Ical.Net.Tests
             var serializer = new CalendarSerializer();
             var serialized = serializer.SerializeToString(iCal);
 
-            Assert.IsTrue(serialized.Contains("TZID:America/Detroit"), "Time zone not found in serialization");
-            Assert.IsTrue(serialized.Contains("BEGIN:STANDARD"), "The standard timezone info was not serialized");
-            Assert.IsTrue(serialized.Contains("BEGIN:DAYLIGHT"), "The daylight timezone info was not serialized");
-            Assert.IsTrue(serialized.Contains("TZNAME:EDT"), "EDT was not serialized");
-            Assert.IsTrue(serialized.Contains("TZNAME:EPT"), "EPT was not serialized");
-            Assert.IsTrue(serialized.Contains("TZNAME:EST"), "EST was not serialized");
-            Assert.IsTrue(serialized.Contains("DTSTART:20070311T020000"), "DTSTART:20070311T020000 was not serialized");
-            Assert.IsTrue(serialized.Contains("DTSTART:20071104T020000"), "DTSTART:20071104T020000 was not serialized");
+            Assert.Multiple(() =>
+            {
+                Assert.That(serialized.Contains("TZID:America/Detroit"), Is.True, "Time zone not found in serialization");
+                Assert.That(serialized.Contains("BEGIN:STANDARD"), Is.True, "The standard timezone info was not serialized");
+                Assert.That(serialized.Contains("BEGIN:DAYLIGHT"), Is.True, "The daylight timezone info was not serialized");
+                Assert.That(serialized.Contains("TZNAME:EDT"), Is.True, "EDT was not serialized");
+                Assert.That(serialized.Contains("TZNAME:EPT"), Is.True, "EPT was not serialized");
+                Assert.That(serialized.Contains("TZNAME:EST"), Is.True, "EST was not serialized");
+                Assert.That(serialized.Contains("DTSTART:20070311T020000"), Is.True, "DTSTART:20070311T020000 was not serialized");
+                Assert.That(serialized.Contains("DTSTART:20071104T020000"), Is.True, "DTSTART:20071104T020000 was not serialized");
+            });
         }
 
         private static Calendar CreateTestCalendar(string tzId, DateTime? earliestTime = null, bool includeHistoricalData = true)


### PR DESCRIPTION
* Migrate NUnit 3.14.0 to 4.2.2
* Add NUnit.Analyzers 4.3.0
* Convert Classic Assert to Constraint Model
* Introduce Assert.Multiple to group assertions, ensuring all are evaluated even if some fail.
* Simplify test case source return types to IEnumerable without a type argument
* Remove unused using directives and added necessary ones.

Test logic is left unchanged except for 7 tests in Exception context. 
Here all try...catch blocks are replaced with `Throws.` assertions.

Closes #611