### PR TITLE
Improve recurrence handling, remove restrictions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Build
       run: dotnet build --no-restore --configuration Release -p:nowarn=1591
     - name: Test
-      run: dotnet test --no-build --configuration Release --verbosity quiet /p:AltCover=true /p:AltCoverXmlReport="coverage.xml" /p:AltCoverStrongNameKey="../IcalNetStrongnameKey.snk" /p:AltCoverAssemblyExcludeFilter="Ical.Net.Tests|NUnit3.TestAdapter|AltCover" /p:AltCoverAttributeFilter="ExcludeFromCodeCoverage" /p:AltCoverLineCover="false"
+      run: dotnet test --no-build --configuration Release --verbosity normal /p:AltCover=true /p:AltCoverXmlReport="coverage.xml" /p:AltCoverStrongNameKey="../IcalNetStrongnameKey.snk" /p:AltCoverAssemblyExcludeFilter="Ical.Net.Tests|NUnit3.TestAdapter|AltCover" /p:AltCoverAttributeFilter="ExcludeFromCodeCoverage" /p:AltCoverLineCover="false"
 
     - name: Store coverage report as artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,4 +31,4 @@ jobs:
     - name: Build
       run: dotnet build --no-restore --configuration Release -p:nowarn=1591
     - name: Test
-      run: dotnet test --no-build --configuration Release --verbosity quiet
+      run: dotnet test --no-build --configuration Release --verbosity normal

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -41,8 +41,8 @@ namespace Ical.Net.Tests
             {
                 Assert.That(
                     occurrences,
-                    Has.Count.GreaterThanOrEqualTo(dateTimes.Length),
-                    "There should have been " + dateTimes.Length + " or more occurrences; there were " + occurrences.Count);
+                    Has.Count.EqualTo(dateTimes.Length),
+                    "There should have been " + dateTimes.Length + " occurrences; there were " + occurrences.Count);
 
                 if (evt.RecurrenceRules.Count > 0)
                 {
@@ -1872,72 +1872,54 @@ namespace Ical.Net.Tests
         }
 
         [Test, Category("Recurrence")]
-        public void Secondly_AtLeastDefinedNumberOfOccurrences_ShouldSucceed()
+        public void Secondly_DefinedNumberOfOccurrences_ShouldSucceed()
         {
             var iCal = Calendar.Load(IcsFiles.Secondly1);
 
-            EventOccurrenceTest(
-                iCal,
-                new CalDateTime(2007, 6, 21, 8, 0, 0, _tzid),
-                new CalDateTime(2007, 6, 21, 8, 1, 1, _tzid), // End period is exclusive, not inclusive.
-                new[]
-                {
-                    new CalDateTime(2007, 6, 21, 8, 0, 0, _tzid),
-                    new CalDateTime(2007, 6, 21, 8, 0, 1, _tzid),
-                    new CalDateTime(2007, 6, 21, 8, 0, 2, _tzid),
-                    new CalDateTime(2007, 6, 21, 8, 0, 3, _tzid),
-                    new CalDateTime(2007, 6, 21, 8, 0, 4, _tzid),
-                    new CalDateTime(2007, 6, 21, 8, 0, 5, _tzid),
-                    new CalDateTime(2007, 6, 21, 8, 0, 6, _tzid),
-                    new CalDateTime(2007, 6, 21, 8, 0, 7, _tzid),
-                    new CalDateTime(2007, 6, 21, 8, 0, 8, _tzid),
-                    new CalDateTime(2007, 6, 21, 8, 0, 9, _tzid),
-                    new CalDateTime(2007, 6, 21, 8, 0, 10, _tzid)
-                },
-                null
-            );
+            var start = new CalDateTime(2007, 6, 21, 8, 0, 0, _tzid);
+            var end = new CalDateTime(2007, 6, 21, 8, 1, 0, _tzid); // End period is exclusive, not inclusive.
+
+            var dateTimes = new List<IDateTime>();
+            for (var dt = start; dt.LessThan(end); dt = (CalDateTime) dt.AddSeconds(1))
+            {
+                dateTimes.Add(new CalDateTime(dt));
+            }
+
+            EventOccurrenceTest(iCal, start, end, dateTimes.ToArray(), null);
         }
 
         [Test, Category("Recurrence")]
-        public void Minutely_AtLeastDefinedNumberOfOccurrences_ShouldSucceed()
+        public void Minutely_DefinedNumberOfOccurrences_ShouldSucceed()
         {
             var iCal = Calendar.Load(IcsFiles.Minutely1);
 
-            EventOccurrenceTest(
-                iCal,
-                new CalDateTime(2007, 6, 21, 8, 0, 0, _tzid),
-                new CalDateTime(2007, 6, 21, 12, 0, 1, _tzid), // End period is exclusive, not inclusive.
-                new[]
-                {
-                    new CalDateTime(2007, 6, 21, 8, 0, 0, _tzid),
-                    new CalDateTime(2007, 6, 21, 8, 1, 0, _tzid),
-                    new CalDateTime(2007, 6, 21, 8, 2, 0, _tzid),
-                    new CalDateTime(2007, 6, 21, 8, 3, 0, _tzid),
-                    new CalDateTime(2007, 6, 21, 8, 4, 0, _tzid)
-                },
-                null
-            );
+            var start = new CalDateTime(2007, 6, 21, 8, 0, 0, _tzid);
+            var end = new CalDateTime(2007, 6, 21, 12, 0, 1, _tzid); // End period is exclusive, not inclusive.
+
+            var dateTimes = new List<IDateTime>();
+            for (var dt = start; dt.LessThan(end); dt = (CalDateTime)dt.AddMinutes(1))
+            {
+                dateTimes.Add(new CalDateTime(dt));
+            }
+
+            EventOccurrenceTest(iCal, start, end, dateTimes.ToArray(), null);
         }
 
         [Test, Category("Recurrence")]
