### PR TITLE
Refactor to use DateOnly and TimeOnly for date/time handling

### DIFF
--- a/Ical.Net.Tests/CalDateTimeTests.cs
+++ b/Ical.Net.Tests/CalDateTimeTests.cs
@@ -305,12 +305,9 @@ public class CalDateTimeTests
         Assert.Multiple(() =>
         {
             Assert.That(c2.Value, Is.EqualTo(c3.Value));
-            Assert.That(c2.Ticks, Is.EqualTo(c3.Ticks));
             Assert.That(c2.TzId, Is.EqualTo(c3.TzId));
             Assert.That(CalDateTime.UtcNow.Value.Kind, Is.EqualTo(DateTimeKind.Unspecified));
             Assert.That(CalDateTime.Today.Value.Kind, Is.EqualTo(DateTimeKind.Unspecified));
-            Assert.That(c.Millisecond, Is.EqualTo(0));
-            Assert.That(c.Ticks, Is.EqualTo(dt.Ticks));
             Assert.That(c.DayOfYear, Is.EqualTo(dt.DayOfYear));
             Assert.That(c.Time?.ToTimeSpan(), Is.EqualTo(dt.TimeOfDay));
             Assert.That(c.Subtract(TimeSpan.FromSeconds(dt.Second)).Value.Second, Is.EqualTo(0));

--- a/Ical.Net.Tests/CalDateTimeTests.cs
+++ b/Ical.Net.Tests/CalDateTimeTests.cs
@@ -73,45 +73,9 @@ public class CalDateTimeTests
             .SetName($"IANA to BCL: {ianaNy} to {bclCst}");
     }
 
-    [TestCaseSource(nameof(AsDateTimeOffsetTestCases))]
-    public DateTimeOffset AsDateTimeOffsetTests(CalDateTime incoming)
-        => incoming.AsDateTimeOffset;
-
-    public static IEnumerable AsDateTimeOffsetTestCases()
-    {
-        const string nyTzId = "America/New_York";
-        var summerDate = DateTime.Parse("2018-05-15T11:00");
-
-        var nySummerOffset = TimeSpan.FromHours(-4);
-        var nySummer = new CalDateTime(summerDate, nyTzId);
-        yield return new TestCaseData(nySummer)
-            .SetName("NY Summer DateTime returns DateTimeOffset with UTC-4")
-            .Returns(new DateTimeOffset(summerDate, nySummerOffset));
-
-        var utc = new CalDateTime(summerDate, "UTC");
-        yield return new TestCaseData(utc)
-            .SetName("UTC summer DateTime returns a DateTimeOffset with UTC-0")
-            .Returns(new DateTimeOffset(summerDate, TimeSpan.Zero));
-
-        var convertedToNySummer = new CalDateTime(summerDate, nyTzId);
-        yield return new TestCaseData(convertedToNySummer)
-            .SetName(
-                "Summer UTC DateTime converted to NY time zone by setting TzId returns a DateTimeOffset with UTC-4")
-            .Returns(new DateTimeOffset(summerDate, nySummerOffset));
-
-        var noTz = new CalDateTime(summerDate);
-        var currentSystemOffset = TimeZoneInfo.Local.GetUtcOffset(summerDate);
-        yield return new TestCaseData(noTz)
-            .SetName(
-                $"Summer DateTime with no time zone information returns the system-local's UTC offset ({currentSystemOffset})")
-            .Returns(new DateTimeOffset(summerDate, currentSystemOffset));
-    }
-
     [Test(Description = "Calling AsUtc should always return the proper UTC time, even if the TzId has changed")]
     public void TestTzidChanges()
     {
-        var x = new CalDateTime(2018, 5, 21).AsDateTimeOffset;
-
         var someTime = DateTimeOffset.Parse("2018-05-21T11:35:00-04:00");
 
         var someDt = new CalDateTime(someTime.DateTime, "America/New_York");
@@ -356,32 +320,6 @@ public class CalDateTimeTests
             Assert.That(c.ToString("dd.MM.yyyy"), Is.EqualTo("02.01.2025 Europe/Berlin"));
             // Create a date-only CalDateTime from a CalDateTime
             Assert.That(new CalDateTime(new CalDateTime(2025, 1, 1)), Is.EqualTo(new CalDateTime(2025, 1, 1)));
-        });
-    }
-
-    [Test]
-    public void Simple_PropertyAndMethod_NotHasTime_Tests()
-    {
-        var dt = new DateTime(2025, 1, 2, 0, 0, 0, DateTimeKind.Utc);
-        var c = new CalDateTime(dt, tzId: "Europe/Berlin", hasTime: false);
-
-        // Adding time to a date-only value should not change the HasTime property
-        Assert.Multiple(() =>
-        {
-            var result = c.AddHours(1);
-            Assert.That(result.HasTime, Is.True);
-
-            result = c.AddMinutes(1);
-            Assert.That(result.HasTime, Is.True);
-
-            result = c.AddSeconds(1);
-            Assert.That(result.HasTime, Is.True);
-
-            result = c.AddMilliseconds(1000);
-            Assert.That(result.HasTime, Is.True);
-
-            result = c.AddTicks(TimeSpan.FromMinutes(1).Ticks);
-            Assert.That(result.HasTime, Is.True);
         });
     }
 }

--- a/Ical.Net.Tests/CalDateTimeTests.cs
+++ b/Ical.Net.Tests/CalDateTimeTests.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 
 namespace Ical.Net.Tests;
 
@@ -205,9 +206,33 @@ public class CalDateTimeTests
             .SetName("!= operator 2 timezones");
 
         yield return new TestCaseData(new Func<IDateTime, bool>(dt => (CalDateTime) dt == new CalDateTime(2025, 1, 15, 10, 20, 30, tzId: null)))
-            .Returns(true)
+            .Returns(false)
             .SetName("== operator UTC vs. floating");
     }
+
+    [Test]
+    public void EqualityShouldBeTransitive()
+    {
+        var seq1 =
+            new CalDateTime[]
+            {
+                new("20241204T000000", tzId: "Europe/Vienna"),
+                new("20241204T000000", tzId: null),
+                new("20241204T000000", tzId: "America/New_York")
+            }.Distinct();
+
+        var seq2 =
+            new CalDateTime[]
+            {
+                new("20241204T000000", tzId: "America/New_York"),
+                new("20241204T000000", tzId: "Europe/Vienna"),
+                new("20241204T000000", tzId: null)
+            }.Distinct();
+
+        // Equality using GetHashCode()
+        Assert.That(seq1.Count(), Is.EqualTo(seq2.Count()));
+    }
+
 
     [Test, TestCaseSource(nameof(DateOnlyArithmeticTestCases))]
     public (DateTime Value, bool HasTime) DateOnlyArithmeticTests(Func<IDateTime, IDateTime> operation)

--- a/Ical.Net.Tests/CalDateTimeTests.cs
+++ b/Ical.Net.Tests/CalDateTimeTests.cs
@@ -183,21 +183,9 @@ public class CalDateTimeTests
             .Returns(dateTime.Add(TimeSpan.FromMilliseconds(0)))
             .SetName($"{nameof(IDateTime.Add)} 100 milliseconds round down");
 
-        yield return new TestCaseData(new Func<IDateTime, IDateTime>(dt => dt.AddMilliseconds(500)))
-            .Returns(dateTime.AddMilliseconds(1000))
-            .SetName($"{nameof(IDateTime.AddMilliseconds)} 500 milliseconds round up");
-
         yield return new TestCaseData(new Func<IDateTime, IDateTime>(dt => dt.AddMinutes(70)))
             .Returns(dateTime.AddMinutes(70))
             .SetName($"{nameof(IDateTime.AddMinutes)} 70 minutes");
-
-        yield return new TestCaseData(new Func<IDateTime, IDateTime>(dt => dt.AddTicks(100)))
-            .Returns(dateTime.AddTicks(0))
-            .SetName($"{nameof(IDateTime.AddTicks)} 100 ticks truncated");
-
-        yield return new TestCaseData(new Func<IDateTime, IDateTime>(dt => dt.AddTicks(TimeSpan.FromHours(1).Ticks)))
-            .Returns(dateTime.AddTicks(TimeSpan.FromHours(1).Ticks))
-            .SetName($"{nameof(IDateTime.AddTicks)} ticks of 1 hour");
     }
 
     [Test, TestCaseSource(nameof(EqualityTestCases))]
@@ -275,22 +263,6 @@ public class CalDateTimeTests
         yield return new TestCaseData(new Func<IDateTime, IDateTime>(dt => dt.Add(TimeSpan.FromSeconds(30))))
             .Returns((dateTime.Add(TimeSpan.FromSeconds(30)), true))
             .SetName($"{nameof(IDateTime.Add)} 30 seconds TimeSpan HasTime=true");
-
-        yield return new TestCaseData(new Func<IDateTime, IDateTime>(dt => dt.AddMilliseconds(TimeSpan.FromDays(2).Milliseconds)))
-            .Returns((dateTime.AddMilliseconds(TimeSpan.FromDays(2).Milliseconds), false))
-            .SetName($"{nameof(IDateTime.AddMilliseconds)} 2 days in milliseconds");
-
-        yield return new TestCaseData(new Func<IDateTime, IDateTime>(dt => dt.AddMilliseconds(TimeSpan.FromHours(2).TotalMilliseconds)))
-            .Returns((dateTime.AddMilliseconds(TimeSpan.FromHours(2).TotalMilliseconds), true))
-            .SetName($"{nameof(IDateTime.AddMilliseconds)} 2 hours in milliseconds");
-
-        yield return new TestCaseData(new Func<IDateTime, IDateTime>(dt => dt.AddTicks(TimeSpan.FromDays(2).Ticks)))
-            .Returns((dateTime.AddTicks(TimeSpan.FromDays(2).Ticks), false))
-            .SetName($"{nameof(IDateTime.AddTicks)} ticks of 2 days");
-
-        yield return new TestCaseData(new Func<IDateTime, IDateTime>(dt => dt.AddTicks(TimeSpan.FromHours(2).Ticks)))
-            .Returns((dateTime.AddTicks(TimeSpan.FromHours(2).Ticks), true))
-            .SetName($"{nameof(IDateTime.AddTicks)} ticks of 2 hours");
     }
 
     [Test]

--- a/Ical.Net.Tests/CalDateTimeTests.cs
+++ b/Ical.Net.Tests/CalDateTimeTests.cs
@@ -73,8 +73,8 @@ public class CalDateTimeTests
             .SetName($"IANA to BCL: {ianaNy} to {bclCst}");
     }
 
-    [Test(Description = "Calling AsUtc should always return the proper UTC time, even if the TzId has changed")]
-    public void TestTzidChanges()
+    [Test(Description = "A certain date/time value applied to different timezones should return the same UTC date/time")]
+    public void SameDateTimeWithDifferentTzIdShouldReturnSameUtc()
     {
         var someTime = DateTimeOffset.Parse("2018-05-21T11:35:00-04:00");
 
@@ -87,7 +87,7 @@ public class CalDateTimeTests
         Assert.That(berlinUtc, Is.Not.EqualTo(firstUtc));
     }
 
-    [Test, TestCaseSource(nameof(DateTimeKindOverrideTestCases))]
+    [Test, TestCaseSource(nameof(DateTimeKindOverrideTestCases)), Description("DateTimeKind of values is always DateTimeKind.Unspecified")]
     public DateTimeKind DateTimeKindOverrideTests(DateTime dateTime, string tzId)
         => new CalDateTime(dateTime, tzId).Value.Kind;
 
@@ -120,9 +120,9 @@ public class CalDateTimeTests
             .Returns(DateTimeKind.Unspecified)
             .SetName("DateTime with Kind = Local with null tzid returns DateTimeKind.Unspecified");
 
-        yield return new TestCaseData(DateTime.SpecifyKind(localDt, DateTimeKind.Unspecified), null)
+        yield return new TestCaseData(DateTime.SpecifyKind(localDt, DateTimeKind.Local), null)
             .Returns(DateTimeKind.Unspecified)
-            .SetName("DateTime with Kind = Unspecified and null tzid returns DateTimeKind.Unspecified");
+            .SetName("DateTime with Kind = Local and null tzid returns DateTimeKind.Unspecified");
     }
 
     [Test, TestCaseSource(nameof(ToStringTestCases))]

--- a/Ical.Net.Tests/CalendarEventTest.cs
+++ b/Ical.Net.Tests/CalendarEventTest.cs
@@ -478,8 +478,8 @@ END:VCALENDAR";
 
         var evt = new CalendarEvent()
         {
-            DtStart = new CalDateTime(now) { HasTime = true },
-            DtEnd = new CalDateTime(now.AddHours(1)) { HasTime = true },
+            DtStart = new CalDateTime(DateOnly.FromDateTime(now), TimeOnly.FromDateTime(now)),
+            DtEnd = new CalDateTime(DateOnly.FromDateTime(now.AddHours(1)), TimeOnly.FromDateTime(now.AddHours(1)))
         };
 
         Assert.Multiple(() =>
@@ -491,8 +491,8 @@ END:VCALENDAR";
 
         evt = new CalendarEvent()
         {
-            DtStart = new CalDateTime(now.Date) { HasTime = true },
-            DtEnd = new CalDateTime(now.Date.AddHours(1)) { HasTime = true },
+            DtStart = new CalDateTime(DateOnly.FromDateTime(now.Date), TimeOnly.FromDateTime(now.Date)),
+            DtEnd = new CalDateTime(DateOnly.FromDateTime(now.Date.AddHours(1)), TimeOnly.FromDateTime(now.Date.AddHours(1)))
         };
 
         Assert.Multiple(() =>
@@ -503,7 +503,7 @@ END:VCALENDAR";
 
         evt = new CalendarEvent()
         {
-            DtStart = new CalDateTime(now.Date) { HasTime = false },
+            DtStart = new CalDateTime(DateOnly.FromDateTime(now)),
         };
 
         Assert.Multiple(() =>
@@ -514,7 +514,7 @@ END:VCALENDAR";
 
         evt = new CalendarEvent()
         {
-            DtStart = new CalDateTime(now) { HasTime = true },
+            DtStart = new CalDateTime(DateOnly.FromDateTime(now), TimeOnly.FromDateTime(now)),
             Duration = TimeSpan.FromHours(2),
         };
 
@@ -526,7 +526,7 @@ END:VCALENDAR";
 
         evt = new CalendarEvent()
         {
-            DtStart = new CalDateTime(now.Date) { HasTime = true },
+            DtStart = new CalDateTime(DateOnly.FromDateTime(now.Date), TimeOnly.FromDateTime(now.Date)),
             Duration = TimeSpan.FromHours(2),
         };
 
@@ -537,7 +537,7 @@ END:VCALENDAR";
 
         evt = new CalendarEvent()
         {
-            DtStart = new CalDateTime(now.Date) { HasTime = false },
+            DtStart = new CalDateTime(DateOnly.FromDateTime(now)),
             Duration = TimeSpan.FromDays(1),
         };
 

--- a/Ical.Net.Tests/ComponentTest.cs
+++ b/Ical.Net.Tests/ComponentTest.cs
@@ -22,29 +22,4 @@ public class ComponentTest
         Assert.That(evt.Created, Is.Null); // We don't want this to be set automatically
         Assert.That(evt.DtStamp, Is.Not.Null);
     }
-
-    [Test, Category("Components")]
-    public void ChangeCalDateTimeValue()
-    {
-        var e = new CalendarEvent
-        {
-            Start = new CalDateTime(2017, 11, 22, 11, 00, 01),
-            End = new CalDateTime(2017, 11, 22, 11, 30, 01),
-        };
-
-        var firstStartAsUtc = e.Start.AsUtc;
-        var firstEndAsUtc = e.End.AsUtc;
-
-        e.Start.Value = new DateTime(2017, 11, 22, 11, 30, 01);
-        e.End.Value = new DateTime(2017, 11, 22, 12, 00, 01);
-
-        var secondStartAsUtc = e.Start.AsUtc;
-        var secondEndAsUtc = e.End.AsUtc;
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(secondStartAsUtc, Is.Not.EqualTo(firstStartAsUtc));
-            Assert.That(secondEndAsUtc, Is.Not.EqualTo(firstEndAsUtc));
-        });
-    }
 }

