### PR TITLE
Fix copying of `Attendee`s `Uri`-typed properties

### DIFF
--- a/Ical.Net.Tests/SerializationTests.cs
+++ b/Ical.Net.Tests/SerializationTests.cs
@@ -314,8 +314,8 @@ public class SerializationTests
 
         var evt = AttendeeTest.VEventFactory();
         cal.Events.Add(evt);
-        // new Uri() creates lowercase for the "MAILTO:" part
-        // according to the RFC 2368 specification
+        // The casing of `MAILTO` is not in line with RFC 2368, but we should
+        // be able to deal with it nevertheless and preserve it the way it is.
         const string org = "MAILTO:james@example.com";
         evt.Organizer = new Organizer(org);
 
@@ -331,7 +331,7 @@ public class SerializationTests
 
         foreach (var a in evt.Attendees)
         {
-            var vals = GetValues(vEvt, "ATTENDEE", a.Value.ToString());
+            var vals = GetValues(vEvt, "ATTENDEE", a.Value.OriginalString.ToString());
             foreach (var v in new Dictionary<string, string>
                      {
                          ["CN"] = a.CommonName,

--- a/Ical.Net/DataTypes/Attendee.cs
+++ b/Ical.Net/DataTypes/Attendee.cs
@@ -253,7 +253,7 @@ public class Attendee : EncodableDataType
         if (obj is not Attendee atn) return;
         base.CopyFrom(obj);
 
-        Value = new Uri(atn.Value.ToString());
+        Value = atn.Value;
 
         // String assignments create new instances
         CommonName = atn.CommonName;
@@ -263,8 +263,8 @@ public class Attendee : EncodableDataType
 
         Rsvp = atn.Rsvp;
 
-        SentBy = atn.SentBy != null ? new Uri(atn.SentBy.ToString()) : null;
-        DirectoryEntry = atn.DirectoryEntry != null ? new Uri(atn.DirectoryEntry.ToString()) : null;
+        SentBy = atn.SentBy;
+        DirectoryEntry = atn.DirectoryEntry;
     }
 
     protected bool Equals(Attendee other) => Equals(SentBy, other.SentBy)


### PR DESCRIPTION
Prior to this PR, when cloning an `Attendee` object, `Uri`-typed properties (i.e. `Value`, `SentBy`, `DirectoryEntry`) were copied like `newValue = new Uri(oldValue.ToString())`, which caused the Uri's `OriginalString` value to get lost. This PR fixes the behavior by simply copying the reference, which is safe as `Uri` is immutable. The PR also fixes the test `AttendeesSerialized`, which tested for the incorrect behavior.