-        public void Hourly_AtLeastDefinedNumberOfOccurrences_ShouldSucceed()
+        public void Hourly_DefinedNumberOfOccurrences_ShouldSucceed()
         {
             var iCal = Calendar.Load(IcsFiles.Hourly1);
 
-            EventOccurrenceTest(
-                iCal,
-                new CalDateTime(2007, 6, 21, 8, 0, 0, _tzid),
-                new CalDateTime(2007, 6, 25, 8, 0, 1, _tzid), // End period is exclusive, not inclusive.
-                new[]
-                {
-                    new CalDateTime(2007, 6, 21, 8, 0, 0, _tzid),
-                    new CalDateTime(2007, 6, 21, 9, 0, 0, _tzid),
-                    new CalDateTime(2007, 6, 21, 10, 0, 0, _tzid),
-                    new CalDateTime(2007, 6, 21, 11, 0, 0, _tzid),
-                    new CalDateTime(2007, 6, 21, 12, 0, 0, _tzid)
-                },
-                null
-            );
+            var start = new CalDateTime(2007, 6, 21, 8, 0, 0, _tzid);
+            var end = new CalDateTime(2007, 6, 25, 8, 0, 1, _tzid); // End period is exclusive, not inclusive.
+
+            var dateTimes = new List<IDateTime>();
+            for (var dt = start; dt.LessThan(end); dt = (CalDateTime)dt.AddHours(1))
+            {
+                dateTimes.Add(new CalDateTime(dt));
+            }
+
+            EventOccurrenceTest(iCal, start, end, dateTimes.ToArray(), null);
         }
 
         /// <summary>

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -30,6 +30,10 @@ namespace Ical.Net.Tests
         )
         {
             var evt = cal.Events.Skip(eventIndex).First();
+            var rule = evt.RecurrenceRules.FirstOrDefault();
+#pragma warning disable 0618
+            if (rule != null) rule.RestrictionType = RecurrenceRestrictionType.NoRestriction;
+#pragma warning restore 0618
             fromDate.AssociatedObject = cal;
             toDate.AssociatedObject = cal;
 
@@ -2767,6 +2771,9 @@ namespace Ical.Net.Tests
             // This case (DTSTART of type DATE and FREQ=MINUTELY) is undefined in RFC 5545.
             // ical.net handles the case by pretending DTSTART has the time set to midnight.
             evt.RecurrenceRules.Add(new RecurrencePattern($"FREQ={freq};INTERVAL=10;COUNT=5"));
+#pragma warning disable 0618
+            evt.RecurrenceRules[0].RestrictionType = RecurrenceRestrictionType.NoRestriction;
+#pragma warning restore 0618
 
             var occurrences = evt.GetOccurrences(CalDateTime.Today.AddDays(-1), CalDateTime.Today.AddDays(100))
                 .OrderBy(x => x)
@@ -2791,6 +2798,9 @@ namespace Ical.Net.Tests
             // NOTE: evaluators are not generally meant to be used directly like this.
             // However, this does make a good test to ensure they behave as they should.
             var pattern = new RecurrencePattern("FREQ=SECONDLY;INTERVAL=10");
+#pragma warning disable 0618
+            pattern.RestrictionType = RecurrenceRestrictionType.NoRestriction;
+#pragma warning restore 0618
 
             var us = new CultureInfo("en-US");
 

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -42,7 +42,7 @@ namespace Ical.Net.Tests
                 Assert.That(
                     occurrences,
                     Has.Count.GreaterThanOrEqualTo(dateTimes.Length),
-                    "There should have " + dateTimes.Length + " or more occurrences; there were " + occurrences.Count);
+                    "There should have been " + dateTimes.Length + " or more occurrences; there were " + occurrences.Count);
 
                 if (evt.RecurrenceRules.Count > 0)
                 {
@@ -1871,11 +1871,8 @@ namespace Ical.Net.Tests
             );
         }
 
-        /// <summary>
-        /// At least a few SECONDLY occurrences are generated without TimeoutException.
-        /// </summary>
         [Test, Category("Recurrence")]
-        public void Secondly_DefinedNumberOfOccurrences_ShouldSucceed()
+        public void Secondly_AtLeastDefinedNumberOfOccurrences_ShouldSucceed()
         {
             var iCal = Calendar.Load(IcsFiles.Secondly1);
 
@@ -1901,11 +1898,8 @@ namespace Ical.Net.Tests
             );
         }
 
-        /// <summary>
-        /// At least a few MINUTELY occurrences are generated without TimeoutException.
-        /// </summary>
         [Test, Category("Recurrence")]
-        public void Minutely_DefinedNumberOfOccurrences_ShouldSucceed()
+        public void Minutely_AtLeastDefinedNumberOfOccurrences_ShouldSucceed()
         {
             var iCal = Calendar.Load(IcsFiles.Minutely1);
 
@@ -1925,11 +1919,8 @@ namespace Ical.Net.Tests
             );
         }
 
-        /// <summary>
-        /// At least a few HOURLY occurrences are generated without TimeoutException.
-        /// </summary>
         [Test, Category("Recurrence")]