--- a/Ical.Net.Tests/DeserializationTests.cs
+++ b/Ical.Net.Tests/DeserializationTests.cs
@@ -325,8 +325,8 @@ END:VCALENDAR
         var evt = iCal.Events["594oeajmftl3r9qlkb476rpr3c@google.com"];
         Assert.That(evt, Is.Not.Null);
 
-        IDateTime dtStart = new CalDateTime(2006, 12, 18, tzId);
-        IDateTime dtEnd = new CalDateTime(2006, 12, 23, tzId);
+        IDateTime dtStart = new CalDateTime(2006, 12, 18);
+        IDateTime dtEnd = new CalDateTime(2006, 12, 23);
         var occurrences = iCal.GetOccurrences(dtStart, dtEnd).OrderBy(o => o.Period.StartTime).ToList();
 
         var dateTimes = new[]

--- a/Ical.Net.Tests/ProgramTest.cs
+++ b/Ical.Net.Tests/ProgramTest.cs
@@ -52,8 +52,8 @@ public class ProgramTest
 
         // Get occurrences for the first event
         var occurrences = evt1.GetOccurrences(
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(2000, 1, 1, _tzid)).OrderBy(o => o.Period.StartTime).ToList();
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(2000, 1, 1)).OrderBy(o => o.Period.StartTime).ToList();
 
         var dateTimes = new[]
         {
@@ -104,8 +104,8 @@ public class ProgramTest
 
         // Get occurrences for the 2nd event
         occurrences = evt2.GetOccurrences(
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(1998, 4, 1, _tzid)).OrderBy(o => o.Period.StartTime).ToList();
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(1998, 4, 1)).OrderBy(o => o.Period.StartTime).ToList();
 
         var dateTimes1 = new[]
         {

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -3786,5 +3786,28 @@ END:VCALENDAR
         }
         return dt.Value;
     }
-}
 
+    [Test]
+    public void GetOccurrenceShouldExcludeDtEnd()
+    {
+        var ical = """
+                   BEGIN:VCALENDAR
+                   VERSION:2.0
+                   PRODID:-//github.com/ical-org/ical.net//NONSGML ical.net 5.0//EN
+                   BEGIN:VEVENT
+                   UID:123456
+                   DTSTAMP:20240630T000000Z
+                   DTSTART;VALUE=DATE:20241001
+                   DTEND;VALUE=DATE:20241202
+                   SUMMARY:Don't include the end date of this event
+                   END:VEVENT
+                   END:VCALENDAR
+                   """;
+
+        var calendar = Calendar.Load(ical);
+        // Set start date for occurrences to search to the end date of the event
+        var occurrences = calendar.GetOccurrences(new CalDateTime(2024, 12, 2));
+
+        Assert.That(occurrences, Is.Empty);
+    }
+}

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -2691,9 +2691,8 @@ public class RecurrenceTests
     {
         var vEvent = new CalendarEvent
         {
-            Start = new CalDateTime(DateTime.Parse("2020-01-11T00:00")),
+            Start = new CalDateTime(DateTime.Parse("2020-01-11")), // no time means all day
             End = new CalDateTime(DateTime.Parse("2020-01-11T00:00")),
-            IsAllDay = true,
         };
 
         var occurrences = vEvent.GetOccurrences(DateTime.Parse("2020-01-10T00:00"), DateTime.Parse("2020-01-11T00:00"));

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -3788,7 +3788,7 @@ END:VCALENDAR
     }
 
     [Test]
