### PR TITLE
Add GitHub workflow for code coverage calculation

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,14 +3,13 @@
 # The report is stored as artifact, and uploaded to Codecov.
 
 on:
-  workflow_dispatch: {}  # temprorarily enable the workflow for manual runs
-  # comment out the following lines to enable the workflow for pull requests and pushes
-  # pull_request:
-  #  branches:
-  #    - main
-  # push:
-  #  branches:
-  #    - main
+  # workflow_dispatch: {}  # temporarily enable the workflow for manual runs
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
 
 jobs:
   coverage:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,50 @@
+﻿﻿name: Code Coverage
+# This job runs unit tests and generates a code coverage report.
+# The report is stored as artifact, and uploaded to Codecov.
+
+on:
+  workflow_dispatch: {}  # temprorarily enable the workflow for manual runs
+  # comment out the following lines to enable the workflow for pull requests and pushes
+  # pull_request:
+  #  branches:
+  #    - main
+  # push:
+  #  branches:
+  #    - main
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Fetch all history for all tags and branches
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          8.0.x
+    - name: Restore dependencies --verbosity quiet
+      run: dotnet restore
+    - name: Add AltCover package to test project
+      run: dotnet add ./Ical.Net.Tests/Ical.Net.Tests.csproj package AltCover
+
+    - name: Build
+      run: dotnet build --no-restore --configuration Release -p:nowarn=1591
+    - name: Test
+      run: dotnet test --no-build --configuration Release --verbosity quiet /p:AltCover=true /p:AltCoverXmlReport="coverage.xml" /p:AltCoverStrongNameKey="../IcalNetStrongnameKey.snk" /p:AltCoverAssemblyExcludeFilter="Ical.Net.Tests|NUnit3.TestAdapter|AltCover" /p:AltCoverAttributeFilter="ExcludeFromCodeCoverage" /p:AltCoverLineCover="false"
+
+    - name: Store coverage report as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: ./Ical.Net.Tests/coverage.*.xml  # store all coverage reports
+    - name: Upload coverage to Codecov  
+      uses: codecov/codecov-action@v4  
+      with:  
+        # files: automatically finds all in ./Ical.Net.Tests/
+        name: coverage
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,17 @@
+﻿coverage:
+  precision: 0      # no decimals
+  round: nearest    # round up/down
+  range: "80...100"
+
+  status:
+    project:        # show status on project level
+      default:
+        target: 80  # Set the target coverage percentage
+    patch:          # show status on patch level
+      default:
+        target: 80  # minimum coverage for successful commit 
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: true  # Only comment if there are changes in coverage


### PR DESCRIPTION
The coverage workflow triggers for pull request and push to main.
It will not stop CI in case of failure for now. Coverage is processed on [Codecov](https://app.codecov.io/github/ical-org/ical.net/tree/main/Ical.Net).
Should be integrated into the test workflow, if everything works fine.
[That's the calculation](https://app.codecov.io/github/axunonb/ical.net/tree/main/Ical.Net) from my ical.net fork.