-        public void Hourly_DefinedNumberOfOccurrences_ShouldSucceed()
+        public void Hourly_AtLeastDefinedNumberOfOccurrences_ShouldSucceed()
         {
             var iCal = Calendar.Load(IcsFiles.Hourly1);
 

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -18,12 +18,6 @@ namespace Ical.Net.Tests
     [TestFixture]
     public class RecurrenceTests
     {
-        [SetUp]
-        public void SetupBeforeEachTest()
-        {
-            RecurrenceUtil.RecurrenceTimeout = RecurrenceUtil.DefaultTimeout;
-        }
-
         private const string _tzid = "US-Eastern";
 
         private void EventOccurrenceTest(
@@ -543,7 +537,6 @@ namespace Ical.Net.Tests
         [Test, Category("Recurrence")]
         public void WeeklyCountWkst1()
         {
-            RecurrenceUtil.RecurrenceTimeout = 1500;
             var iCal1 = Calendar.Load(IcsFiles.WeeklyUntilWkst1);
             var iCal2 = Calendar.Load(IcsFiles.WeeklyCountWkst1);
             ProgramTest.TestCal(iCal1);
@@ -1879,27 +1872,12 @@ namespace Ical.Net.Tests
         }
 
         /// <summary>
-        /// Too many SECONDLY recurrences should time out.
-        /// </summary>
-        [Test, Category("Recurrence")]
-        public void Secondly_HighNumberOfOccurrences_ShouldTimeout()
-        {
-            RecurrenceUtil.RecurrenceTimeout = 50; // reduce below default to ensure timeout
-            Assert.That(() =>
-            {
-                var iCal = Calendar.Load(IcsFiles.Secondly1);
-                _ = iCal.GetOccurrences(new CalDateTime(2007, 6, 21, 8, 0, 0, _tzid), new CalDateTime(2007, 7, 21, 8, 0, 0, _tzid));
-            }, Throws.Exception.TypeOf<TimeoutException>(), "Too many occurrences should timeout.");
-        }
-
-        /// <summary>
         /// At least a few SECONDLY occurrences are generated without TimeoutException.
         /// </summary>
         [Test, Category("Recurrence")]
-        public void Secondly_LowNumberOfOccurrences_ShouldSucceed()
+        public void Secondly_DefinedNumberOfOccurrences_ShouldSucceed()
         {
             var iCal = Calendar.Load(IcsFiles.Secondly1);
-            RecurrenceUtil.RecurrenceTimeout = 1500;
 
             EventOccurrenceTest(
                 iCal,
@@ -1924,27 +1902,10 @@ namespace Ical.Net.Tests
         }
 
         /// <summary>
-        /// Too many MINUTELY occurrences time out.
-        /// </summary>
-        [Test, Category("Recurrence")]
-        public void Minutely_HighNumberOfOccurrences_ShouldTimeout()
-        {
-            RecurrenceUtil.RecurrenceTimeout = 50; // reduce below default to ensure timeout
-            Assert.That(() =>
-            {
-                var iCal = Calendar.Load(IcsFiles.Minutely1);
-                var evt = iCal.Events.First();
-                var occurrences = evt.GetOccurrences(
-                    new CalDateTime(2007, 6, 21, 8, 0, 0, _tzid),
-                    new CalDateTime(2007, 7, 21, 8, 0, 0, _tzid));
-            }, Throws.Exception.TypeOf<TimeoutException>(), "Too many occurrences should timeout.");
-        }
-
-        /// <summary>
         /// At least a few MINUTELY occurrences are generated without TimeoutException.
         /// </summary>
         [Test, Category("Recurrence")]
-        public void Minutely_LowNumberOfOccurrences_ShouldSucceed()
+        public void Minutely_DefinedNumberOfOccurrences_ShouldSucceed()
         {
             var iCal = Calendar.Load(IcsFiles.Minutely1);
 
@@ -1965,26 +1926,10 @@ namespace Ical.Net.Tests
         }
 
         /// <summary>
-        /// Too many HOURLY occurrences time out.
-        /// </summary>
-        [Test, Category("Recurrence")]
-        public void Hourly_HighNumberOfOccurrences_ShouldTimeout()
-        {
-            RecurrenceUtil.RecurrenceTimeout = 50; // reduce below default to ensure timeout
-            Assert.That(() =>
-                {
-                var iCal = Calendar.Load(IcsFiles.Hourly1);
-                _ = iCal.GetOccurrences(new CalDateTime(2007, 6, 21, 8, 0, 0, _tzid),
-                    new CalDateTime(2013, 7, 21, 8, 0, 0, _tzid));
-            },
-    Throws.Exception.TypeOf<TimeoutException>(), "Too many occurrences should timeout.");
-        }
-
-        /// <summary>
         /// At least a few HOURLY occurrences are generated without TimeoutException.
         /// </summary>
         [Test, Category("Recurrence")]
-        public void Hourly_LowNumberOfOccurrences_ShouldSucceed()
+        public void Hourly_DefinedNumberOfOccurrences_ShouldSucceed()
         {
             var iCal = Calendar.Load(IcsFiles.Hourly1);
 
@@ -3765,7 +3710,6 @@ END:VCALENDAR
         [TestCaseSource(nameof(TestLibicalTestCasesSource))]
         public void TestLibicalTestCases(RecurrenceTestCase testCase)
         {
-            RecurrenceUtil.RecurrenceTimeout = 1500;
             ExecuteRecurrenceTestCase(testCase);
         }
 

--- a/Ical.Net/Calendar.cs
+++ b/Ical.Net/Calendar.cs
@@ -192,7 +192,7 @@ namespace Ical.Net
             return tz;
         }
 
- 
+
         /// <summary>
         /// Clears recurrence evaluations for recurring components.
         /// </summary>
@@ -213,6 +213,7 @@ namespace Ical.Net
         public virtual HashSet<Occurrence> GetOccurrences(IDateTime dt)
             => GetOccurrences<IRecurringComponent>(new CalDateTime(dt.Date), new CalDateTime(dt.Date.AddDays(1).AddSeconds(-1)));
 
+        /// <inheritdoc cref="GetOccurrences(IDateTime)"/>
         public virtual HashSet<Occurrence> GetOccurrences(DateTime dt)
             => GetOccurrences<IRecurringComponent>(new CalDateTime(dt.Date), new CalDateTime(dt.Date.AddDays(1).AddSeconds(-1)));
 
@@ -222,10 +223,11 @@ namespace Ical.Net
         /// </summary>
         /// <param name="startTime">The beginning date/time of the range.</param>
         /// <param name="endTime">The end date/time of the range.</param>
-        /// <returns>A list of occurrences that fall between the dates provided.</returns>
+        /// <returns>A list of occurrences that fall between the date/time arguments provided.</returns>
         public virtual HashSet<Occurrence> GetOccurrences(IDateTime startTime, IDateTime endTime)
             => GetOccurrences<IRecurringComponent>(startTime, endTime);
 
+        /// <inheritdoc cref="GetOccurrences(IDateTime, IDateTime)"/>
         public virtual HashSet<Occurrence> GetOccurrences(DateTime startTime, DateTime endTime)
             => GetOccurrences<IRecurringComponent>(new CalDateTime(startTime), new CalDateTime(endTime));
 
@@ -239,14 +241,16 @@ namespace Ical.Net
         /// the occurrences.
         /// </note>
         /// </summary>
-        /// <param name="dt">The date for which to return occurrences.</param>
+        /// <param name="dt">The date for which to return occurrences. Time is ignored on this parameter.</param>
         /// <returns>A list of Periods representing the occurrences of this object.</returns>
         public virtual HashSet<Occurrence> GetOccurrences<T>(IDateTime dt) where T : IRecurringComponent
             => GetOccurrences<T>(new CalDateTime(dt.Date), new CalDateTime(dt.Date.AddDays(1).AddTicks(-1)));
 
+        /// <inheritdoc cref="GetOccurrences(IDateTime)"/>
         public virtual HashSet<Occurrence> GetOccurrences<T>(DateTime dt) where T : IRecurringComponent
             => GetOccurrences<T>(new CalDateTime(dt.Date), new CalDateTime(dt.Date.AddDays(1).AddTicks(-1)));
 
+        /// <inheritdoc cref="GetOccurrences(IDateTime, IDateTime)"/>
         public virtual HashSet<Occurrence> GetOccurrences<T>(DateTime startTime, DateTime endTime) where T : IRecurringComponent
             => GetOccurrences<T>(new CalDateTime(startTime), new CalDateTime(endTime));
 
@@ -259,21 +263,21 @@ namespace Ical.Net
         /// <param name="endTime">The ending date range</param>
         public virtual HashSet<Occurrence> GetOccurrences<T>(IDateTime startTime, IDateTime endTime) where T : IRecurringComponent
         {
-                var occurrences = new HashSet<Occurrence>(RecurringItems
-                    .OfType<T>()
-                    .SelectMany(recurrable => recurrable.GetOccurrences(startTime, endTime)));
+            var occurrences = new HashSet<Occurrence>(RecurringItems
+                .OfType<T>()
+                .SelectMany(recurrable => recurrable.GetOccurrences(startTime, endTime)));
 
-                var removeOccurrencesQuery = occurrences
-                    .Where(o => o.Source is UniqueComponent)
-                    .GroupBy(o => ((UniqueComponent)o.Source).Uid)
-                    .SelectMany(group => group
-                        .Where(o => o.Source.RecurrenceId != null)
-                        .SelectMany(occurrence => group.
-                            Where(o => o.Source.RecurrenceId == null && occurrence.Source.RecurrenceId.Date.Equals(o.Period.StartTime.Date))));
+            var removeOccurrencesQuery = occurrences
+                .Where(o => o.Source is UniqueComponent)
+                .GroupBy(o => ((UniqueComponent)o.Source).Uid)
+                .SelectMany(group => group
+                    .Where(o => o.Source.RecurrenceId != null)
+                    .SelectMany(occurrence => group.
+                        Where(o => o.Source.RecurrenceId == null && occurrence.Source.RecurrenceId.Date.Equals(o.Period.StartTime.Date))));
 
-                occurrences.ExceptWith(removeOccurrencesQuery);
-                return occurrences;
-            }
+            occurrences.ExceptWith(removeOccurrencesQuery);
+            return occurrences;
+        }
 
         /// <summary>
         /// Creates a typed object that is a direct child of the iCalendar itself.  Generally,

--- a/Ical.Net/Calendar.cs
+++ b/Ical.Net/Calendar.cs
@@ -211,7 +211,7 @@ namespace Ical.Net
         /// <param name="dt">The date for which to return occurrences. Time is ignored on this parameter.</param>
         /// <returns>A list of occurrences that occur on the given date (<paramref name="dt"/>).</returns>
         public virtual HashSet<Occurrence> GetOccurrences(IDateTime dt)
-            => GetOccurrences<IRecurringComponent>(new CalDateTime(dt.AsSystemLocal.Date), new CalDateTime(dt.AsSystemLocal.Date.AddDays(1).AddSeconds(-1)));
+            => GetOccurrences<IRecurringComponent>(new CalDateTime(dt.Date), new CalDateTime(dt.Date.AddDays(1).AddSeconds(-1)));
 
         public virtual HashSet<Occurrence> GetOccurrences(DateTime dt)
             => GetOccurrences<IRecurringComponent>(new CalDateTime(dt.Date), new CalDateTime(dt.Date.AddDays(1).AddSeconds(-1)));
@@ -242,7 +242,7 @@ namespace Ical.Net
         /// <param name="dt">The date for which to return occurrences.</param>
         /// <returns>A list of Periods representing the occurrences of this object.</returns>
         public virtual HashSet<Occurrence> GetOccurrences<T>(IDateTime dt) where T : IRecurringComponent
-            => GetOccurrences<T>(new CalDateTime(dt.AsSystemLocal.Date), new CalDateTime(dt.AsSystemLocal.Date.AddDays(1).AddTicks(-1)));
+            => GetOccurrences<T>(new CalDateTime(dt.Date), new CalDateTime(dt.Date.AddDays(1).AddTicks(-1)));
 
         public virtual HashSet<Occurrence> GetOccurrences<T>(DateTime dt) where T : IRecurringComponent
             => GetOccurrences<T>(new CalDateTime(dt.Date), new CalDateTime(dt.Date.AddDays(1).AddTicks(-1)));

--- a/Ical.Net/Constants.cs
+++ b/Ical.Net/Constants.cs
@@ -219,6 +219,7 @@ namespace Ical.Net
         Fifth = 5
     }
 
+    [Obsolete("Usage may cause undesired results or exceptions. Will be removed.", false)]
     public enum RecurrenceRestrictionType
     {
         /// <summary>
@@ -247,6 +248,7 @@ namespace Ical.Net
         RestrictHourly
     }
 
+    [Obsolete("Usage may cause undesired results or exceptions. Will be removed.", false)]
     public enum RecurrenceEvaluationModeType
     {
         /// <summary>

--- a/Ical.Net/DataTypes/RecurrencePattern.cs
+++ b/Ical.Net/DataTypes/RecurrencePattern.cs
@@ -84,6 +84,11 @@ namespace Ical.Net.DataTypes
 
         public DayOfWeek FirstDayOfWeek { get; set; } = DayOfWeek.Monday;
 
+        /// <summary>
+        /// The type of restriction to apply to the evaluation of this recurrence pattern.
+        /// Returns <see cref="RecurrenceRestrictionType.NoRestriction"/> if not set.
+        /// </summary>
+        [Obsolete("Usage may cause undesired results or exceptions. Will be removed.", false)]
         public RecurrenceRestrictionType RestrictionType
         {
             get
@@ -93,11 +98,12 @@ namespace Ical.Net.DataTypes
                 {
                     return _restrictionType.Value;
                 }
-                return Calendar?.RecurrenceRestriction ?? RecurrenceRestrictionType.Default;
+                return RecurrenceRestrictionType.NoRestriction;
             }
             set => _restrictionType = value;
         }
 
+        [Obsolete("Usage may cause undesired results or exceptions. Will be removed.", false)]
         public RecurrenceEvaluationModeType EvaluationMode
         {
             get

--- a/Ical.Net/DataTypes/RecurrencePattern.cs
+++ b/Ical.Net/DataTypes/RecurrencePattern.cs
@@ -15,9 +15,10 @@ namespace Ical.Net.DataTypes
     public class RecurrencePattern : EncodableDataType
     {
         private int _interval = int.MinValue;
+#pragma warning disable 0618
         private RecurrenceRestrictionType? _restrictionType;
         private RecurrenceEvaluationModeType? _evaluationMode;
-
+#pragma warning restore 0618
         public FrequencyType Frequency { get; set; }
 
         private DateTime _until = DateTime.MinValue;
@@ -84,6 +85,7 @@ namespace Ical.Net.DataTypes
 
         public DayOfWeek FirstDayOfWeek { get; set; } = DayOfWeek.Monday;
 
+#pragma warning disable 0618
         /// <summary>
         /// The type of restriction to apply to the evaluation of this recurrence pattern.
         /// Returns <see cref="RecurrenceRestrictionType.NoRestriction"/> if not set.
@@ -98,7 +100,7 @@ namespace Ical.Net.DataTypes
                 {
                     return _restrictionType.Value;
                 }
-                return RecurrenceRestrictionType.NoRestriction;
+                return Calendar?.RecurrenceRestriction ?? RecurrenceRestrictionType.Default;
             }
             set => _restrictionType = value;
         }
@@ -117,6 +119,7 @@ namespace Ical.Net.DataTypes
             }
             set => _evaluationMode = value;
         }
