### PR TITLE
Nullable=disable for CI builds

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ jobs:
       run: dotnet add ./Ical.Net.Tests/Ical.Net.Tests.csproj package AltCover
 
     - name: Build
-      run: dotnet build --no-restore --configuration Release -p:nowarn=1591
+      run: dotnet build --no-restore --configuration Release -p:Nullable=disable -p:nowarn=1591
     - name: Test
       run: dotnet test --no-build --configuration Release --verbosity normal /p:AltCover=true /p:AltCoverXmlReport="coverage.xml" /p:AltCoverStrongNameKey="../IcalNetStrongnameKey.snk" /p:AltCoverAssemblyExcludeFilter="Ical.Net.Tests|NUnit3.TestAdapter|AltCover" /p:AltCoverAttributeFilter="ExcludeFromCodeCoverage" /p:AltCoverLineCover="false"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --no-restore --configuration Release -p:nowarn=1591
+      run: dotnet build --no-restore --configuration Release -p:Nullable=disable -p:nowarn=1591
     - name: Test
       run: dotnet test --no-build --configuration Release --verbosity quiet
 
@@ -48,7 +48,7 @@ jobs:
     - name: Build and pack for publishing
       run: |
         dotnet restore
-        dotnet build --configuration Release Ical.Net/Ical.Net.csproj -p:Version=${{env.VERSION}} -p:FileVersion=${{env.VERSION}}.${{github.run_number}} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -p:ContinuousIntegrationBuild=true
+        dotnet build --configuration Release Ical.Net/Ical.Net.csproj -p:Version=${{env.VERSION}} -p:FileVersion=${{env.VERSION}}.${{github.run_number}} -p:Nullable=disable -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -p:ContinuousIntegrationBuild=true
         dotnet pack --configuration Release Ical.Net/Ical.Net.csproj -p:Version=${{env.VERSION}} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg --no-build -p:PackageVersion=${{env.VERSION}}
     - name: Store artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,6 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --no-restore --configuration Release -p:nowarn=1591
+      run: dotnet build --no-restore --configuration Release -p:Nullable=disable -p:nowarn=1591
     - name: Test
       run: dotnet test --no-build --configuration Release --verbosity normal


### PR DESCRIPTION
CI build processes now use `-p:Nullable=disable` to avoid breaking changes while we gradually migrate to NRT