### PR TITLE
Define behavior for time-based FREQ and date-only DTSTART

### DIFF
--- a/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
@@ -900,6 +900,15 @@ namespace Ical.Net.Evaluation
 
         public override HashSet<Period> Evaluate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd, bool includeReferenceDateInResults)
         {
+            if ((this.Pattern.Frequency != FrequencyType.None) && (this.Pattern.Frequency < FrequencyType.Daily) && !referenceDate.HasTime)
+            {
+                // This case is not defined by RFC 5545. We handle it by evaluating the rule
+                // as if referenceDate had a time (i.e. set to midnight).
+
+                referenceDate = referenceDate.Copy<IDateTime>();
+                referenceDate.HasTime = true;
+            }
+
             // Create a recurrence pattern suitable for use during evaluation.
             var pattern = ProcessRecurrencePattern(referenceDate);
 


### PR DESCRIPTION
Fixes https://github.com/ical-org/ical.net/issues/602.

Implement defined behavior of recurrence evaluation in case of a time-based FREQ (sec/min/hour) and a DTSTART of type DATE (i.e. date-only). With this PR such scenarios are handled as if DTSTART had a time set to midnight.

The case was previously covered by test `Evaluate1`, which was broken and is fixed with this PR.