+#pragma warning restore 0618
 
         public RecurrencePattern()
         {
@@ -148,8 +151,10 @@ namespace Ical.Net.DataTypes
         }
 
         protected bool Equals(RecurrencePattern other) => (Interval == other.Interval)
+#pragma warning disable 0618
             && RestrictionType == other.RestrictionType
             && EvaluationMode == other.EvaluationMode
+#pragma warning restore 0618
             && Frequency == other.Frequency
             && Until.Equals(other.Until)
             && Count == other.Count
@@ -176,8 +181,10 @@ namespace Ical.Net.DataTypes
             unchecked
             {
                 var hashCode = Interval.GetHashCode();
+#pragma warning disable 0618
                 hashCode = (hashCode * 397) ^ RestrictionType.GetHashCode();
                 hashCode = (hashCode * 397) ^ EvaluationMode.GetHashCode();
+#pragma warning restore 0618
                 hashCode = (hashCode * 397) ^ (int)Frequency;
                 hashCode = (hashCode * 397) ^ Until.GetHashCode();
                 hashCode = (hashCode * 397) ^ Count;
@@ -218,8 +225,10 @@ namespace Ical.Net.DataTypes
             ByMonth = new List<int>(r.ByMonth);
             BySetPosition = new List<int>(r.BySetPosition);
             FirstDayOfWeek = r.FirstDayOfWeek;
+#pragma warning disable 0618
             RestrictionType = r.RestrictionType;
             EvaluationMode = r.EvaluationMode;
+#pragma warning restore 0618
         }
 
         private static bool CollectionEquals<T>(IEnumerable<T> c1, IEnumerable<T> c2) => c1.SequenceEqual(c2);

