### PR TITLE
RRULE Evaluation: Apply `BYYEARDAY=366` only in leap years.

### DIFF
--- a/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
@@ -467,7 +467,9 @@ namespace Ical.Net.Evaluation
                     var date1 = date;
                     yearDayDates.AddRange(pattern.ByYearDay.Select(yearDay => yearDay > 0
                         ? date1.AddDays(-date1.DayOfYear + yearDay)
-                        : date1.AddDays(-date1.DayOfYear + 1).AddYears(1).AddDays(yearDay)));
+                        : date1.AddDays(-date1.DayOfYear + 1).AddYears(1).AddDays(yearDay))
+                        // Ignore the BY values that don't fit into the current year (i.e. +-366 in non-leap-years).
+                        .Where(d => d.Year == date1.Year));
                 }
                 return yearDayDates;
             }
@@ -483,7 +485,7 @@ namespace Ical.Net.Evaluation
                         ? date.AddDays(-date.DayOfYear + yearDay)
                         : date.AddDays(-date.DayOfYear + 1).AddYears(1).AddDays(yearDay);
 
-                    if (newDate.DayOfYear == date.DayOfYear)
+                    if (newDate.Date == date.Date)
                     {
                         goto Next;
                     }


### PR DESCRIPTION
Fix for the following cases of #618:
* `RRULE:FREQ=YEARLY;BYYEARDAY=-366;COUNT=3`
* `RRULE:FREQ=YEARLY;BYYEARDAY=366;COUNT=3`

I.e. `BYYEARDAY=366` should only exist if day 366 (or -366) exists, which is only the case in leap years.