-    public void GetOccurrenceShouldExcludeDtEnd()
+    public void GetOccurrenceShouldExcludeDtEndFloating()
     {
         var ical = """
                    BEGIN:VCALENDAR
@@ -3807,6 +3807,30 @@ END:VCALENDAR
         var calendar = Calendar.Load(ical);
         // Set start date for occurrences to search to the end date of the event
         var occurrences = calendar.GetOccurrences(new CalDateTime(2024, 12, 2));
+
+        Assert.That(occurrences, Is.Empty);
+    }
+
+    [Test]
+    public void GetOccurrenceShouldExcludeDtEndZoned()
+    {
+        var ical = """
+                   BEGIN:VCALENDAR
+                   VERSION:2.0
+                   PRODID:Video Wall
+                   BEGIN:VEVENT
+                   UID:VW6
+                   DTSTAMP:20240630T000000Z
+                   DTSTART;TZID=Europe/London;VALUE=DATE:20241001
+                   DTEND;TZID=Europe/London;VALUE=DATE:20241128
+                   SUMMARY:New home speech.mp4
+                   COMMENT:New location announcement; may need update before Thanksgiving
+                   END:VEVENT
+                   END:VCALENDAR
+                   """;
+
+        var calendar = Calendar.Load(ical);
+        var occurrences = calendar.GetOccurrences(new CalDateTime("20241128")).ToList();
 
         Assert.That(occurrences, Is.Empty);
     }

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -93,8 +93,8 @@ public class RecurrenceTests
         ProgramTest.TestCal(iCal);
         var evt = iCal.Events.First();
         var occurrences = evt.GetOccurrences(
-            new CalDateTime(2006, 1, 1, _tzid),
-            new CalDateTime(2011, 1, 1, _tzid)).OrderBy(o => o.Period.StartTime).ToList();
+            new CalDateTime(2006, 1, 1),
+            new CalDateTime(2011, 1, 1)).OrderBy(o => o.Period.StartTime).ToList();
 
         IDateTime dt = new CalDateTime(2007, 1, 1, 8, 30, 0, _tzid);
         var i = 0;
@@ -128,8 +128,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.DailyCount1);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(2006, 7, 1, _tzid),
-            new CalDateTime(2006, 9, 1, _tzid),
+            new CalDateTime(2006, 7, 1),
+            new CalDateTime(2006, 9, 1),
             new[]
             {
                 new CalDateTime(2006, 07, 18, 10, 00, 00, _tzid),
@@ -158,8 +158,8 @@ public class RecurrenceTests
         var evt = iCal.Events.First();
 
         var occurrences = evt.GetOccurrences(
-            new CalDateTime(1997, 9, 1, _tzid),
-            new CalDateTime(1998, 1, 1, _tzid)).OrderBy(o => o.Period.StartTime).ToList();
+            new CalDateTime(1997, 9, 1),
+            new CalDateTime(1998, 1, 1)).OrderBy(o => o.Period.StartTime).ToList();
 
         IDateTime dt = new CalDateTime(1997, 9, 2, 9, 0, 0, _tzid);
         var i = 0;
@@ -172,8 +172,8 @@ public class RecurrenceTests
                 {
                     Assert.That(occurrences[i].Period.StartTime, Is.EqualTo(dt), "Event should occur at " + dt);
                     Assert.That(
-                        (dt.LessThan(new CalDateTime(1997, 10, 26, _tzid)) && dt.TimeZoneName == "US-Eastern") ||
-                        (dt.GreaterThan(new CalDateTime(1997, 10, 26, _tzid)) && dt.TimeZoneName == "US-Eastern"),
+                        (dt.LessThan(new CalDateTime(1997, 10, 26)) && dt.TimeZoneName == "US-Eastern") ||
+                        (dt.GreaterThan(new CalDateTime(1997, 10, 26)) && dt.TimeZoneName == "US-Eastern"),
                         Is.True,
                         "Event " + dt + " doesn't occur in the correct time zone (including Daylight & Standard time zones)");
                 });
@@ -193,8 +193,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.Daily1);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1997, 9, 1, _tzid),
-            new CalDateTime(1997, 12, 4, _tzid),
+            new CalDateTime(1997, 9, 1),
+            new CalDateTime(1997, 12, 4),
             new[]
             {
                 new CalDateTime(1997, 9, 2, 9, 0, 0, _tzid),
@@ -307,8 +307,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.DailyCount2);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1997, 9, 1, _tzid),
-            new CalDateTime(1998, 1, 1, _tzid),
+            new CalDateTime(1997, 9, 1),
+            new CalDateTime(1998, 1, 1),
             new[]
             {
                 new CalDateTime(1997, 9, 2, 9, 0, 0, _tzid),
@@ -332,8 +332,8 @@ public class RecurrenceTests
         var evt = iCal.Events.First();
 
         var occurrences = evt.GetOccurrences(
-            new CalDateTime(1998, 1, 1, _tzid),
-            new CalDateTime(2000, 12, 31, _tzid)).OrderBy(o => o.Period.StartTime).ToList();
+            new CalDateTime(1998, 1, 1),
+            new CalDateTime(2000, 12, 31)).OrderBy(o => o.Period.StartTime).ToList();
 
         IDateTime dt = new CalDateTime(1998, 1, 1, 9, 0, 0, _tzid);
         var i = 0;
@@ -385,8 +385,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.WeeklyCount1);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1997, 9, 1, _tzid),
-            new CalDateTime(1998, 1, 1, _tzid),
+            new CalDateTime(1997, 9, 1),
+            new CalDateTime(1998, 1, 1),
             new[]
             {
                 new CalDateTime(1997, 9, 2, 9, 0, 0, _tzid),
@@ -425,8 +425,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.WeeklyUntil1);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1997, 9, 1, _tzid),
-            new CalDateTime(1999, 1, 1, _tzid),
+            new CalDateTime(1997, 9, 1),
+            new CalDateTime(1999, 1, 1),
             new[]
             {
                 new CalDateTime(1997, 9, 2, 9, 0, 0, _tzid),
@@ -479,8 +479,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.WeeklyWkst1);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1997, 9, 1, _tzid),
-            new CalDateTime(1998, 1, 31, _tzid),
+            new CalDateTime(1997, 9, 1),
+            new CalDateTime(1998, 1, 31),
             new[]
             {
                 new CalDateTime(1997, 9, 2, 9, 0, 0, _tzid),
@@ -521,8 +521,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.WeeklyUntilWkst1);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1997, 9, 1, _tzid),
-            new CalDateTime(1999, 1, 1, _tzid),
+            new CalDateTime(1997, 9, 1),
+            new CalDateTime(1999, 1, 1),
             new[]
             {
                 new CalDateTime(1997, 9, 2, 9, 0, 0, _tzid),
@@ -571,8 +571,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.WeeklyUntilWkst2);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(1999, 1, 1, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(1999, 1, 1),
             new[]
             {
                 new CalDateTime(1997, 9, 3, 9, 0, 0, _tzid),
@@ -640,8 +640,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.WeeklyUntilWkst2);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1997, 9, 9, _tzid),
-            new CalDateTime(1999, 1, 1, _tzid),
+            new CalDateTime(1997, 9, 9),
+            new CalDateTime(1999, 1, 1),
             new[]
             {
                 new CalDateTime(1997, 9, 15, 9, 0, 0, _tzid),
@@ -704,8 +704,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.WeeklyCountWkst2);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(1999, 1, 1, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(1999, 1, 1),
             new[]
             {
                 new CalDateTime(1997, 9, 2, 9, 0, 0, _tzid),
@@ -730,8 +730,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.MonthlyCountByDay1);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(1999, 1, 1, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(1999, 1, 1),
             new[]
             {
                 new CalDateTime(1997, 9, 5, 9, 0, 0, _tzid),
@@ -770,8 +770,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.MonthlyUntilByDay1);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(1999, 1, 1, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(1999, 1, 1),
             new[]
             {
                 new CalDateTime(1997, 9, 5, 9, 0, 0, _tzid),
@@ -798,8 +798,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.MonthlyCountByDay2);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(1999, 1, 1, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(1999, 1, 1),
             new[]
             {
                 new CalDateTime(1997, 9, 7, 9, 0, 0, _tzid),
@@ -838,8 +838,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.MonthlyCountByDay3);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(1999, 1, 1, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(1999, 1, 1),
             new[]
             {
                 new CalDateTime(1997, 9, 22, 9, 0, 0, _tzid),
@@ -870,8 +870,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.ByMonthDay1);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(1998, 3, 1, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(1998, 3, 1),
             new[]
             {
                 new CalDateTime(1997, 9, 28, 9, 0, 0, _tzid),
@@ -903,8 +903,8 @@ public class RecurrenceTests
 
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(1998, 3, 1, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(1998, 3, 1),
             new[]
             {
                 new CalDateTime(1997, 9, 2, 9, 0, 0, _tzid),
@@ -943,8 +943,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.MonthlyCountByMonthDay2);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(1998, 3, 1, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(1998, 3, 1),
             new[]
             {
                 new CalDateTime(1997, 9, 30, 9, 0, 0, _tzid),
@@ -983,8 +983,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.MonthlyCountByMonthDay3);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(2000, 1, 1, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(2000, 1, 1),
             new[]
             {
                 new CalDateTime(1997, 9, 10, 9, 0, 0, _tzid),
@@ -1023,8 +1023,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.MonthlyByDay1);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(1998, 4, 1, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(1998, 4, 1),
             new[]
             {
                 new CalDateTime(1997, 9, 2, 9, 0, 0, _tzid),
@@ -1079,8 +1079,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.YearlyByMonth1);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(2002, 1, 1, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(2002, 1, 1),
             new[]
             {
                 new CalDateTime(1997, 6, 10, 9, 0, 0, _tzid),
@@ -1107,8 +1107,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.YearlyCountByMonth1);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(2003, 4, 1, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(2003, 4, 1),
             new[]
             {
                 new CalDateTime(1997, 3, 10, 9, 0, 0, _tzid),
@@ -1135,8 +1135,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.YearlyCountByYearDay1);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(2007, 1, 1, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(2007, 1, 1),
             new[]
             {
                 new CalDateTime(1997, 1, 1, 9, 0, 0, _tzid),
@@ -1175,8 +1175,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.YearlyByDay1);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(1999, 12, 31, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(1999, 12, 31),
             new[]
             {
                 new CalDateTime(1997, 5, 19, 9, 0, 0, _tzid),
@@ -1213,8 +1213,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.YearlyByWeekNo1);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(1999, 12, 31, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(1999, 12, 31),
             new[]
             {
                 new CalDateTime(1997, 5, 12, 9, 0, 0, _tzid),
@@ -1239,8 +1239,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.YearlyByWeekNo2);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(1999, 12, 31, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(1999, 12, 31),
             new[]
             {
                 new CalDateTime(1997, 5, 12, 9, 0, 0, _tzid),
@@ -1264,8 +1264,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.YearlyByWeekNo3);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(2001, 1, 1, _tzid),
-            new CalDateTime(2003, 1, 31, _tzid),
+            new CalDateTime(2001, 1, 1),
+            new CalDateTime(2003, 1, 31),
             new[]
             {
                 new CalDateTime(2002, 1, 1, 10, 0, 0, _tzid),
@@ -1287,8 +1287,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.YearlyByWeekNo4);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(1999, 12, 31, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(1999, 12, 31),
             new[]
             {
                 new CalDateTime(1997, 5, 12, 9, 0, 0, _tzid),
@@ -1331,8 +1331,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.YearlyByWeekNo5);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(2001, 1, 1, _tzid),
-            new CalDateTime(2003, 1, 31, _tzid),
+            new CalDateTime(2001, 1, 1),
+            new CalDateTime(2003, 1, 31),
             new[]
             {
                 new CalDateTime(2002, 1, 1, 10, 0, 0, _tzid),
@@ -1362,8 +1362,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.YearlyByMonth2);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(1999, 12, 31, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(1999, 12, 31),
             new[]
             {
                 new CalDateTime(1997, 3, 13, 9, 0, 0, _tzid),
@@ -1391,8 +1391,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.YearlyByMonth3);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(1999, 12, 31, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(1999, 12, 31),
             new[]
             {
                 new CalDateTime(1997, 6, 5, 9, 0, 0, _tzid),
@@ -1450,8 +1450,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.MonthlyByMonthDay1);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(2000, 12, 31, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(2000, 12, 31),
             new[]
             {
                 new CalDateTime(1998, 2, 13, 9, 0, 0, _tzid),
@@ -1480,8 +1480,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.MonthlyByMonthDay2);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(1998, 6, 30, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(1998, 6, 30),
             new[]
             {
                 new CalDateTime(1997, 9, 13, 9, 0, 0, _tzid),
@@ -1520,8 +1520,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.YearlyByMonthDay1);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(2004, 12, 31, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(2004, 12, 31),
             new[]
             {
                 new CalDateTime(1996, 11, 5, 9, 0, 0, _tzid),
@@ -1541,8 +1541,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.MonthlyBySetPos1);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(2004, 12, 31, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(2004, 12, 31),
             new[]
             {
                 new CalDateTime(1997, 9, 4, 9, 0, 0, _tzid),
@@ -1567,8 +1567,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.MonthlyBySetPos2);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(1998, 3, 31, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(1998, 3, 31),
             new[]
             {
                 new CalDateTime(1997, 9, 29, 9, 0, 0, _tzid),
@@ -1603,8 +1603,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.HourlyUntil1);
         EventOccurrenceTest(
             iCal,
-            fromDate: new CalDateTime(1996, 1, 1, _tzid),
-            toDate: new CalDateTime(1998, 3, 31, _tzid),
+            fromDate: new CalDateTime(1996, 1, 1),
+            toDate: new CalDateTime(1998, 3, 31),
             dateTimes: new[]
             {
                 new CalDateTime(1997, 9, 2, 9, 0, 0, _tzid),
@@ -1625,8 +1625,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.MinutelyCount1);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1997, 9, 2, _tzid),
-            new CalDateTime(1997, 9, 3, _tzid),
+            new CalDateTime(1997, 9, 2),
+            new CalDateTime(1997, 9, 3),
             new[]
             {
                 new CalDateTime(1997, 9, 2, 9, 0, 0, _tzid),
@@ -1649,8 +1649,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.MinutelyCount2);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(1998, 12, 31, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(1998, 12, 31),
             new[]
             {
                 new CalDateTime(1997, 9, 2, 9, 0, 0, _tzid),
@@ -1671,8 +1671,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.MinutelyCount3);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(2010, 8, 27, _tzid),
-            new CalDateTime(2010, 8, 28, _tzid),
+            new CalDateTime(2010, 8, 27),
+            new CalDateTime(2010, 8, 28),
             new[]
             {
                 new CalDateTime(2010, 8, 27, 11, 0, 0, _tzid),
@@ -1699,8 +1699,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.MinutelyCount4);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(2010, 8, 27, _tzid),
-            new CalDateTime(2010, 8, 28, _tzid),
+            new CalDateTime(2010, 8, 27),
+            new CalDateTime(2010, 8, 28),
             new[]
             {
                 new CalDateTime(2010, 8, 27, 11, 0, 0, _tzid),
@@ -1727,8 +1727,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.DailyByHourMinute1);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1997, 9, 2, _tzid),
-            new CalDateTime(1997, 9, 4, _tzid),
+            new CalDateTime(1997, 9, 2),
+            new CalDateTime(1997, 9, 4),
             new[]
             {
                 new CalDateTime(1997, 9, 2, 9, 0, 0, _tzid),
@@ -1797,8 +1797,8 @@ public class RecurrenceTests
         var evt1 = iCal1.Events.First();
         var evt2 = iCal2.Events.First();
 
-        var evt1Occ = evt1.GetOccurrences(new CalDateTime(1997, 9, 1, _tzid), new CalDateTime(1997, 9, 3, _tzid)).OrderBy(o => o.Period.StartTime).ToList();
-        var evt2Occ = evt2.GetOccurrences(new CalDateTime(1997, 9, 1, _tzid), new CalDateTime(1997, 9, 3, _tzid)).OrderBy(o => o.Period.StartTime).ToList();
+        var evt1Occ = evt1.GetOccurrences(new CalDateTime(1997, 9, 1), new CalDateTime(1997, 9, 3)).OrderBy(o => o.Period.StartTime).ToList();
+        var evt2Occ = evt2.GetOccurrences(new CalDateTime(1997, 9, 1), new CalDateTime(1997, 9, 3)).OrderBy(o => o.Period.StartTime).ToList();
         Assert.That(evt1Occ.Count == evt2Occ.Count, Is.True, "MinutelyByHour1() does not match DailyByHourMinute1() as it should");
         for (var i = 0; i < evt1Occ.Count; i++)
             Assert.That(evt2Occ[i].Period, Is.EqualTo(evt1Occ[i].Period), "PERIOD " + i + " from DailyByHourMinute1 (" + evt1Occ[i].Period + ") does not match PERIOD " + i + " from MinutelyByHour1 (" + evt2Occ[i].Period + ")");
@@ -1813,8 +1813,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.WeeklyCountWkst3);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(1998, 12, 31, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(1998, 12, 31),
             new[]
             {
                 new CalDateTime(1997, 8, 5, 9, 0, 0, _tzid),
@@ -1836,8 +1836,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.WeeklyCountWkst4);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(1996, 1, 1, _tzid),
-            new CalDateTime(1998, 12, 31, _tzid),
+            new CalDateTime(1996, 1, 1),
+            new CalDateTime(1998, 12, 31),
             new[]
             {
                 new CalDateTime(1997, 8, 5, 9, 0, 0, _tzid),
@@ -1859,8 +1859,8 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.Bug1741093);
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(2007, 7, 1, _tzid),
-            new CalDateTime(2007, 8, 1, _tzid),
+            new CalDateTime(2007, 7, 1),
+            new CalDateTime(2007, 8, 1),
             new[]
             {
                 new CalDateTime(2007, 7, 2, 8, 0, 0, _tzid),
@@ -2327,8 +2327,8 @@ public class RecurrenceTests
         // Weekly with UNTIL value
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(2009, 12, 4, localTzid),
-            new CalDateTime(2009, 12, 10, localTzid),
+            new CalDateTime(2009, 12, 4),
+            new CalDateTime(2009, 12, 10),
             new[]
             {
                 new CalDateTime(2009, 12, 4, 2, 00, 00, localTzid)
@@ -2340,8 +2340,8 @@ public class RecurrenceTests
         // Weekly with COUNT=2
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(2009, 12, 4, localTzid),
-            new CalDateTime(2009, 12, 12, localTzid),
+            new CalDateTime(2009, 12, 4),
+            new CalDateTime(2009, 12, 12),
             new[]
             {
                 new CalDateTime(2009, 12, 4, 2, 00, 00, localTzid),
@@ -2476,7 +2476,7 @@ public class RecurrenceTests
     {
         var iCal = Calendar.Load(IcsFiles.Bug3007244);
 
-        // CalDateTimes.HasTime = false
+        // date only cannot have a time zone
         EventOccurrenceTest(
             cal: iCal,
             fromDate: new CalDateTime(2010, 7, 18),
@@ -2486,7 +2486,7 @@ public class RecurrenceTests
             eventIndex: 0
         );
 
-        // CalDateTimes.HasTime = false
+        // date only cannot have a time zone
         EventOccurrenceTest(
             cal: iCal,
             fromDate: new CalDateTime(2011, 7, 18),
@@ -3003,8 +3003,8 @@ END:VEVENT
 END:VCALENDAR";
         var calendar = Calendar.Load(ical);
         var firstEvent = calendar.Events.First();
-        var startSearch = new CalDateTime(2010, 1, 1, _tzid);
-        var endSearch = new CalDateTime(2016, 12, 31, _tzid);
+        var startSearch = new CalDateTime(2010, 1, 1);
+        var endSearch = new CalDateTime(2016, 12, 31);
 
         var occurrences = firstEvent.GetOccurrences(startSearch, endSearch).Select(o => o.Period).ToList();
         Assert.That(occurrences.Count == 0, Is.True);
@@ -3675,15 +3675,15 @@ END:VCALENDAR
                     break;
 
                 case "DTSTART":
-                    current.DtStart = new CalDateTime(val) { TzId = "UTC" };
+                    current.DtStart = new CalDateTime(val, "UTC");
                     break;
 
                 case "START-AT":
-                    current.StartAt = new CalDateTime(val) { TzId = "UTC" };
+                    current.StartAt = new CalDateTime(val, "UTC");
                     break;
 
                 case "INSTANCES":
-                    current.Instances = val.Split(',').Select(dt => new CalDateTime(dt) { TzId = "UTC" }).ToList();
+                    current.Instances = val.Split(',').Select(dt => new CalDateTime(dt, "UTC")).ToList();
                     break;
 
                 case "EXCEPTION":

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -3810,28 +3810,4 @@ END:VCALENDAR
 
         Assert.That(occurrences, Is.Empty);
     }
-
-    [Test]
-    public void GetOccurrenceShouldExcludeDtEndZoned()
-    {
-        var ical = """
-                   BEGIN:VCALENDAR
-                   VERSION:2.0
-                   PRODID:Video Wall
-                   BEGIN:VEVENT
-                   UID:VW6
-                   DTSTAMP:20240630T000000Z
-                   DTSTART;TZID=Europe/London;VALUE=DATE:20241001
-                   DTEND;TZID=Europe/London;VALUE=DATE:20241128
-                   SUMMARY:New home speech.mp4
-                   COMMENT:New location announcement; may need update before Thanksgiving
-                   END:VEVENT
-                   END:VCALENDAR
-                   """;
-
-        var calendar = Calendar.Load(ical);
-        var occurrences = calendar.GetOccurrences(new CalDateTime("20241128")).ToList();
-
-        Assert.That(occurrences, Is.Empty);
-    }
 }

--- a/Ical.Net.Tests/SerializationTests.cs
+++ b/Ical.Net.Tests/SerializationTests.cs
@@ -176,8 +176,8 @@ public class SerializationTests
         var evt = new CalendarEvent
         {
             Summary = "Testing",
-            Start = new CalDateTime(2016, 7, 14, tz.TzId),
-            End = new CalDateTime(2016, 7, 15, tz.TzId)
+            Start = new CalDateTime(2016, 7, 14),
+            End = new CalDateTime(2016, 7, 15)
         };
         cal.Events.Add(evt);
 

--- a/Ical.Net.Tests/SimpleDeserializationTests.cs
+++ b/Ical.Net.Tests/SimpleDeserializationTests.cs
@@ -327,8 +327,8 @@ END:VCALENDAR
         var evt = iCal.Events["594oeajmftl3r9qlkb476rpr3c@google.com"];
         Assert.That(evt, Is.Not.Null);
 
-        IDateTime dtStart = new CalDateTime(2006, 12, 18, tzId);
-        IDateTime dtEnd = new CalDateTime(2006, 12, 23, tzId);
+        IDateTime dtStart = new CalDateTime(2006, 12, 18);
+        IDateTime dtEnd = new CalDateTime(2006, 12, 23);
         var occurrences = iCal.GetOccurrences(dtStart, dtEnd).OrderBy(o => o.Period.StartTime).ToList();
 
         var dateTimes = new[]

--- a/Ical.Net.Tests/TodoTest.cs
+++ b/Ical.Net.Tests/TodoTest.cs
@@ -25,8 +25,7 @@ public class TodoTest
 
         foreach (var calDateTime in incoming)
         {
-            var dt = calDateTime.Key;
-            dt.TzId = _tzid;
+            var dt = new CalDateTime(calDateTime.Key.Date, calDateTime.Key.Time, _tzid);
             Assert.That(todo[0].IsActive(dt), Is.EqualTo(calDateTime.Value));
         }
     }
@@ -175,8 +174,7 @@ public class TodoTest
 
         foreach (var calDateTime in incoming)
         {
-            var dt = calDateTime.Key;
-            dt.TzId = _tzid;
+            var dt = new CalDateTime(calDateTime.Key.Date, calDateTime.Key.Time, _tzid);
             Assert.That(todo[0].IsCompleted(dt), Is.EqualTo(calDateTime.Value));
         }
     }

--- a/Ical.Net/Calendar.cs
+++ b/Ical.Net/Calendar.cs
@@ -205,11 +205,17 @@ public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, I
     /// <param name="dt">The date for which to return occurrences. Time is ignored on this parameter.</param>
     /// <returns>A list of occurrences that occur on the given date (<paramref name="dt"/>).</returns>
     public virtual HashSet<Occurrence> GetOccurrences(IDateTime dt)
-        => GetOccurrences<IRecurringComponent>(new CalDateTime(dt.Date), new CalDateTime(dt.Date.AddDays(1).AddSeconds(-1)));
+    {
+        var endTimeOnly = dt.Time?.Add(TimeSpan.FromSeconds(-1));
+        return GetOccurrences<IRecurringComponent>(new CalDateTime(dt.Date, dt.Time), new CalDateTime(dt.Date.AddDays(1), endTimeOnly));
+    }
 
     /// <inheritdoc cref="GetOccurrences(IDateTime)"/>
     public virtual HashSet<Occurrence> GetOccurrences(DateTime dt)
-        => GetOccurrences<IRecurringComponent>(new CalDateTime(dt.Date), new CalDateTime(dt.Date.AddDays(1).AddSeconds(-1)));
+    {
+        var endDateTime = dt.Date.AddDays(1).AddSeconds(-1);
+        return GetOccurrences<IRecurringComponent>(new CalDateTime(DateOnly.FromDateTime(dt), TimeOnly.FromDateTime(dt)), new CalDateTime(DateOnly.FromDateTime(endDateTime), TimeOnly.FromDateTime(endDateTime)));
+    }
 
     /// <summary>
     /// Returns a list of occurrences of each recurring component
@@ -223,7 +229,7 @@ public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, I
 
     /// <inheritdoc cref="GetOccurrences(IDateTime, IDateTime)"/>
     public virtual HashSet<Occurrence> GetOccurrences(DateTime startTime, DateTime endTime)
-        => GetOccurrences<IRecurringComponent>(new CalDateTime(startTime), new CalDateTime(endTime));
+        => GetOccurrences<IRecurringComponent>(new CalDateTime(DateOnly.FromDateTime(startTime), TimeOnly.FromDateTime(startTime)), new CalDateTime(DateOnly.FromDateTime(endTime), TimeOnly.FromDateTime(endTime)));
 
     /// <summary>
     /// Returns all occurrences of components of type T that start on the date provided.
@@ -238,11 +244,17 @@ public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, I
     /// <param name="dt">The date for which to return occurrences. Time is ignored on this parameter.</param>
     /// <returns>A list of Periods representing the occurrences of this object.</returns>
     public virtual HashSet<Occurrence> GetOccurrences<T>(IDateTime dt) where T : IRecurringComponent
-        => GetOccurrences<T>(new CalDateTime(dt.Date), new CalDateTime(dt.Date.AddDays(1).AddTicks(-1)));
+    {
+        var endTimeOnly = dt.Time?.Add(TimeSpan.FromTicks(-1));
+        return GetOccurrences<T>(new CalDateTime(dt.Date, dt.Time), new CalDateTime(dt.Date.AddDays(1), endTimeOnly));
+    }
 
     /// <inheritdoc cref="GetOccurrences(IDateTime)"/>
     public virtual HashSet<Occurrence> GetOccurrences<T>(DateTime dt) where T : IRecurringComponent
-        => GetOccurrences<T>(new CalDateTime(dt.Date), new CalDateTime(dt.Date.AddDays(1).AddTicks(-1)));
+    {
+        var endDateTime = dt.Date.AddDays(1).AddTicks(-1);
+        return GetOccurrences<T>(new CalDateTime(DateOnly.FromDateTime(dt), TimeOnly.FromDateTime(dt)), new CalDateTime(DateOnly.FromDateTime(endDateTime), TimeOnly.FromDateTime(endDateTime)));
+    }
 
     /// <inheritdoc cref="GetOccurrences(IDateTime, IDateTime)"/>
     public virtual HashSet<Occurrence> GetOccurrences<T>(DateTime startTime, DateTime endTime) where T : IRecurringComponent

--- a/Ical.Net/Calendar.cs
+++ b/Ical.Net/Calendar.cs
@@ -206,15 +206,13 @@ public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, I
     /// <returns>A list of occurrences that occur on the given date (<paramref name="dt"/>).</returns>
     public virtual HashSet<Occurrence> GetOccurrences(IDateTime dt)
     {
-        var endTimeOnly = dt.Time?.Add(TimeSpan.FromSeconds(-1));
-        return GetOccurrences<IRecurringComponent>(new CalDateTime(dt.Date, dt.Time), new CalDateTime(dt.Date.AddDays(1), endTimeOnly));
+        return GetOccurrences<IRecurringComponent>(new CalDateTime(dt.Date), new CalDateTime(dt.Date.AddDays(1)));
     }
 
     /// <inheritdoc cref="GetOccurrences(IDateTime)"/>
     public virtual HashSet<Occurrence> GetOccurrences(DateTime dt)
     {
-        var endDateTime = dt.Date.AddDays(1).AddSeconds(-1);
-        return GetOccurrences<IRecurringComponent>(new CalDateTime(DateOnly.FromDateTime(dt), TimeOnly.FromDateTime(dt)), new CalDateTime(DateOnly.FromDateTime(endDateTime), TimeOnly.FromDateTime(endDateTime)));
+        return GetOccurrences<IRecurringComponent>(new CalDateTime(DateOnly.FromDateTime(dt)), new CalDateTime(DateOnly.FromDateTime(dt.Date.AddDays(1))));
     }
 
     /// <summary>
@@ -245,15 +243,13 @@ public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, I
     /// <returns>A list of Periods representing the occurrences of this object.</returns>
     public virtual HashSet<Occurrence> GetOccurrences<T>(IDateTime dt) where T : IRecurringComponent
     {
-        var endTimeOnly = dt.Time?.Add(TimeSpan.FromTicks(-1));
-        return GetOccurrences<T>(new CalDateTime(dt.Date, dt.Time), new CalDateTime(dt.Date.AddDays(1), endTimeOnly));
+        return GetOccurrences<T>(new CalDateTime(dt.Date), new CalDateTime(dt.Date.AddDays(1)));
     }
 
     /// <inheritdoc cref="GetOccurrences(IDateTime)"/>
     public virtual HashSet<Occurrence> GetOccurrences<T>(DateTime dt) where T : IRecurringComponent
     {
-        var endDateTime = dt.Date.AddDays(1).AddTicks(-1);
-        return GetOccurrences<T>(new CalDateTime(DateOnly.FromDateTime(dt), TimeOnly.FromDateTime(dt)), new CalDateTime(DateOnly.FromDateTime(endDateTime), TimeOnly.FromDateTime(endDateTime)));
+        return GetOccurrences<T>(new CalDateTime(DateOnly.FromDateTime(dt)), new CalDateTime(DateOnly.FromDateTime(dt.Date.AddDays(1))));
     }
 
     /// <inheritdoc cref="GetOccurrences(IDateTime, IDateTime)"/>

--- a/Ical.Net/CalendarComponents/CalendarEvent.cs
+++ b/Ical.Net/CalendarComponents/CalendarEvent.cs
@@ -150,29 +150,6 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
     public virtual bool IsAllDay
     {
         get => !Start.HasTime;
-        set
-        {
-            // Set whether the start date/time
-            // has a time value.
-            if (Start != null)
-            {
-                Start = value
-                    ? new CalDateTime(Start.Date)
-                    : new CalDateTime(Start.Date, Start.Time, Start.TzId);
-            }
-            if (End != null)
-            {
-                End = value
-                    ? new CalDateTime(End.Date)
-                    : new CalDateTime(End.Date, End.Time, End.TzId);
-            }
-
-            if (value && Start != null && End != null && Equals(Start.Date, End.Date))
-            {
-                Duration = default(TimeSpan);
-                End = Start.AddDays(1);
-            }
-        }
     }
 
     /// <summary>

--- a/Ical.Net/CalendarComponents/CalendarEvent.cs
+++ b/Ical.Net/CalendarComponents/CalendarEvent.cs
@@ -152,15 +152,19 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
         get => !Start.HasTime;
         set
         {
-            // Set whether or not the start date/time
+            // Set whether the start date/time
             // has a time value.
             if (Start != null)
             {
-                Start.HasTime = !value;
+                Start = value
+                    ? new CalDateTime(Start.Date)
+                    : new CalDateTime(Start.Date, Start.Time, Start.TzId);
             }
             if (End != null)
             {
-                End.HasTime = !value;
+                End = value
+                    ? new CalDateTime(End.Date)
+                    : new CalDateTime(End.Date, End.Time, End.TzId);
             }
 
             if (value && Start != null && End != null && Equals(Start.Date, End.Date))
@@ -213,7 +217,7 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
 
     /// <summary>
     /// The transparency of the event.  In other words,
-    /// whether or not the period of time this event
+    /// whether the period of time this event
     /// occupies can contain other events (transparent),
     /// or if the time cannot be scheduled for anything
     /// else (opaque).
@@ -242,7 +246,7 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
 
 
     /// <summary>
-    /// Determines whether or not the <see cref="CalendarEvent"/> is actively displayed
+    /// Determines whether the <see cref="CalendarEvent"/> is actively displayed
     /// as an upcoming or occurred event.
     /// </summary>
     /// <returns>True if the event has not been cancelled, False otherwise.</returns>

--- a/Ical.Net/DataTypes/CalDateTime.cs
+++ b/Ical.Net/DataTypes/CalDateTime.cs
@@ -18,6 +18,9 @@ namespace Ical.Net.DataTypes;
 /// <remarks>
 /// In addition to the features of the <see cref="DateTime"/> class, the <see cref="CalDateTime"/>
 /// class handles timezones, and integrates seamlessly into the iCalendar framework.
+/// <para/>
+/// Any <see cref="Time"/> values are always rounded to the nearest second.
+/// This is because RFC 5545, Section 3.3.5 does not allow for fractional seconds.
 /// </remarks>
 /// </summary>
 public sealed class CalDateTime : EncodableDataType, IDateTime
@@ -25,22 +28,28 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
     // The date part that is used to return the Value property.
     private DateOnly _dateOnly;
     // The time part that is used to return the Value property.
-    private TimeOnly _timeOnly;
-
-    private const string UtcTzId = "UTC";
+    private TimeOnly? _timeOnly;
 
     /// <summary>
-    /// Gets the current date/time in the local timezone.
+    /// The timezone ID for Universal Coordinated Time (UTC).
+    /// </summary>
+    public const string UtcTzId = "UTC";
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="CalDateTime"/> class
+    /// with the current date/time and sets the <see cref="TzId"/> to <see langword="null"/>.
     /// </summary>
     public static CalDateTime Now => new CalDateTime(DateTime.Now, null, true);
 
     /// <summary>
-    /// Gets the current date in the local timezone.
+    /// Creates a new instance of the <see cref="CalDateTime"/> class
+    /// with the current date and sets the <see cref="TzId"/> to <see langword="null"/>.
     /// </summary>
     public static CalDateTime Today => new CalDateTime(DateTime.Today, null, false);
 
     /// <summary>
-    /// Gets the current date/time in the Coordinated Universal Time (UTC) timezone.
+    /// Creates a new instance of the <see cref="CalDateTime"/> class
+    /// with the current date/time in the Coordinated Universal Time (UTC) timezone.
     /// </summary>
     public static CalDateTime UtcNow => new CalDateTime(DateTime.UtcNow, UtcTzId, true);
 
@@ -51,6 +60,8 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
 
     /// <summary>
     /// Creates a new instance of the <see cref="CalDateTime"/> class.
+    /// The instance will represent an RFC 5545, Section 3.3.5, DATE-TIME value, if <see cref="IDateTime.HasTime"/> is <see langword="true"/>.
+    /// It will represent an RFC 5545, Section 3.3.4, DATE value, if <see cref="IDateTime.HasTime"/> is <see langword="false"/>.
     /// </summary>
     /// <param name="value"></param>
     public CalDateTime(IDateTime value)
@@ -62,34 +73,39 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
     }
 
     /// <summary>
-    /// Creates a new instance of the <see cref="CalDateTime"/> class
-    /// and sets the <see cref="TzId"/> to "UTC" if the <paramref name="value"/>
-    /// has <see cref="DateTimeKind.Utc"/>, otherwise it will be left as <see langword="null"/>.
+    /// Creates a new instance of the <see cref="CalDateTime"/> class.
+    /// The instance will represent an RFC 5545, Section 3.3.5, DATE-TIME value, if <see paramref="hasTime"/> is <see langword="true"/>.
+    /// It will represent an RFC 5545, Section 3.3.4, DATE value, if <see paramref="hasTime"/> is <see langword="false"/>.
     /// <para/>
-    /// The timezone will be set to UTC if the <paramref name="value"/> has <see cref="DateTimeKind.Utc"/>.
-    /// Else, the timezone will be <see langword="null"/>.
+    /// The <see cref="TzId"/> will be set to "UTC" if the <paramref name="value"/>
+    /// has <see cref="DateTimeKind.Utc"/> and <paramref name="hasTime"/> is <see langword="true"/>.
+    /// Otherwise <see cref="TzId"/> will be <see langword="null"/>.
     /// </summary>
-    /// <param name="value"></param>
-    /// <param name="hasTime">Set to <see langword="true"/> (default), if the <see cref="DateTime.TimeOfDay"/> must be included.</param>
+    /// <param name="value">The <see cref="DateTime"/> value. Its <see cref="DateTimeKind"/> will be ignored.</param>
+    /// <param name="hasTime">
+    /// The instance will represent an RFC 5545, Section 3.3.5, DATE-TIME value, if <see paramref="hasTime"/> is <see langword="true"/>.
+    /// It will represent an RFC 5545, Section 3.3.4, DATE value, if <see paramref="hasTime"/> is <see langword="false"/>.
+    /// </param>
     public CalDateTime(DateTime value, bool hasTime = true) : this(value, value.Kind == DateTimeKind.Utc ? UtcTzId : null, hasTime)
     { }
 
     /// <summary>
-    /// Creates a new instance of the <see cref="CalDateTime"/> class using the specified timezone.
+    /// Creates a new instance of the <see cref="CalDateTime"/> class.
+    /// The instance will represent an RFC 5545, Section 3.3.5, DATE-TIME value, if <see paramref="hasTime"/> is <see langword="true"/>.
+    /// It will represent an RFC 5545, Section 3.3.4, DATE value, if <see paramref="hasTime"/> is <see langword="false"/>.
+    /// The instance will represent an RFC 5545, Section 3.3.5, DATE-TIME value, if <see paramref="hasTime"/> is <see langword="true"/>.
     /// </summary>
-    /// <param name="value"></param>
-    /// <param name="tzId">The specified value will override value's <see cref="DateTime.Kind"/> property.
-    /// If the timezone specified is UTC, the underlying <see cref="DateTime.Kind"/> will be
-    /// <see cref="DateTimeKind.Utc"/>. If a non-UTC timezone or no timezone is specified, the
-    /// <see cref="DateTimeKind.Unspecified"/> will be used. A timezone of <see langword="null"/> represents
-    /// the system's local timezone.
+    /// <param name="value">The <see cref="DateTime"/> value. Its <see cref="DateTimeKind"/> will be ignored.</param>
+    /// <param name="tzId">A timezone of <see langword="null"/> represents
+    /// a floating date/time, which is the same in all timezones. (<seealso cref="UtcTzId"/>) represents the Coordinated Universal Time.
+    /// Other values determine the timezone of the date/time.
     /// </param>
-    /// <param name="hasTime">Set to <see langword="true"/> (default), if the <see cref="DateTime.TimeOfDay"/> must be included.</param>
+    /// <param name="hasTime">
+    /// The instance will represent an RFC 5545, Section 3.3.5, DATE-TIME value, if <see paramref="hasTime"/> is <see langword="true"/>.
+    /// It will represent an RFC 5545, Section 3.3.4, DATE value, if <see paramref="hasTime"/> is <see langword="false"/>.
+    /// </param>
     public CalDateTime(DateTime value, string? tzId, bool hasTime = true)
     {
-        if (value.Kind == DateTimeKind.Utc && tzId is null or UtcTzId)
-            tzId = UtcTzId;
-
         if (hasTime)
             Initialize(DateOnly.FromDateTime(value), TimeOnly.FromDateTime(value), tzId);
         else
@@ -98,12 +114,11 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
 
     /// <summary>
     /// Creates a new instance of the <see cref="CalDateTime"/> class using the specified timezone.
+    /// The instance will represent an RFC 5545, Section 3.3.5, DATE-TIME value.
     /// </summary>
-    /// <param name="tzId">The specified value will determine the <see cref="DateTime.Kind"/> property.
-    /// If the timezone specified is UTC, the underlying <see cref="DateTime.Kind"/> will be
-    /// <see cref="DateTimeKind.Utc"/>. If a non-UTC timezone or no timezone is specified, the underlying
-    /// <see cref="DateTimeKind.Unspecified"/> will be used. A timezone of <see langword="null"/> represents
-    /// the system's local timezone.
+    /// <param name="tzId">A timezone of <see langword="null"/> represents
+    /// a floating date/time, which is the same in all timezones. (<seealso cref="UtcTzId"/>) represents the Coordinated Universal Time.
+    /// Other values determine the timezone of the date/time.
     /// </param>
     /// <param name="year"></param>
     /// <param name="month"></param>
@@ -117,31 +132,36 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
     }
 
     /// <summary>
-    /// Creates a new instance of the <see cref="CalDateTime"/> class using the specified timezone.
-    /// Sets <see cref="DateTimeKind.Unspecified"/> for the <see cref="Value"/> property.
+    /// Creates a new instance of the <see cref="CalDateTime"/> class with <see cref="TzId"/> set to <see langword="null"/>.
+    /// The instance will represent an RFC 5545, Section 3.3.4, DATE value,
+    /// and thus it cannot have a timezone.
     /// </summary>
-    /// <param name="tzId">The specified value will determine the <see cref="DateTime.Kind"/> property.
-    /// If the timezone specified is UTC, the underlying <see cref="DateTime.Kind"/> will be
-    /// <see cref="DateTimeKind.Utc"/>. If a non-UTC timezone or no timezone is specified, the underlying
-    /// <see cref="DateTimeKind.Unspecified"/> will be used. A timezone of <see langword="null"/> represents
-    /// the system's local timezone.
-    /// </param>
     /// <param name="year"></param>
     /// <param name="month"></param>
     /// <param name="day"></param>
-    public CalDateTime(int year, int month, int day, string? tzId = null)
+    public CalDateTime(int year, int month, int day)
     {
-        Initialize(new DateOnly(year, month, day), null, tzId);
+        Initialize(new DateOnly(year, month, day), null, null);
+    }
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="CalDateTime"/> class with <see cref="TzId"/> set to <see langword="null"/>.
+    /// The instance will represent an RFC 5545, Section 3.3.4, DATE value,
+    /// and thus it cannot have a timezone.
+    /// </summary>
+    /// <param name="date"></param>
+    public CalDateTime(DateOnly date)
+    {
+        Initialize(date, null, null);
     }
 
     /// <summary>
     /// Creates a new instance of the <see cref="CalDateTime"/> class using the specified timezone.
+    /// The instance will represent an RFC 5545, Section 3.3.5, DATE-TIME value.
     /// </summary>
-    /// <param name="tzId">The specified value will determine the <see cref="DateTime.Kind"/> property.
-    /// If the timezone specified is UTC, the underlying <see cref="DateTime.Kind"/> will be
-    /// <see cref="DateTimeKind.Utc"/>. If a non-UTC timezone or no timezone is specified, the underlying
-    /// <see cref="DateTimeKind.Unspecified"/> will be used. A timezone of <see langword="null"/> represents
-    /// the system's local timezone.
+    /// <param name="tzId">A timezone of <see langword="null"/> represents
+    /// a floating date/time, which is the same in all timezones. (<seealso cref="UtcTzId"/>) represents the Coordinated Universal Time.
+    /// Other values determine the timezone of the date/time.
     /// </param>
     /// <param name="date"></param>
     /// <param name="time"></param>
@@ -154,29 +174,36 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
     /// Creates a new instance of the <see cref="CalDateTime"/> class by parsing <paramref name="value"/>
     /// using the <see cref="DateTimeSerializer"/>.
     /// </summary>
-    /// <param name="value">An iCalendar-compatible date or date-time string.</param>
-    /// <param name="tzId">The specified value will determine the <see cref="DateTime.Kind"/> property.
-    /// If the timezone specified is UTC, the underlying <see cref="DateTime.Kind"/> will be
-    /// <see cref="DateTimeKind.Utc"/>. If a non-UTC timezone or no timezone is specified, the underlying
-    /// <see cref="DateTimeKind.Unspecified"/> will be used. A timezone of <see langword="null"/> represents
-    /// the system's local timezone.
+    /// <param name="value">An iCalendar-compatible date or date-time string.
+    /// <para/>
+    /// If the parsed string represents an RFC 5545, Section 3.3.4, DATE value,
+    /// it cannot have a timezone, and the <see paramref="tzId"/> will be ignored.
+    /// <para/>
+    /// If the parsed string represents an RFC 5545, DATE-TIME value, the <see paramref="tzId"/> will be used.
+    /// </param>
+    /// <param name="tzId">A timezone of <see langword="null"/> represents
+    /// a floating date/time, which is the same in all timezones. (<seealso cref="UtcTzId"/>) represents the Coordinated Universal Time.
+    /// Other values determine the timezone of the date/time.
     /// </param>
     public CalDateTime(string value, string? tzId = null)
     {
         var serializer = new DateTimeSerializer();
         CopyFrom(serializer.Deserialize(new StringReader(value)) as ICopyable
                  ?? throw new InvalidOperationException("Failure deserializing value"));
-        TzId = tzId;
+        _tzId = HasTime ? tzId : null;
     }
 
     private void Initialize(DateOnly dateOnly, TimeOnly? timeOnly, string? tzId)
     {
-        HasTime = timeOnly.HasValue;
-        HasDate = true;
         _dateOnly = dateOnly;
-        _timeOnly = timeOnly ?? new TimeOnly();
+        _timeOnly = RoundTimeToNearestSecond(timeOnly);
 
-        _tzId = string.Equals(UtcTzId, tzId, StringComparison.OrdinalIgnoreCase) ? UtcTzId : tzId;
+        _tzId = tzId switch
+        {
+            _ when string.Equals(UtcTzId, tzId, StringComparison.OrdinalIgnoreCase) => UtcTzId,
+            _ when !timeOnly.HasValue => null,
+            _ => tzId
+        };
     }
 
     /// <inheritdoc/>
@@ -206,10 +233,8 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
         {
             // Maintain the private date/time backing fields
             _dateOnly = calDt._dateOnly;
-            _timeOnly = calDt._timeOnly;
+            _timeOnly = RoundTimeToNearestSecond(calDt._timeOnly);
             _tzId = calDt._tzId;
-            HasTime = calDt.HasTime;
-            HasDate = calDt.HasDate;
         }
 
         AssociateWith(dt);
@@ -228,7 +253,7 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
         unchecked
         {
             var hashCode = Value.GetHashCode();
-            hashCode = (hashCode * 397) ^ HasDate.GetHashCode();
+            hashCode = (hashCode * 397) ^ HasTime.GetHashCode();
             hashCode = (hashCode * 397) ^ AsUtc.GetHashCode();
             hashCode = (hashCode * 397) ^ (TzId != null ? TzId.GetHashCode() : 0);
             return hashCode;
@@ -236,27 +261,46 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
     }
 
     public static bool operator <(CalDateTime? left, IDateTime? right)
-        => left != null && right != null && left.AsUtc < right.AsUtc;
+        => left != null
+           && right != null
+           && (left.IsFloating || right.IsFloating ? left.Value < right.Value : left.AsUtc < right.AsUtc);
 
     public static bool operator >(CalDateTime? left, IDateTime? right)
-        => left != null && right != null && left.AsUtc > right.AsUtc;
-
+        => left != null
+           && right != null
+           && (left.IsFloating || right.IsFloating ? left.Value > right.Value : left.AsUtc > right.AsUtc);
+    
     public static bool operator <=(CalDateTime? left, IDateTime? right)
-        => left != null && right != null && left.AsUtc <= right.AsUtc;
+        => left != null
+           && right != null
+           && (left.IsFloating || right.IsFloating ? left.Value <= right.Value : left.AsUtc <= right.AsUtc);
 
     public static bool operator >=(CalDateTime? left, IDateTime? right)
-        => left != null && right != null && left.AsUtc >= right.AsUtc;
-
+        => left != null
+           && right != null
+           && (left.IsFloating || right.IsFloating ? left.Value >= right.Value : left.AsUtc >= right.AsUtc);
+    
     public static bool operator ==(CalDateTime? left, IDateTime? right)
     {
-        return ReferenceEquals(left, null) || ReferenceEquals(right, null)
-            ? ReferenceEquals(left, right)
-            : right is CalDateTime calDateTime
-                && left.Value.Equals(calDateTime.Value)
-                && left.HasDate == calDateTime.HasDate
-                && left.HasTime == calDateTime.HasTime
-                && left.AsUtc.Equals(calDateTime.AsUtc)
-                && string.Equals(left.TzId, calDateTime.TzId, StringComparison.OrdinalIgnoreCase);
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+
+        if (left is null || right is null)
+        {
+            return false;
+        }
+
+        if (left.IsFloating || right.IsFloating)
+        {
+            return left.Value.Equals(right.Value)
+                   && left.HasTime == right.HasTime;
+        }
+
+        return left.Value.Equals(right.Value)
+               && left.HasTime == right.HasTime
+               && string.Equals(left.TzId, right.TzId, StringComparison.OrdinalIgnoreCase);
     }
 
     public static bool operator !=(CalDateTime? left, IDateTime? right)
@@ -266,17 +310,22 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
     /// Subtracts a <see cref="TimeSpan"/> from the <see cref="CalDateTime"/>.
     /// </summary>
     /// <remarks>
-    /// This will also set <seealso cref="HasTime"/> to <see langword="true"/>,
+    /// This will also add a <see cref="IDateTime.Time"/> part that did not exist before the operation,
     /// if the <see cref="TimeSpan"/> is not a multiple of 24 hours.
     /// </remarks>
     public static IDateTime operator -(CalDateTime left, TimeSpan right)
     {
         var copy = left.Copy<CalDateTime>();
+        var newValue = copy.Value - right;
         if ((right.Ticks % TimeSpan.TicksPerDay) != 0)
         {
-            copy.HasTime = true;
+            copy._dateOnly = DateOnly.FromDateTime(newValue);
+            copy._timeOnly = RoundTimeToNearestSecond(newValue);
         }
-        copy.Value -= right;
+        else
+        {
+            copy._dateOnly = DateOnly.FromDateTime(newValue);
+        }
         return copy;
     }
 
@@ -284,17 +333,22 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
     /// Adds a <see cref="TimeSpan"/> to the <see cref="CalDateTime"/>.
     /// </summary>
     /// <remarks>
-    /// This will also set <seealso cref="HasTime"/> to <see langword="true"/>,
+    /// This will also add a <see cref="IDateTime.Time"/> part that did not exist before the operation,
     /// if the <see cref="TimeSpan"/> is not a multiple of 24 hours.
     /// </remarks>
     public static IDateTime operator +(CalDateTime left, TimeSpan right)
     {
         var copy = left.Copy<CalDateTime>();
+        var newValue = copy.Value + right;
         if ((right.Ticks % TimeSpan.TicksPerDay) != 0)
         {
-            copy.HasTime = true;
+            copy._dateOnly = DateOnly.FromDateTime(newValue);
+            copy._timeOnly = RoundTimeToNearestSecond(newValue);
         }
-        copy.Value += right;
+        else
+        {
+            copy._dateOnly = DateOnly.FromDateTime(newValue);
+        }
         return copy;
     }
 
@@ -304,110 +358,58 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
     public static implicit operator CalDateTime(DateTime left) => new CalDateTime(left);
 
     /// <summary>
-    /// Converts the date/time to the date/time of the computer running the program.
-    /// If the DateTimeKind is Unspecified, it's assumed that the underlying
-    /// Value already represents the system's datetime.
-    /// </summary>
-    public DateTime AsSystemLocal => AsDateTimeOffset.LocalDateTime;
-
-    /// <summary>
     /// Returns a representation of the <see cref="DateTime"/> in UTC.
     /// </summary>
-    public DateTime AsUtc => AsDateTimeOffset.UtcDateTime;
+    public DateTime AsUtc => ToTimeZone(UtcTzId).Value;
 
     /// <summary>
-    /// Gets the underlying <see cref="DateOnlyValue"/> of <see cref="Value"/>.
-    /// </summary>
-    public DateOnly? DateOnlyValue => HasDate ? _dateOnly : null;
-
-    /// <summary>
-    /// Gets the underlying <see cref="TimeOnlyValue"/> of <see cref="Value"/>.
-    /// </summary>
-    public TimeOnly? TimeOnlyValue => HasTime ? _timeOnly : null;
-
-    /// <summary>
-    /// Gets the underlying <see cref="DateTime"/> <see cref="Value"/>.
-    /// Depending on <see cref="HasTime"/> setting,
-    /// the <see cref="DateTime"/> returned has <see cref="DateTime.TimeOfDay"/>
-    /// set to midnight or the time from initialization. The precision of the time part is up to seconds.
+    /// Gets the date and time value in the ISO calendar as a <see cref="DateTime"/> type with <see cref="DateTimeKind.Unspecified"/>.
+    /// The value has no associated timezone.
+    /// The precision of the time part is up to seconds.
     /// <para/>
-    /// See also <seealso cref="DateOnlyValue"/> and <seealso cref="TimeOnlyValue"/> for the date and time parts.
+    /// The value is equivalent to <seealso cref="NodaTime.LocalDateTime"/>.
     /// </summary>
     public DateTime Value
     {
         get
         {
             // HasDate and HasTime both have setters, so they can be changed.
-            if (HasDate && HasTime)
+            if (_timeOnly.HasValue)
             {
                 return new DateTime(_dateOnly.Year, _dateOnly.Month,
-                    _dateOnly.Day, _timeOnly.Hour, _timeOnly.Minute, _timeOnly.Second,
-                    IsUtc ? DateTimeKind.Utc : DateTimeKind.Unspecified);
+                    _dateOnly.Day, _timeOnly.Value.Hour, _timeOnly.Value.Minute, _timeOnly.Value.Second,
+                    DateTimeKind.Unspecified);
             }
 
-            if (HasDate) // but no time
-                return new DateTime(_dateOnly.Year, _dateOnly.Month, _dateOnly.Day,
-                    0, 0, 0,
-                    IsUtc ? DateTimeKind.Utc : DateTimeKind.Unspecified);
-
-            throw new InvalidOperationException($"Cannot create DateTime when {nameof(HasDate)} is false.");
-        }
-
-        set
-        {
-            // Initialize, keeping the HasTime setting
-            if (HasTime)
-                Initialize(DateOnly.FromDateTime(value), TimeOnly.FromDateTime(value), _tzId);
-            else
-                Initialize(DateOnly.FromDateTime(value), null, _tzId);
+            // No time part
+            return new DateTime(_dateOnly.Year, _dateOnly.Month, _dateOnly.Day,
+                0, 0, 0,
+                DateTimeKind.Unspecified);
         }
     }
 
-    /// <summary>
-    /// Returns true if the underlying <see cref="DateTime"/> <see cref="Value"/> is in UTC.
-    /// </summary>
-    public bool IsUtc => string.Equals(_tzId, UtcTzId, StringComparison.OrdinalIgnoreCase);
+    /// <inheritdoc/>
+    public bool IsFloating => _tzId is null;
 
-    /// <summary>
-    /// <see langword="true"/> if the underlying <see cref="DateTime"/> <see cref="Value"/> has a 'date' part (year, month, day).
-    /// </summary>
-    public bool HasDate { get; set; } = true;
+    /// <inheritdoc/>
+    public bool IsUtc => string.Equals(_tzId, UtcTzId, StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// <see langword="true"/> if the underlying <see cref="DateTime"/> <see cref="Value"/> has a 'time' part (hour, minute, second).
     /// </summary>
-    public bool HasTime { get; set; } = true;
+    public bool HasTime => _timeOnly.HasValue;
 
-    private string? _tzId = string.Empty;
-
-    /// <summary>
-    /// Setting the <see cref="TzId"/> to a local timezone will set <see cref="Value"/> to <see cref="DateTimeKind.Unspecified"/>.
-    /// Setting <see cref="TzId"/> to UTC will set <see cref="Value"/> to <see cref="DateTimeKind.Utc"/>.
-    /// If the value is set to <see langword="null"/>, <see cref="Value"/> will be <see cref="DateTimeKind.Unspecified"/>,
-    /// and the system's local timezone will be used.
-    /// <para/>
-    /// Setting the <see cref="TzId"/> will initialize in the same way aw with the <seealso cref="CalDateTime(DateTime, string, bool)"/>.<br/>
-    /// To convert to another timezone, use <see cref="ToTimeZone"/>.
-    /// </summary>
-    public string? TzId
-    {
-        get => _tzId;
-        set
-        {
-            if (string.Equals(_tzId, value, StringComparison.OrdinalIgnoreCase))
-            {
-                return;
-            }
-
-            _tzId = value;
-            Initialize(_dateOnly, HasTime ? _timeOnly : null, value);
-        }
-    }
+    private string? _tzId;
 
     /// <summary>
-    /// Gets the timezone name, if it references a timezone.
-    /// This is an alias for <see cref="TzId"/>.
+    /// Gets the IANA timezone ID of this <see cref="CalDateTime"/> instance.
+    /// It can be <see cref="UtcTzId"/> for Coordinated Universal Time,
+    /// or <see langword="null"/> for a floating date/time, or value for a specific timezone.
     /// </summary>
+    public string? TzId => _tzId;
+
+    /// <inheritdoc cref="TzId"/>
+    /// <remarks>This is an alias for <see cref="TzId"/></remarks>
     public string? TimeZoneName => TzId;
 
     /// <inheritdoc cref="DateTime.Year"/>
@@ -440,41 +442,62 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
     /// <inheritdoc cref="DateTime.DayOfYear"/>
     public int DayOfYear => Value.DayOfYear;
 
-    /// <inheritdoc cref="DateTime.Date"/>
-    public DateTime Date => Value.Date;
+    /// <inheritdoc cref="DateOnly"/>
+    public DateOnly Date => _dateOnly;
 
-    /// <inheritdoc cref="DateTime.TimeOfDay"/>
-    public TimeSpan TimeOfDay => Value.TimeOfDay;
+    /// <inheritdoc cref="TimeOnly"/>
+    public TimeOnly? Time => _timeOnly;
 
     /// <summary>
-    /// Returns a representation of the <see cref="IDateTime"/> in the <paramref name="tzId"/> timezone
+    /// Any <see cref="Time"/> values are always rounded to the nearest second.
+    /// RFC 5545, Section 3.3.5 does not allow for fractional seconds.
     /// </summary>
-    public IDateTime ToTimeZone(string? tzId)
+    private static TimeOnly? RoundTimeToNearestSecond(TimeOnly? time)
     {
-        // If TzId is empty, it's a system-local datetime, so we should use the system timezone as the starting point.
-        var originalTzId = TzId ?? TimeZoneInfo.Local.Id;
-
-        var zonedOriginal = DateUtil.ToZonedDateTimeLeniently(Value, originalTzId);
-        var converted = zonedOriginal.WithZone(DateUtil.GetZone(tzId));
-
-        return converted.Zone == DateTimeZone.Utc
-            ? new CalDateTime(converted.ToDateTimeUtc(), tzId)
-            : new CalDateTime(DateTime.SpecifyKind(converted.ToDateTimeUnspecified(), DateTimeKind.Unspecified), tzId);
+        if (time is null)
+        {
+            return null;
+        }
+        var roundedSecond = time.Value.Second + (time.Value.Millisecond >= 500 ? 1 : 0);
+        return roundedSecond == 60
+            ? new TimeOnly(time.Value.Hour, time.Value.Minute, 0).AddMinutes(1)
+            : new TimeOnly(time.Value.Hour, time.Value.Minute, roundedSecond);
     }
 
     /// <summary>
-    /// Returns a <see cref="DateTimeOffset"/> representation of the <see cref="Value"/>.
-    /// If a TzId is specified, it will use that timezone's UTC offset, otherwise it will use the
-    /// system-local timezone.
+    /// Any <see cref="Time"/> values are always rounded to the nearest second.
+    /// RFC 5545, Section 3.3.5 does not allow for fractional seconds.
     /// </summary>
-    public DateTimeOffset AsDateTimeOffset =>
-        TzId is null
-            ? new DateTimeOffset(Value)
-            : DateUtil.ToZonedDateTimeLeniently(Value, TzId).ToDateTimeOffset();
+    private static TimeOnly? RoundTimeToNearestSecond(DateTime dateTime)
+    {
+        var roundedSecond = dateTime.Second + (dateTime.Millisecond >= 500 ? 1 : 0);
+        return roundedSecond == 60
+            ? new TimeOnly(dateTime.Hour, dateTime.Minute, 0).AddMinutes(1)
+            : new TimeOnly(dateTime.Hour, dateTime.Minute, roundedSecond);
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>If <see paramref="otherTzId"/> is not a well-known timezone ID, the system's local timezone will be used.</remarks>
+    public IDateTime ToTimeZone(string otherTzId)
+    {
+        var zonedOriginal = DateUtil.ToZonedDateTimeLeniently(Value, TzId);
+        var converted = zonedOriginal.WithZone(DateUtil.GetZone(otherTzId));
+
+        return converted.Zone == DateTimeZone.Utc
+            ? new CalDateTime(converted.ToDateTimeUtc(), UtcTzId)
+            : new CalDateTime(converted.ToDateTimeUnspecified(), otherTzId);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// If the <see cref="TzId"/> is <see langword="null"/> or does not represent an
+    /// IANA or other well-known timezone ID, the system's local timezone will be used.
+    /// </remarks>
+    public DateTimeOffset AsDateTimeOffset => DateUtil.ToZonedDateTimeLeniently(Value, TzId).ToDateTimeOffset();
 
     /// <inheritdoc cref="DateTime.Add"/>
     /// <remarks>
-    /// This will also set <seealso cref="HasTime"/> to <see langword="true"/>,
+    /// This will also add a <see cref="IDateTime.Time"/> part that did not exist before the operation,
     /// if the hours are not a multiple of 24.
     /// </remarks>
     public IDateTime Add(TimeSpan ts) => this + ts;
@@ -486,24 +509,13 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
     /// <summary>Returns a new <see cref="IDateTime"/> by subtracting the specified <see cref="TimeSpan" /> from the value of this instance.</summary>
     /// <param name="ts">An interval.</param>
     /// <returns>An object whose value is the difference of the date and time represented by this instance and the time interval represented by <paramref name="ts" />.</returns>
-    /// <remarks>
-    /// This will also set <seealso cref="HasTime"/> to <see langword="true"/>,
-    /// if the hours are not a multiple of 24.
-    /// </remarks>
     public IDateTime Subtract(TimeSpan ts) => this - ts;
-
-    [Obsolete("This operator will be removed in a future version.", true)]
-    public static TimeSpan? operator -(CalDateTime? left, IDateTime? right)
-    {
-        left?.AssociateWith(right); // Should not be done in operator overloads
-        return left?.AsUtc - right?.AsUtc;
-    }
 
     /// <inheritdoc cref="DateTime.AddYears"/>
     public IDateTime AddYears(int years)
     {
         var dt = Copy<CalDateTime>();
-        dt.Value = Value.AddYears(years);
+        dt._dateOnly = dt._dateOnly.AddYears(years);
         return dt;
     }
 
@@ -511,7 +523,7 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
     public IDateTime AddMonths(int months)
     {
         var dt = Copy<CalDateTime>();
-        dt.Value = Value.AddMonths(months);
+        dt._dateOnly = dt._dateOnly.AddMonths(months);
         return dt;
     }
 
@@ -519,93 +531,117 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
     public IDateTime AddDays(int days)
     {
         var dt = Copy<CalDateTime>();
-        dt.Value = Value.AddDays(days);
+        dt._dateOnly = dt._dateOnly.AddDays(days);
         return dt;
     }
 
     /// <inheritdoc cref="DateTime.AddHours"/>
     /// <remarks>
-    /// This will also set <seealso cref="HasTime"/> to <see langword="true"/>,
+    /// This will also add a <see cref="IDateTime.Time"/> part that did not exist before the operation,
     /// if the hours are not a multiple of 24.
     /// </remarks>
     public IDateTime AddHours(int hours)
     {
-        var dt = Copy<CalDateTime>();
-        if (!dt.HasTime && hours % 24 > 0)
+        var copy = Copy<CalDateTime>();
+        var newValue = copy.Value.AddHours(hours);
+        if (!copy.HasTime && (hours % 24 == 0))
         {
-            dt.HasTime = true;
+            copy._dateOnly = DateOnly.FromDateTime(newValue);
         }
-        dt.Value = Value.AddHours(hours);
-        return dt;
+        else
+        {
+            copy._dateOnly = DateOnly.FromDateTime(newValue);
+            copy._timeOnly = RoundTimeToNearestSecond(newValue);
+        }
+        return copy;
     }
 
     /// <inheritdoc cref="DateTime.AddMinutes"/>
     /// <remarks>
-    /// This will also set <seealso cref="HasTime"/> to <see langword="true"/>,
+    /// This will also add a <see cref="IDateTime.Time"/> part that did not exist before the operation,
     /// if the minutes are not a multiple of 1440.
     /// </remarks>
     public IDateTime AddMinutes(int minutes)
     {
-        var dt = Copy<CalDateTime>();
-        if (!dt.HasTime && minutes % 1440 > 0)
+        var copy = Copy<CalDateTime>();
+        var newValue = copy.Value.AddMinutes(minutes);
+        if (!copy.HasTime && (minutes % 1440 == 0))
         {
-            dt.HasTime = true;
+            copy._dateOnly = DateOnly.FromDateTime(newValue);
         }
-        dt.Value = Value.AddMinutes(minutes);
-        return dt;
+        else
+        {
+            copy._dateOnly = DateOnly.FromDateTime(newValue);
+            copy._timeOnly = RoundTimeToNearestSecond(newValue);
+        }
+        return copy;
     }
 
     /// <inheritdoc cref="DateTime.AddSeconds"/>
     /// <remarks>
-    /// This will also set <seealso cref="HasTime"/> to <see langword="true"/>,
+    /// This will also add a <see cref="IDateTime.Time"/> part that did not exist before the operation,
     /// if the seconds are not a multiple of 86400.
     /// </remarks>
     public IDateTime AddSeconds(int seconds)
     {
-        var dt = Copy<CalDateTime>();
-        if (!dt.HasTime && seconds % 86400 > 0)
+        var copy = Copy<CalDateTime>();
+        var newValue = copy.Value.AddSeconds(seconds);
+        if (!copy.HasTime && (seconds % 86400 == 0))
         {
-            dt.HasTime = true;
+            copy._dateOnly = DateOnly.FromDateTime(newValue);
         }
-        dt.Value = Value.AddSeconds(seconds);
-        return dt;
+        else
+        {
+            copy._dateOnly = DateOnly.FromDateTime(newValue);
+            copy._timeOnly = RoundTimeToNearestSecond(newValue);
+        }
+        return copy;
     }
 
     /// <inheritdoc cref="DateTime.AddMilliseconds"/>
     /// <remarks>
-    /// This will also set <seealso cref="HasTime"/> to <see langword="true"/>
+    /// This will also add a <see cref="IDateTime.Time"/> part that did not exist before the operation,
     /// if the milliseconds are not a multiple of 86400000.
     /// <para/>
     /// Milliseconds less than full seconds get truncated.
     /// </remarks>
-    public IDateTime AddMilliseconds(int milliseconds)
+    public IDateTime AddMilliseconds(double milliseconds)
     {
-        var dt = Copy<CalDateTime>();
-        if (!dt.HasTime && milliseconds % 86400000 > 0)
+        var copy = Copy<CalDateTime>();
+        var newValue = copy.Value.AddMilliseconds(milliseconds);
+        if (!copy.HasTime && ((long) milliseconds % 86400000) == 0)
         {
-            dt.HasTime = true;
+            copy._dateOnly = DateOnly.FromDateTime(newValue);
         }
-        dt.Value = Value.AddMilliseconds(milliseconds);
-        return dt;
+        else
+        {
+            copy._dateOnly = DateOnly.FromDateTime(newValue);
+            copy._timeOnly = RoundTimeToNearestSecond(newValue);
+        }
+        return copy;
     }
 
     /// <inheritdoc cref="DateTime.AddTicks"/>
     /// <remarks>
-    /// This will also set <seealso cref="HasTime"/> to <see langword="true"/>.
+    /// This will also add a <see cref="IDateTime.Time"/> part that did not exist before the operation,
     /// if ticks do not result in multiple of full days.
     /// <para/>
     /// Ticks less than full seconds get truncated.
     /// </remarks>
     public IDateTime AddTicks(long ticks)
     {
-        var dt = Copy<CalDateTime>();
-        if (!dt.HasTime && (ticks % TimeSpan.TicksPerDay) != 0)
+        var copy = Copy<CalDateTime>();
+        var newValue = copy.Value.AddTicks(ticks);
+        if (!copy.HasTime && (ticks % TimeSpan.TicksPerDay == 0))
         {
-            dt.HasTime = true;
+            copy._dateOnly = DateOnly.FromDateTime(newValue);
         }
-
-        dt.Value = Value.AddTicks(ticks);
-        return dt;
+        else
+        {
+            copy._dateOnly = DateOnly.FromDateTime(newValue);
+            copy._timeOnly = RoundTimeToNearestSecond(newValue);
+        }
+        return copy;
     }
 
     /// <summary>
@@ -627,7 +663,6 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
     /// Returns <see langword="true"/> if the current <see cref="IDateTime"/> instance is greater than or equal to <paramref name="dt"/>.
     /// </summary>
     public bool GreaterThanOrEqual(IDateTime dt) => this >= dt;
-
 
     /// <summary>
     /// Associates the current instance with the specified <see cref="IDateTime"/> object.
@@ -688,17 +723,14 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
         var dateTimeOffset = AsDateTimeOffset;
 
         // Use the .NET format options to format the DateTimeOffset
-
-        if (HasTime && !HasDate)
-        {
-            return $"{dateTimeOffset.TimeOfDay.ToString(format, formatProvider)} {_tzId}";
-        }
+        var tzIdString = _tzId is not null ? $" {_tzId}" : string.Empty;
 
         if (HasTime)
         {
-            return $"{dateTimeOffset.ToString(format, formatProvider)} {_tzId}";
+            return $"{dateTimeOffset.ToString(format, formatProvider)}{tzIdString}";
         }
 
-        return $"{dateTimeOffset.ToString("d", formatProvider)} {_tzId}";
+        // No time part
+        return $"{DateOnly.FromDateTime(dateTimeOffset.Date).ToString(format ?? "d", formatProvider)}{tzIdString}";
     }
 }

--- a/Ical.Net/DataTypes/CalDateTime.cs
+++ b/Ical.Net/DataTypes/CalDateTime.cs
@@ -488,13 +488,6 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
             : new CalDateTime(converted.ToDateTimeUnspecified(), otherTzId);
     }
 
-    /// <inheritdoc />
-    /// <remarks>
-    /// If the <see cref="TzId"/> is <see langword="null"/> or does not represent an
-    /// IANA or other well-known timezone ID, the system's local timezone will be used.
-    /// </remarks>
-    public DateTimeOffset AsDateTimeOffset => DateUtil.ToZonedDateTimeLeniently(Value, TzId).ToDateTimeOffset();
-
     /// <inheritdoc cref="DateTime.Add"/>
     /// <remarks>
     /// This will also add a <see cref="IDateTime.Time"/> part that did not exist before the operation,
@@ -720,7 +713,7 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
     public string ToString(string? format, IFormatProvider? formatProvider)
     {
         formatProvider ??= CultureInfo.InvariantCulture;
-        var dateTimeOffset = AsDateTimeOffset;
+        var dateTimeOffset = DateUtil.ToZonedDateTimeLeniently(Value, _tzId).ToDateTimeOffset();
 
         // Use the .NET format options to format the DateTimeOffset
         var tzIdString = _tzId is not null ? $" {_tzId}" : string.Empty;

--- a/Ical.Net/DataTypes/CalDateTime.cs
+++ b/Ical.Net/DataTypes/CalDateTime.cs
@@ -421,12 +421,6 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
     /// <inheritdoc cref="DateTime.Second"/>
     public int Second => Value.Second;
 
-    /// <inheritdoc cref="DateTime.Millisecond"/>
-    public int Millisecond => Value.Millisecond;
-
-    /// <inheritdoc cref="DateTime.Ticks"/>
-    public long Ticks => Value.Ticks;
-
     /// <inheritdoc cref="DateTime.DayOfWeek"/>
     public DayOfWeek DayOfWeek => Value.DayOfWeek;
 

--- a/Ical.Net/DataTypes/CalDateTime.cs
+++ b/Ical.Net/DataTypes/CalDateTime.cs
@@ -292,10 +292,9 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
             return false;
         }
 
-        if (left.IsFloating || right.IsFloating)
+        if (left.IsFloating != right.IsFloating)
         {
-            return left.Value.Equals(right.Value)
-                   && left.HasTime == right.HasTime;
+            return false;
         }
 
         return left.Value.Equals(right.Value)

--- a/Ical.Net/DataTypes/CalDateTime.cs
+++ b/Ical.Net/DataTypes/CalDateTime.cs
@@ -201,9 +201,8 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
 
         _tzId = tzId switch
         {
-            _ when !timeOnly.HasValue && string.Equals(UtcTzId, tzId, StringComparison.OrdinalIgnoreCase) => UtcTzId,
             _ when !timeOnly.HasValue => null,
-            _ => tzId
+            _ => tzId // can also be UtcTzId
         };
     }
 
@@ -451,10 +450,8 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
         {
             return null;
         }
-        var roundedSecond = time.Value.Second + (time.Value.Millisecond >= 500 ? 1 : 0);
-        return roundedSecond == 60
-            ? new TimeOnly(time.Value.Hour, time.Value.Minute, 0).AddMinutes(1)
-            : new TimeOnly(time.Value.Hour, time.Value.Minute, roundedSecond);
+
+        return new TimeOnly(time.Value.Hour, time.Value.Minute, time.Value.Second);
     }
 
     /// <summary>

--- a/Ical.Net/DataTypes/CalDateTime.cs
+++ b/Ical.Net/DataTypes/CalDateTime.cs
@@ -201,7 +201,7 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
 
         _tzId = tzId switch
         {
-            _ when string.Equals(UtcTzId, tzId, StringComparison.OrdinalIgnoreCase) => UtcTzId,
+            _ when !timeOnly.HasValue && string.Equals(UtcTzId, tzId, StringComparison.OrdinalIgnoreCase) => UtcTzId,
             _ when !timeOnly.HasValue => null,
             _ => tzId
         };

--- a/Ical.Net/DataTypes/IDateTime.cs
+++ b/Ical.Net/DataTypes/IDateTime.cs
@@ -11,18 +11,12 @@ namespace Ical.Net.DataTypes;
 public interface IDateTime : IEncodableDataType, IComparable<IDateTime>, IFormattable, ICalendarDataType
 {
     /// <summary>
-    /// Converts the date/time to this computer's local date/time.
-    /// </summary>
-    DateTime AsSystemLocal { get; }
-
-    /// <summary>
     /// Converts the date/time to UTC (Coordinated Universal Time)
     /// </summary>
     DateTime AsUtc { get; }
 
     /// <summary>
-    /// Returns a DateTimeOffset representation of the Value. If a TzId is specified, it will use that time zone's UTC offset, otherwise it will use the
-    /// system-local time zone.
+    /// Returns a DateTimeOffset representation of the <see cref="Value"/> in the <see cref="TzId"/> timezone.
     /// </summary>
     DateTimeOffset AsDateTimeOffset { get; }
 
@@ -33,106 +27,114 @@ public interface IDateTime : IEncodableDataType, IComparable<IDateTime>, IFormat
     bool IsUtc { get; }
 
     /// <summary>
-    /// Gets the time zone name this time is in, if it references a time zone.
+    /// Gets the timezone name this time is in, if it references a timezone.
     /// </summary>
     string? TimeZoneName { get; }
 
     /// <summary>
-    /// Gets/sets the underlying DateTime value stored.  This should always
+    /// Gets the underlying DateTime value. This should always
     /// use DateTimeKind.Utc, regardless of its actual representation.
     /// Use IsUtc along with the TZID to control how this
     /// date/time is handled.
     /// </summary>
-    DateTime Value { get; set; }
+    DateTime Value { get; }
 
     /// <summary>
-    /// Gets/sets whether or not this date/time value contains a 'date' part.
+    /// Returns <see langword="true"/>, if the date/time value contains a 'time' part.
     /// </summary>
-    bool HasDate { get; set; }
+    bool HasTime { get; }
 
     /// <summary>
-    /// Gets/sets whether or not this date/time value contains a 'time' part.
+    /// Returns <see langword="true"/>, if the date/time value is floating.
+    /// <para/>
+    /// A floating date/time value does not include a timezone identifier or UTC offset,
+    /// so it is interpreted as local time in the context where it is used.
+    /// <para/>
+    /// A floating date/time value is useful when the exact timezone is not
+    /// known or when the event should be interpreted in the local timezone of
+    /// the user or system processing the calendar data.
     /// </summary>
-    bool HasTime { get; set; }
+    bool IsFloating { get; }
 
     /// <summary>
-    /// Gets/sets the time zone ID for this date/time value.
+    /// Gets the timezone ID that applies to the <see cref="Value"/>.
     /// </summary>
-    string? TzId { get; set; }
+    string? TzId { get; }
 
     /// <summary>
-    /// Gets the year for this date/time value.
+    /// Gets the year that applies to the <see cref="Value"/>.
     /// </summary>
     int Year { get; }
 
     /// <summary>
-    /// Gets the month for this date/time value.
+    /// Gets the month that applies to the <see cref="Value"/>.
     /// </summary>
     int Month { get; }
 
     /// <summary>
-    /// Gets the day for this date/time value.
+    /// Gets the day that applies to the <see cref="Value"/>.
     /// </summary>
     int Day { get; }
 
     /// <summary>
-    /// Gets the hour for this date/time value.
+    /// Gets the hour that applies to the <see cref="Value"/>.
     /// </summary>
     int Hour { get; }
 
     /// <summary>
-    /// Gets the minute for this date/time value.
+    /// Gets the minute that applies to the <see cref="Value"/>.
     /// </summary>
     int Minute { get; }
 
     /// <summary>
-    /// Gets the second for this date/time value.
+    /// Gets the second that applies to the <see cref="Value"/>.
     /// </summary>
     int Second { get; }
 
     /// <summary>
-    /// Gets the millisecond for this date/time value.
+    /// Gets the millisecond that applies to the <see cref="Value"/>.
     /// </summary>
     int Millisecond { get; }
 
     /// <summary>
-    /// Gets the ticks for this date/time value.
+    /// Gets the ticks that applies to the <see cref="Value"/>.
     /// </summary>
     long Ticks { get; }
 
     /// <summary>
-    /// Gets the DayOfWeek for this date/time value.
+    /// Gets the DayOfWeek that applies to the <see cref="Value"/>.
     /// </summary>
     DayOfWeek DayOfWeek { get; }
 
     /// <summary>
-    /// Gets the date portion of the date/time value.
+    /// Gets the date portion of the <see cref="Value"/>.
     /// </summary>
-    DateTime Date { get; }
+    DateOnly Date { get; }
 
     /// <summary>
-    /// Converts the date/time value to a local time
-    /// within the specified time zone.
+    /// Gets the time portion of the <see cref="Value"/>, or <see langword="null"/> if the <see cref="Value"/> is a pure date.
     /// </summary>
-    IDateTime ToTimeZone(string tzId);
+    TimeOnly? Time { get; }
 
+    /// <summary>
+    /// Converts the <see cref="Value"/> to a date/time
+    /// within the specified <see paramref="otherTzId"/> timezone.
+    /// </summary>
+    IDateTime ToTimeZone(string otherTzId);
     IDateTime Add(TimeSpan ts);
     IDateTime Subtract(TimeSpan ts);
     TimeSpan Subtract(IDateTime dt);
-
     IDateTime AddYears(int years);
     IDateTime AddMonths(int months);
     IDateTime AddDays(int days);
     IDateTime AddHours(int hours);
     IDateTime AddMinutes(int minutes);
     IDateTime AddSeconds(int seconds);
-    IDateTime AddMilliseconds(int milliseconds);
+    IDateTime AddMilliseconds(double milliseconds);
     IDateTime AddTicks(long ticks);
-
     bool LessThan(IDateTime dt);
     bool GreaterThan(IDateTime dt);
     bool LessThanOrEqual(IDateTime dt);
     bool GreaterThanOrEqual(IDateTime dt);
-
     void AssociateWith(IDateTime dt);
 }

--- a/Ical.Net/DataTypes/IDateTime.cs
+++ b/Ical.Net/DataTypes/IDateTime.cs
@@ -92,16 +92,6 @@ public interface IDateTime : IEncodableDataType, IComparable<IDateTime>, IFormat
     int Second { get; }
 
     /// <summary>
-    /// Gets the millisecond that applies to the <see cref="Value"/>.
-    /// </summary>
-    int Millisecond { get; }
-
-    /// <summary>
-    /// Gets the ticks that applies to the <see cref="Value"/>.
-    /// </summary>
-    long Ticks { get; }
-
-    /// <summary>
     /// Gets the DayOfWeek that applies to the <see cref="Value"/>.
     /// </summary>
     DayOfWeek DayOfWeek { get; }

--- a/Ical.Net/DataTypes/IDateTime.cs
+++ b/Ical.Net/DataTypes/IDateTime.cs
@@ -134,8 +134,6 @@ public interface IDateTime : IEncodableDataType, IComparable<IDateTime>, IFormat
     IDateTime AddHours(int hours);
     IDateTime AddMinutes(int minutes);
     IDateTime AddSeconds(int seconds);
-    IDateTime AddMilliseconds(double milliseconds);
-    IDateTime AddTicks(long ticks);
     bool LessThan(IDateTime dt);
     bool GreaterThan(IDateTime dt);
     bool LessThanOrEqual(IDateTime dt);

--- a/Ical.Net/DataTypes/IDateTime.cs
+++ b/Ical.Net/DataTypes/IDateTime.cs
@@ -12,6 +12,9 @@ public interface IDateTime : IEncodableDataType, IComparable<IDateTime>, IFormat
 {
     /// <summary>
     /// Converts the date/time to UTC (Coordinated Universal Time)
+    /// If <see cref="IsFloating"/>==<see langword="true"/>
+    /// it means that the <see cref="Value"/> is considered as local time for every timezone:
+    /// The returned <see cref="Value"/> is unchanged, but with <see cref="DateTimeKind.Utc"/>.
     /// </summary>
     DateTime AsUtc { get; }
 
@@ -27,10 +30,12 @@ public interface IDateTime : IEncodableDataType, IComparable<IDateTime>, IFormat
     string? TimeZoneName { get; }
 
     /// <summary>
-    /// Gets the underlying DateTime value. This should always
-    /// use DateTimeKind.Utc, regardless of its actual representation.
-    /// Use IsUtc along with the TZID to control how this
-    /// date/time is handled.
+    /// Gets the date and time value in the ISO calendar as a <see cref="DateTime"/> type with <see cref="DateTimeKind.Unspecified"/>.
+    /// The value has no associated timezone.<br/>
+    /// The precision of the time part is up to seconds.
+    /// <para/>
+    /// Use <see cref="IsUtc"/> along with <see cref="TzId"/> and <see cref="IsFloating"/>
+    /// to control how this date/time is handled.
     /// </summary>
     DateTime Value { get; }
 
@@ -114,6 +119,10 @@ public interface IDateTime : IEncodableDataType, IComparable<IDateTime>, IFormat
     /// <summary>
     /// Converts the <see cref="Value"/> to a date/time
     /// within the specified <see paramref="otherTzId"/> timezone.
+    /// <para/>
+    /// If <see cref="IsFloating"/>==<see langword="true"/>
+    /// it means that the <see cref="Value"/> is considered as local time for every timezone:
+    /// The returned <see cref="Value"/> is unchanged and the <see paramref="otherTzId"/> is set as <see cref="TzId"/>.
     /// </summary>
     IDateTime ToTimeZone(string otherTzId);
     IDateTime Add(TimeSpan ts);

--- a/Ical.Net/DataTypes/IDateTime.cs
+++ b/Ical.Net/DataTypes/IDateTime.cs
@@ -16,11 +16,6 @@ public interface IDateTime : IEncodableDataType, IComparable<IDateTime>, IFormat
     DateTime AsUtc { get; }
 
     /// <summary>
-    /// Returns a DateTimeOffset representation of the <see cref="Value"/> in the <see cref="TzId"/> timezone.
-    /// </summary>
-    DateTimeOffset AsDateTimeOffset { get; }
-
-    /// <summary>
     /// Gets/sets whether the Value of this date/time represents
     /// a universal time.
     /// </summary>

--- a/Ical.Net/DataTypes/Trigger.cs
+++ b/Ical.Net/DataTypes/Trigger.cs
@@ -37,7 +37,11 @@ public class Trigger : EncodableDataType
             Duration = null;
 
             // Ensure date/time has a time part
-            _mDateTime.HasTime = true;
+            if (!_mDateTime.HasTime)
+            {
+                _mDateTime = new CalDateTime(_mDateTime.Date, new TimeOnly(), _mDateTime.TzId)
+                    { AssociatedObject = _mDateTime.AssociatedObject };
+            }
         }
     }
 

--- a/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
@@ -954,8 +954,10 @@ public class RecurrencePatternEvaluator : Evaluator
             // This case is not defined by RFC 5545. We handle it by evaluating the rule
             // as if referenceDate had a time (i.e. set to midnight).
 
-            referenceDate = referenceDate.Copy<IDateTime>();
-            referenceDate.HasTime = true;
+            if (referenceDate.HasTime)
+                referenceDate = referenceDate.Copy<IDateTime>();
+            else
+                referenceDate = new CalDateTime(referenceDate.Date, new TimeOnly(), referenceDate.TzId) { AssociatedObject = referenceDate.AssociatedObject };
         }
 
         // Create a recurrence pattern suitable for use during evaluation.
@@ -988,6 +990,6 @@ public class RecurrencePatternEvaluator : Evaluator
 
         return dt1.IsUtc
             ? new CalDateTime(copy.AsUtc)
-            : new CalDateTime(copy.AsSystemLocal);
+            : copy;
     }
 }

--- a/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
@@ -953,11 +953,7 @@ public class RecurrencePatternEvaluator : Evaluator
         {
             // This case is not defined by RFC 5545. We handle it by evaluating the rule
             // as if referenceDate had a time (i.e. set to midnight).
-
-            if (referenceDate.HasTime)
-                referenceDate = referenceDate.Copy<IDateTime>();
-            else
-                referenceDate = new CalDateTime(referenceDate.Date, new TimeOnly(), referenceDate.TzId) { AssociatedObject = referenceDate.AssociatedObject };
+            referenceDate = new CalDateTime(referenceDate.Date, new TimeOnly(), referenceDate.TzId) { AssociatedObject = referenceDate.AssociatedObject };
         }
 
         // Create a recurrence pattern suitable for use during evaluation.

--- a/Ical.Net/Evaluation/RecurrenceUtil.cs
+++ b/Ical.Net/Evaluation/RecurrenceUtil.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 //
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Ical.Net.CalendarComponents;
@@ -13,8 +14,12 @@ namespace Ical.Net.Evaluation;
 
 internal class RecurrenceUtil
 {
-    public static HashSet<Occurrence> GetOccurrences(IRecurrable recurrable, IDateTime dt, bool includeReferenceDateInResults) => GetOccurrences(recurrable,
-        new CalDateTime(dt.Date), new CalDateTime(dt.Date.AddDays(1).AddSeconds(-1)), includeReferenceDateInResults);
+    public static HashSet<Occurrence> GetOccurrences(IRecurrable recurrable, IDateTime dt, bool includeReferenceDateInResults)
+    {
+        var endTimeOnly = dt.Time?.Add(TimeSpan.FromSeconds(-1));
+        return GetOccurrences(recurrable,
+        new CalDateTime(dt.Date, dt.Time), new CalDateTime(dt.Date.AddDays(1), endTimeOnly), includeReferenceDateInResults);
+    }
 
     public static HashSet<Occurrence> GetOccurrences(IRecurrable recurrable, IDateTime periodStart, IDateTime periodEnd, bool includeReferenceDateInResults)
     {
@@ -31,8 +36,8 @@ internal class RecurrenceUtil
         // Change the time zone of periodStart/periodEnd as needed
         // so they can be used during the evaluation process.
 
-        periodStart.TzId = start.TzId;
-        periodEnd.TzId = start.TzId;
+        periodStart = new CalDateTime(periodStart.Date, periodStart.Time, start.TzId);
+        periodEnd = new CalDateTime(periodEnd.Date, periodEnd.Time, start.TzId);
 
         var periods = evaluator.Evaluate(start, DateUtil.GetSimpleDateTimeData(periodStart), DateUtil.GetSimpleDateTimeData(periodEnd),
             includeReferenceDateInResults);

--- a/Ical.Net/Evaluation/RecurrenceUtil.cs
+++ b/Ical.Net/Evaluation/RecurrenceUtil.cs
@@ -16,9 +16,8 @@ internal class RecurrenceUtil
 {
     public static HashSet<Occurrence> GetOccurrences(IRecurrable recurrable, IDateTime dt, bool includeReferenceDateInResults)
     {
-        var endTimeOnly = dt.Time?.Add(TimeSpan.FromSeconds(-1));
         return GetOccurrences(recurrable,
-        new CalDateTime(dt.Date, dt.Time), new CalDateTime(dt.Date.AddDays(1), endTimeOnly), includeReferenceDateInResults);
+        new CalDateTime(dt.Date, dt.Time), new CalDateTime(dt.Date.AddDays(1)), includeReferenceDateInResults);
     }
 
     public static HashSet<Occurrence> GetOccurrences(IRecurrable recurrable, IDateTime periodStart, IDateTime periodEnd, bool includeReferenceDateInResults)

--- a/Ical.Net/Evaluation/TodoEvaluator.cs
+++ b/Ical.Net/Evaluation/TodoEvaluator.cs
@@ -73,7 +73,7 @@ public class TodoEvaluator : RecurringEvaluator
         {
             var dtVal = referenceDateTime.Value;
             IncrementDate(ref dtVal, recur, -recur.Interval);
-            referenceDateTime.Value = dtVal;
+            referenceDateTime = new CalDateTime(DateOnly.FromDateTime(dtVal), TimeOnly.FromDateTime(dtVal)) { AssociatedObject = referenceDateTime.AssociatedObject };
         }
     }
 

--- a/Ical.Net/ILoadable.cs
+++ b/Ical.Net/ILoadable.cs
@@ -10,7 +10,7 @@ namespace Ical.Net;
 public interface ILoadable
 {
     /// <summary>
-    /// Gets whether or not the object has been loaded.
+    /// Gets whether the object has been loaded.
     /// </summary>
     bool IsLoaded { get; }
 

--- a/Ical.Net/Serialization/DataTypes/DateTimeSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/DateTimeSerializer.cs
@@ -99,7 +99,7 @@ public class DateTimeSerializer : EncodableDataTypeSerializer
 
         // The associated object is an ICalendarObject of type CalendarProperty
         // that contains any timezone ("TZID" property) deserialized in a prior step
-        dt.TzId = dt.Parameters.Get("TZID");
+        var timeZoneId = dt.Parameters.Get("TZID");
 
         // Decode the value as necessary
         value = Decode(dt, value);
@@ -132,16 +132,11 @@ public class DateTimeSerializer : EncodableDataTypeSerializer
         }
 
         var isUtc = match.Groups[9].Success;
-        var kind = isUtc
-            ? DateTimeKind.Utc
-            : DateTimeKind.Unspecified;
+        if (isUtc) timeZoneId = "UTC";
 
-        if (isUtc) dt.TzId = "UTC";
-
-        dt.Value = timePart.HasValue
-            ? new DateTime(datePart.Year, datePart.Month, datePart.Day, timePart.Value.Hour, timePart.Value.Minute, timePart.Value.Second, kind)
-            : new DateTime(datePart.Year, datePart.Month, datePart.Day, 0, 0, 0, kind);
-        dt.HasTime = timePart.HasValue;
+        dt = timePart.HasValue
+            ? new CalDateTime(datePart, timePart.Value, timeZoneId) { AssociatedObject = dt.AssociatedObject }
+            : new CalDateTime(datePart) { AssociatedObject = dt.AssociatedObject };
 
         return dt;
     }

--- a/Ical.Net/Serialization/DataTypes/RecurrencePatternSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/RecurrencePatternSerializer.cs
@@ -147,8 +147,9 @@ public class RecurrencePatternSerializer : EncodableDataTypeSerializer
             var serializer = factory.Build(typeof(IDateTime), SerializationContext) as IStringSerializer;
             if (serializer != null)
             {
-                IDateTime until = new CalDateTime(recur.Until);
-                until.HasTime = true;
+                var until = new CalDateTime(DateOnly.FromDateTime(recur.Until), TimeOnly.FromDateTime(recur.Until),
+                    recur.Until.Kind == DateTimeKind.Utc ? "UTC" : null);
+
                 values.Add("UNTIL=" + serializer.SerializeToString(until));
             }
         }
@@ -269,7 +270,7 @@ public class RecurrencePatternSerializer : EncodableDataTypeSerializer
                                 var dt = serializer?.Deserialize(new StringReader(keyValue)) as IDateTime;
                                 if (dt != null)
                                 {
-                                    r.Until = dt.Value;
+                                    r.Until = DateTime.SpecifyKind(dt.Value, dt.IsUtc ? DateTimeKind.Utc : DateTimeKind.Unspecified);
                                 }
                             }
                             break;

--- a/Ical.Net/Utility/DateUtil.cs
+++ b/Ical.Net/Utility/DateUtil.cs
@@ -19,7 +19,7 @@ internal static class DateUtil
         => dt.AddHours(-dt.Hour).AddMinutes(-dt.Minute).AddSeconds(-dt.Second);
 
     public static IDateTime EndOfDay(IDateTime dt)
-        => StartOfDay(dt).AddDays(1).AddTicks(-1);
+        => StartOfDay(dt).AddDays(1).AddSeconds(-1);
 
     public static DateTime GetSimpleDateTimeData(IDateTime dt)
         => dt.Value;


### PR DESCRIPTION
Increased `CalDateTime` immutability

CalDateTime:
* `Date` is of type `DateOnly` (breaking vs. v4)
* Make `UtzTzId` a public string
* Remove `DateOnlyValue`
* Remove `HasDate` (always true) (breaking vs. v4)
* Remove `Millisecond` (breaking vs. v4)
* Remove `Ticks` (breaking vs. v4)
* Remove overload CalDateTime(int year, int month, int day, string? tzId) (breaking vs. v4)
* `HasTime` only has a getter (breaking vs. v4)
* `Time` is a getter of type `TimeOnly`. Values are always rounded to the nearest second (breaking vs. v4)
* `AddMilliseconds` takes `double` as argument, like `DateTime.AddMilliseconds` (breaking vs. v4)
* Remove `TimeOnlyValue`
* `Value` only has a getter (breaking vs. v4)
* `TzId` only has a getter (breaking vs. v4)
* Remove `AsSystemLocal` (breaking vs. v4)
* Remove `AsDateTimeOffset` (breaking vs. v4)
* Remove `AddMilliseconds` (breaking vs. v4)
* Remove `AddTicks` (breaking vs. v4)
* Remove unused `TimeSpan? operator -(CalDateTime? left, IDateTime? right)` (breaking vs. v4)
* Update Equality operators for comparing to floating date/time (breaking vs. v4)

IDateTime (breaking vs. v4):
* Remove `AsSystemLocal` (breaking vs. v4)`
* Remove `AsDateTimeOffset` (breaking vs. v4)`
* Remove `AddMilliseconds` (breaking vs. v4)
* Remove `AddTicks` (breaking vs. v4)
* Remove `Millisecond` (breaking vs. v4)
* Remove `Ticks` (breaking vs. v4)
* Add explicit bool IsFloating (implicit TzId == null)
* `Date` is a getter of type `DateOnly`
* `Time` is a getter of type `TimeOnly`
* `HasTime` only has a getter
* Remove `HasDate` (always true) (breaking vs. v4)
* `Value` only has a getter
* `TzId` only has a getter
* `ToTimeZone(string?)` argument is a NRT

Miscellaneous:
* CTORs with `DateTime` arguments persist. Actually they are also comfortable, and now consistently processed
* Keep `IDateTime` - maybe in another PR
* Transitioned from DateTime to DateOnly and TimeOnly across the codebase for improved date and time handling.
* Updated methods, properties, and tests to ensure compatibility with the new approach.
* Updated xmldoc

Resolves #656
Resolves #662 