--- a/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
@@ -135,7 +135,7 @@ namespace Ical.Net.Evaluation
 
             return r;
         }
-
+#pragma warning disable 0618
         private void EnforceEvaluationRestrictions(RecurrencePattern pattern)
         {
             RecurrenceEvaluationModeType? evaluationMode = pattern.EvaluationMode;
@@ -230,7 +230,7 @@ namespace Ical.Net.Evaluation
                 }
             }
         }
-
+#pragma warning 0618 restore
         /// <summary>
         /// Returns a list of start dates in the specified period represented by this recurrence pattern.
         /// This method includes a base date argument, which indicates the start of the first occurrence of this recurrence.

--- a/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
@@ -48,9 +48,6 @@ namespace Ical.Net.Evaluation
     /// </summary>
     public class RecurrencePatternEvaluator : Evaluator
     {
-        // FIXME: in ical4j this is configurable.
-        private const int _maxIncrementCount = 1000;
-
         protected RecurrencePattern Pattern { get; set; }
 
         public RecurrencePatternEvaluator(RecurrencePattern pattern)
@@ -232,14 +229,13 @@ namespace Ical.Net.Evaluation
             }
         }
 
-        /**
-         * Returns a list of start dates in the specified period represented by this recur. This method includes a base date
-         * argument, which indicates the start of the fist occurrence of this recurrence. The base date is used to inject
-         * default values to return a set of dates in the correct format. For example, if the search start date (start) is
-         * Wed, Mar 23, 12:19PM, but the recurrence is Mon - Fri, 9:00AM - 5:00PM, the start dates returned should all be at
-         * 9:00AM, and not 12:19PM.
-         */
-
+        /// <summary>
+        /// Returns a list of start dates in the specified period represented by this recurrence pattern.
+        /// This method includes a base date argument, which indicates the start of the first occurrence of this recurrence.
+        /// The base date is used to inject default values to return a set of dates in the correct format.
+        /// For example, if the search start date (start) is Wed, Mar 23, 12:19PM, but the recurrence is Mon - Fri, 9:00AM - 5:00PM,
+        /// the start dates returned should all be at 9:00AM, and not 12:19PM.
+        /// </summary>
         private HashSet<DateTime> GetDates(IDateTime seed, DateTime periodStart, DateTime periodEnd, int maxCount, RecurrencePattern pattern,
             bool includeReferenceDateInResults)
         {
@@ -261,7 +257,6 @@ namespace Ical.Net.Evaluation
 
             var expandBehavior = RecurrenceUtil.GetExpandBehaviorList(pattern);
 
-            var noCandidateIncrementCount = 0;
             var candidate = DateTime.MinValue;
             while (maxCount < 0 || dates.Count < maxCount)
             {
@@ -289,8 +284,6 @@ namespace Ical.Net.Evaluation
                 var candidates = GetCandidates(seedCopy, pattern, expandBehavior);
                 if (candidates.Count > 0)
                 {
-                    noCandidateIncrementCount = 0;
-
                     foreach (var t in candidates.OrderBy(c => c).Where(t => t >= originalDate))
                     {
                         candidate = t;
@@ -316,14 +309,6 @@ namespace Ical.Net.Evaluation
                         }
                     }
                 }
-                else
-                {
-                    noCandidateIncrementCount++;
-                    if (_maxIncrementCount > 0 && noCandidateIncrementCount > _maxIncrementCount)
-                    {
-                        break;
-                    }
-                }
 
                 IncrementDate(ref seedCopy, pattern, pattern.Interval);
             }
@@ -331,13 +316,13 @@ namespace Ical.Net.Evaluation
             return dates;
         }
 
