### PR TITLE
Remove UTF7 encoding from EncodingProvider

### DIFF
--- a/Ical.Net.Tests/EncodingProviderTests.cs
+++ b/Ical.Net.Tests/EncodingProviderTests.cs
@@ -1,0 +1,89 @@
+﻿//
+// Copyright ical.net project maintainers and contributors.
+// Licensed under the MIT license.
+//
+
+#nullable enable
+using System;
+using Ical.Net.Serialization;
+using NUnit.Framework;
+using EncodingProvider = Ical.Net.Serialization.EncodingProvider;
+
+namespace Ical.Net.Tests;
+
+[TestFixture]
+public class EncodingProviderTests
+{
+    private EncodingProvider GetEncodingProvider() => new EncodingProvider(new SerializationContext());
+
+    [Test]
+    public void Encode_ShouldReturnEncodedString_WhenValidEncodingIsProvided()
+    {
+        const string encoding = "8BIT";
+        var data = "Hello"u8.ToArray();
+
+        var result = GetEncodingProvider().Encode(encoding, data);
+
+        Assert.That(result, Is.EqualTo("Hello"));
+    }
+
+    [Test]
+    public void Encode_ShouldBeNull_WhenInvalidEncodingIsProvided()
+    {
+        const string encoding = "Invalid-Encoding";
+        var data = "Hello"u8.ToArray();
+
+        Assert.That(GetEncodingProvider().Encode(encoding, data), Is.Null);
+    }
+
+    [Test]
+    public void Decode_ShouldReturnDecodedByteArray_WhenValidEncodingIsProvided()
+    {
+        const string encoding = "8BIT";
+        const string data = "Hello";
+
+        var result = GetEncodingProvider().DecodeString(encoding, data);
+
+        Assert.That(result, Is.EqualTo("Hello"u8.ToArray()));
+    }
+
+    [Test]
+    public void Decode_ShouldBeNull_WhenInvalidEncodingIsProvided()
+    {
+        const string encoding = "Invalid-Encoding";
+        const string data = "Hello";
+
+        Assert.That(GetEncodingProvider().DecodeString(encoding, data), Is.Null);
+    }
+
+    [Test]
+    public void Encode_ShouldReturnEncodedString_WithBase64Encoding()
+    {
+        const string encoding = "BASE64";
+        var data = "Hello"u8.ToArray();
+
+        var result = GetEncodingProvider().Encode(encoding, data);
+
+        Assert.That(result, Is.EqualTo("SGVsbG8=")); // "Hello" in Base64
+    }
+
+    [Test]
+    public void Decode_ShouldReturnDecodedByteArray_WithBase64Encoding()
+    {
+        const string encoding = "BASE64";
+        const string data = "SGVsbG8="; // "Hello" in Base64
+
+        var result = GetEncodingProvider().DecodeString(encoding, data);
+
+        Assert.That(result, Is.EqualTo("Hello"u8.ToArray()));
+    }
+
+    [Test]
+    public void Decode_ShouldThrow_WithInvalidBase64String()
+    {
+        const string encoding = "BASE64";
+        const string data = "InvalidBase64==="; // Invalid Base64 string
+
+        Assert.Throws<FormatException>(() => GetEncodingProvider().DecodeString(encoding, data));
+    }
+}


### PR DESCRIPTION
**Breaking Change**
Remove UTF7 encoding from `EncodingProvider` and add unit tests

- Enabled nullable reference types.
- Added XML documentation
- Removed 7-bit methods
- Refactored 8-bit and Base64 methods to remove try-catch blocks.
- Modified Encode, DecodeString, and DecodeData to handle null values.

Closes #649