-        /**
-         * Returns a list of possible dates generated from the applicable BY* rules, using the specified date as a seed.
-         * @param date the seed date
-         * @param value the type of date list to return
-         * @return a DateList
-         */
-
+        /// <summary>
+        /// Returns a list of possible dates generated from the applicable BY* rules, using the specified date as a seed.
+        /// </summary>
+        /// <param name="date">The seed date.</param>
+        /// <param name="pattern"></param>
+        /// <param name="expandBehaviors"></param>
+        /// <returns>A list of possible dates.</returns>
         private List<DateTime> GetCandidates(DateTime date, RecurrencePattern pattern, bool?[] expandBehaviors)
         {
             var dates = new List<DateTime> { date };
@@ -353,11 +338,12 @@ namespace Ical.Net.Evaluation
             return dates;
         }
 
-        /**
-         * Applies BYSETPOS rules to <code>dates</code>. Valid positions are from 1 to the size of the date list. Invalid
-         * positions are ignored.
-         * @param dates
-         */
+        /// <summary>
+        /// Applies BYSETPOS rules to <paramref name="dates"/>. Valid positions are from 1 to the size of the date list. Invalid
+        /// positions are ignored.
+        /// </summary>
+        /// <param name="dates">The list of dates to which the BYSETPOS rules will be applied.</param>
+        /// <param name="pattern"></param>
         private List<DateTime> ApplySetPosRules(List<DateTime> dates, RecurrencePattern pattern)
         {
             // return if no SETPOS rules specified..
@@ -379,12 +365,14 @@ namespace Ical.Net.Evaluation
             return setPosDates;
         }
 
-        /**
-         * Applies BYMONTH rules specified in this Recur instance to the specified date list. If no BYMONTH rules are
-         * specified the date list is returned unmodified.
-         * @param dates
-         * @return
-         */
+        /// <summary>
+        /// Applies BYMONTH rules specified in this Recur instance to the specified date list. 
+        /// If no BYMONTH rules are specified, the date list is returned unmodified.
+        /// </summary>
+        /// <param name="dates">The list of dates to which the BYMONTH rules will be applied.</param>
+        /// <param name="pattern"></param>
+        /// <param name="expand"></param>
+        /// <returns>The modified list of dates after applying the BYMONTH rules.</returns>
         private List<DateTime> GetMonthVariants(List<DateTime> dates, RecurrencePattern pattern, bool? expand)
         {
             if (expand == null || pattern.ByMonth.Count == 0)
@@ -406,12 +394,12 @@ namespace Ical.Net.Evaluation
             return dateSet.ToList();
         }
 
-        /**
-         * Applies BYWEEKNO rules specified in this Recur instance to the specified date list. If no BYWEEKNO rules are
-         * specified the date list is returned unmodified.
-         * @param dates
-         * @return
-         */
+        /// <summary>
+        /// Applies BYWEEKNO rules specified in this Recur instance to the specified date list. 
+        /// If no BYWEEKNO rules are specified, the date list is returned unmodified.
+        /// </summary>
+        /// <param name="dates">The list of dates to which the BYWEEKNO rules will be applied.</param>
+        /// <returns>The modified list of dates after applying the BYWEEKNO rules.</returns>
         private List<DateTime> GetWeekNoVariants(List<DateTime> dates, RecurrencePattern pattern, bool? expand)
         {
             if (expand == null || pattern.ByWeekNo.Count == 0)
@@ -462,13 +450,12 @@ namespace Ical.Net.Evaluation
             return weekNoDates;
         }
 
-        /**
-         * Applies BYYEARDAY rules specified in this Recur instance to the specified date list. If no BYYEARDAY rules are
-         * specified the date list is returned unmodified.
-         * @param dates
-         * @return
-         */
-
+        /// <summary>
+        /// Applies BYYEARDAY rules specified in this Recur instance to the specified date list. 
+        /// If no BYYEARDAY rules are specified, the date list is returned unmodified.
+        /// </summary>
+        /// <param name="dates">The list of dates to which the BYYEARDAY rules will be applied.</param>
+        /// <returns>The modified list of dates after applying the BYYEARDAY rules.</returns>
         private List<DateTime> GetYearDayVariants(List<DateTime> dates, RecurrencePattern pattern, bool? expand)
         {
             if (expand == null || pattern.ByYearDay.Count == 0)
@@ -516,13 +503,12 @@ namespace Ical.Net.Evaluation
             return dates;
         }
 
-        /**
-         * Applies BYMONTHDAY rules specified in this Recur instance to the specified date list. If no BYMONTHDAY rules are
-         * specified the date list is returned unmodified.
-         * @param dates
-         * @return
-         */
-
+        /// <summary>
+        /// Applies BYMONTHDAY rules specified in this Recur instance to the specified date list. 
+        /// If no BYMONTHDAY rules are specified, the date list is returned unmodified.
+        /// </summary>
+        /// <param name="dates">The list of dates to which the BYMONTHDAY rules will be applied.</param>
+        /// <returns>The modified list of dates after applying the BYMONTHDAY rules.</returns>
         private List<DateTime> GetMonthDayVariants(List<DateTime> dates, RecurrencePattern pattern, bool? expand)
         {
             if (expand == null || pattern.ByMonthDay.Count == 0)
@@ -571,20 +557,19 @@ namespace Ical.Net.Evaluation
                     }
                 }
 
-            Next:
+                Next:
                 dates.RemoveAt(i);
             }
 
             return dates;
         }
 
-        /**
-         * Applies BYDAY rules specified in this Recur instance to the specified date list. If no BYDAY rules are specified
-         * the date list is returned unmodified.
-         * @param dates
-         * @return
-         */
-
+        /// <summary>
+        /// Applies BYDAY rules specified in this Recur instance to the specified date list. 
+        /// If no BYDAY rules are specified, the date list is returned unmodified.
+        /// </summary>
+        /// <param name="dates">The list of dates to which BYDAY rules will be applied.</param>
+        /// <returns>The modified list of dates after applying BYDAY rules, or the original list if no BYDAY rules are specified.</returns>
         private List<DateTime> GetDayVariants(List<DateTime> dates, RecurrencePattern pattern, bool? expand)
         {
             if (expand == null || pattern.ByDay.Count == 0)
@@ -632,14 +617,13 @@ namespace Ical.Net.Evaluation
             return dates;
         }
 
-        /**
-         * Returns a list of applicable dates corresponding to the specified week day in accordance with the frequency
-         * specified by this recurrence rule.
-         * @param date
-         * @param weekDay
-         * @return
-         */
-
+        /// <summary>
+        /// Returns a list of applicable dates corresponding to the specified week day in accordance with the frequency
+        /// specified by this recurrence rule.
+        /// </summary>
+        /// <param name="date">The date to start the evaluation from.</param>
+        /// <param name="weekDay">The week day to evaluate.</param>
+        /// <returns>A list of applicable dates.</returns>
         private List<DateTime> GetAbsWeekDays(DateTime date, WeekDay weekDay, RecurrencePattern pattern)
         {
             var days = new List<DateTime>();
@@ -723,15 +707,13 @@ namespace Ical.Net.Evaluation
             return GetOffsetDates(days, weekDay.Offset);
         }
 
-        /**
-         * Returns a single-element sublist containing the element of <code>list</code> at <code>offset</code>. Valid
-         * offsets are from 1 to the size of the list. If an invalid offset is supplied, all elements from <code>list</code>
-         * are added to <code>sublist</code>.
-         * @param list
-         * @param offset
-         * @param sublist
-         */
-
+        /// <summary>
+        /// Returns a single-element sublist containing the element of <paramref name="dates"/> at <paramref name="offset"/>. 
+        /// Valid offsets are from 1 to the size of the list. If an invalid offset is supplied, all elements from <paramref name="dates"/>
+        /// are added to result.
+        /// </summary>
+        /// <param name="dates">The list from which to extract the element.</param>
+        /// <param name="offset">The position of the element to extract.</param>
         private List<DateTime> GetOffsetDates(List<DateTime> dates, int offset)
         {
             if (offset == int.MinValue)
@@ -752,13 +734,14 @@ namespace Ical.Net.Evaluation
             return offsetDates;
         }
 
-        /**
-         * Applies BYHOUR rules specified in this Recur instance to the specified date list. If no BYHOUR rules are
-         * specified the date list is returned unmodified.
-         * @param dates
-         * @return
-         */
-
+        /// <summary>
+        /// Applies BYHOUR rules specified in this Recur instance to the specified date list. 
+        /// If no BYHOUR rules are specified, the date list is returned unmodified.
+        /// </summary>
+        /// <param name="dates">The list of dates to which the BYHOUR rules will be applied.</param>
+        /// <param name="pattern"></param>
+        /// <param name="expand"></param>
+        /// <returns>The modified list of dates after applying the BYHOUR rules.</returns>
         private List<DateTime> GetHourVariants(List<DateTime> dates, RecurrencePattern pattern, bool? expand)
         {
             if (expand == null || pattern.ByHour.Count == 0)
@@ -802,13 +785,14 @@ namespace Ical.Net.Evaluation
             return dates;
         }
 
-        /**
-         * Applies BYMINUTE rules specified in this Recur instance to the specified date list. If no BYMINUTE rules are
-         * specified the date list is returned unmodified.
-         * @param dates
-         * @return
-         */
-
+        /// <summary>
+        /// Applies BYMINUTE rules specified in this Recur instance to the specified date list. 
+        /// If no BYMINUTE rules are specified, the date list is returned unmodified.
+        /// </summary>
+        /// <param name="dates">The list of dates to which the BYMINUTE rules will be applied.</param>
+        /// <param name="pattern"></param>
+        /// <param name="expand"></param>
+        /// <returns>The modified list of dates after applying the BYMINUTE rules.</returns>
         private List<DateTime> GetMinuteVariants(List<DateTime> dates, RecurrencePattern pattern, bool? expand)
         {
             if (expand == null || pattern.ByMinute.Count == 0)
@@ -852,13 +836,14 @@ namespace Ical.Net.Evaluation
             return dates;
         }
 
-        /**
-         * Applies BYSECOND rules specified in this Recur instance to the specified date list. If no BYSECOND rules are
-         * specified the date list is returned unmodified.
-         * @param dates
-         * @return
-         */
-
+        /// <summary>
+        /// Applies BYSECOND rules specified in this Recur instance to the specified date list. 
+        /// If no BYSECOND rules are specified, the date list is returned unmodified.
+        /// </summary>
+        /// <param name="dates">The list of dates to which the BYSECOND rules will be applied.</param>
+        /// <param name="pattern"></param>
+        /// <param name="expand"></param>
+        /// <returns>The modified list of dates after applying the BYSECOND rules.</returns>
         private List<DateTime> GetSecondVariants(List<DateTime> dates, RecurrencePattern pattern, bool? expand)
         {
             if (expand == null || pattern.BySecond.Count == 0)
@@ -927,7 +912,7 @@ namespace Ical.Net.Evaluation
         /// <returns></returns>
         public override HashSet<Period> Evaluate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd, bool includeReferenceDateInResults)
         {
-            if ((this.Pattern.Frequency != FrequencyType.None) && (this.Pattern.Frequency < FrequencyType.Daily) && !referenceDate.HasTime)
+            if (Pattern.Frequency != FrequencyType.None && Pattern.Frequency < FrequencyType.Daily && !referenceDate.HasTime)
             {
                 // This case is not defined by RFC 5545. We handle it by evaluating the rule
                 // as if referenceDate had a time (i.e. set to midnight).

--- a/Ical.Net/Evaluation/RecurrenceUtil.cs
+++ b/Ical.Net/Evaluation/RecurrenceUtil.cs
@@ -1,13 +1,22 @@
 ﻿using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
 using Ical.Net.Utility;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Ical.Net.Evaluation
 {
     internal class RecurrenceUtil
     {
+        // Should be a good default value to cover most cases
+        public const int DefaultTimeout = 1000;
+
+        // for v5 the timeout should be configurable (likely to result in a breaking change)
+        public static int RecurrenceTimeout = DefaultTimeout; // NOSONAR
+
         public static void ClearEvaluation(IRecurrable recurrable)
         {
             var evaluator = recurrable.GetService(typeof(IEvaluator)) as IEvaluator;
@@ -15,9 +24,10 @@ namespace Ical.Net.Evaluation
         }
 
         public static HashSet<Occurrence> GetOccurrences(IRecurrable recurrable, IDateTime dt, bool includeReferenceDateInResults) => GetOccurrences(recurrable,
-            new CalDateTime(dt.AsSystemLocal.Date), new CalDateTime(dt.AsSystemLocal.Date.AddDays(1).AddSeconds(-1)), includeReferenceDateInResults);
+            new CalDateTime(dt.Date), new CalDateTime(dt.Date.AddDays(1).AddSeconds(-1)), includeReferenceDateInResults);
 
-        public static HashSet<Occurrence> GetOccurrences(IRecurrable recurrable, IDateTime periodStart, IDateTime periodEnd, bool includeReferenceDateInResults)
+        public static HashSet<Occurrence> GetOccurrences(IRecurrable recurrable, IDateTime periodStart,
+            IDateTime periodEnd, bool includeReferenceDateInResults)
         {
             var evaluator = recurrable.GetService(typeof(IEvaluator)) as IEvaluator;
             if (evaluator == null || recurrable.Start == null)
@@ -35,19 +45,41 @@ namespace Ical.Net.Evaluation
             periodStart.TzId = start.TzId;
             periodEnd.TzId = start.TzId;
 
-            var periods = evaluator.Evaluate(start, DateUtil.GetSimpleDateTimeData(periodStart), DateUtil.GetSimpleDateTimeData(periodEnd),
-                includeReferenceDateInResults);
+            using var cancellationTokenSource = new CancellationTokenSource();
+            var task = Task.Run(() =>
+            {
+                var periods = evaluator.Evaluate(start, DateUtil.GetSimpleDateTimeData(periodStart),
+                    DateUtil.GetSimpleDateTimeData(periodEnd),
+                    includeReferenceDateInResults);
 
-            var otherOccurrences = from p in periods
-                                   let endTime = p.EndTime ?? p.StartTime
-                                   where
-                                       (endTime.GreaterThan(periodStart) && p.StartTime.LessThan(periodEnd) ||
-                                       (periodStart.Equals(periodEnd) && p.StartTime.LessThanOrEqual(periodStart) && endTime.GreaterThan(periodEnd))) || //A period that starts at the same time it ends
-                                       (p.StartTime.Equals(endTime) && periodStart.Equals(p.StartTime)) //An event that starts at the same time it ends
-                                   select new Occurrence(recurrable, p);
+                var otherOccurrences = from p in periods
+                                       let endTime = p.EndTime ?? p.StartTime
+                                       where
+                                           (endTime.GreaterThan(periodStart) && p.StartTime.LessThan(periodEnd) ||
+                                            (periodStart.Equals(periodEnd) && p.StartTime.LessThanOrEqual(periodStart) &&
+                                             endTime.GreaterThan(periodEnd))) || //A period that starts at the same time it ends
+                                           (p.StartTime.Equals(endTime) &&
+                                            periodStart.Equals(p.StartTime)) //An event that starts at the same time it ends
+                                       select new Occurrence(recurrable, p);
 
-            var occurrences = new HashSet<Occurrence>(otherOccurrences);
-            return occurrences;
+                var occurrences = new HashSet<Occurrence>(otherOccurrences);
+                return occurrences;
+            }, cancellationTokenSource.Token);
+
+            if (task.Wait(TimeSpan.FromMilliseconds(RecurrenceTimeout)))
+            {
+                if (task.IsFaulted && task.Exception != null)
+                {
+                    // maintain original exception details
+                    throw task.Exception;
+                }
+
+                return task.Result;
+            }
+
+            cancellationTokenSource.Cancel();
+            // maintain any exception inside the task before timeout
+            throw new TimeoutException("Getting recurrences has timed out.", task.Exception);
         }
 
         public static bool?[] GetExpandBehaviorList(RecurrencePattern p)

--- a/Ical.Net/Evaluation/RecurringEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurringEvaluator.cs
@@ -29,7 +29,7 @@ namespace Ical.Net.Evaluation
         }
 
         /// <summary>
-        /// Evaulates the RRule component, and adds each specified Period to the Periods collection.
+        /// Evaluates the RRule component, and adds each specified Period to the Periods collection.
         /// </summary>
         /// <param name="referenceDate"></param>
         /// <param name="periodStart">The beginning date of the range to evaluate.</param>
@@ -62,7 +62,7 @@ namespace Ical.Net.Evaluation
             return periods;
         }
 
-        /// <summary> Evalates the RDate component, and adds each specified DateTime or Period to the Periods collection. </summary>
+        /// <summary> Evaluates the RDate component, and adds each specified DateTime or Period to the Periods collection. </summary>
         protected HashSet<Period> EvaluateRDate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd)
         {
             if (Recurrable.RecurrenceDates == null || !Recurrable.RecurrenceDates.Any())
@@ -75,7 +75,7 @@ namespace Ical.Net.Evaluation
         }
 
         /// <summary>
-        /// Evaulates the ExRule component, and excludes each specified DateTime from the Periods collection.
+        /// Evaluates the ExRule component, and excludes each specified DateTime from the Periods collection.
         /// </summary>
         /// <param name="referenceDate"></param>
         /// <param name="periodStart">The beginning date of the range to evaluate.</param>
@@ -102,7 +102,7 @@ namespace Ical.Net.Evaluation
         }
 
         /// <summary>
-        /// Evalates the ExDate component, and excludes each specified DateTime or Period from the Periods collection.
+        /// Evaluates the ExDate component, and excludes each specified DateTime or Period from the Periods collection.
         /// </summary>
         /// <param name="referenceDate"></param>
         /// <param name="periodStart">The beginning date of the range to evaluate.</param>


### PR DESCRIPTION
- Deprecated `RecurrenceRestrictionType` and `RecurrenceEvaluationModeType` enums.

Updated RecurrencePattern.cs:
- Deprecated `RestrictionType` and `EvaluationMode` properties.
- Set default for `RestrictionType`.

Fix RecurrenceUtil:
- None of `GetOccurrences()` overloads convert `IDateTime` arguments with `AsSystemLocal`. This partial conversion is considered a bug. **The change may break user code that contains a fix for the bug.**

Refined RecurrencePatternEvaluator:
- Convert existing Java style comments for methods to XML documentation comments.

Updated Calendar.cs:
- Deprecated properties and methods associated with `RestrictionType` and `EvaluationMode`
- None of `GetOccurrences()` overloads convert `IDateTime` arguments with `AsSystemLocal`. This partial conversion is considered a bug. **The change may break user code that contains a fix for the bug.**
- Removed obsolete `Evaluate` method (just threw when called)

Enhanced RecurrenceTests.cs with more robust test cases:
- Replaced `Assert.That` with `Assert.Multiple`.
- Changed assertion for occurrences count.
- Renamed test methods for clarity.

Corrected typos and improved formatting for better readability.

Fixes #622
