### PR TITLE
Let `GetOccurrences()` et al return an `IEnumerable` rather than `HashSet`.

### DIFF
--- a/Ical.Net.Tests/CollectionHelpersTests.cs
+++ b/Ical.Net.Tests/CollectionHelpersTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Ical.Net.DataTypes;
+using Ical.Net.Utility;
 using NUnit.Framework;
 
 namespace Ical.Net.Tests;
@@ -14,11 +15,7 @@ namespace Ical.Net.Tests;
 internal class CollectionHelpersTests
 {
     private static readonly DateTime _now = DateTime.UtcNow;
-    private static readonly DateTime _later = _now.AddHours(1);
-    private static readonly string _uid = Guid.NewGuid().ToString();
 
-    private static List<RecurrencePattern> GetSimpleRecurrenceList()
-        => new List<RecurrencePattern> { new RecurrencePattern(FrequencyType.Daily, 1) { Count = 5 } };
     private static List<PeriodList> GetExceptionDates()
         => new List<PeriodList> { new PeriodList { new Period(new CalDateTime(_now.AddDays(1).Date)) } };
 
@@ -36,5 +33,66 @@ internal class CollectionHelpersTests
         changedPeriod.First().First().StartTime = new CalDateTime(_now.AddHours(-1));
 
         Assert.That(changedPeriod, Is.Not.EqualTo(GetExceptionDates()));
+    }
+
+    [TestCase(new[] { 1, 3, 5, 7 }, new[] { 2, 4, 6 }, new[] { 1, 2, 3, 4, 5, 6, 7 })]
+    [TestCase(new int[] { }, new int[] { }, new int[] { })]
+    [TestCase(new int[] { }, new[] { 2, 4, 6 }, new[] { 2, 4, 6 })]
+    [TestCase(new[] { 2, 4, 6 }, new int[] { }, new[] { 2, 4, 6 })]
+    [TestCase(new[] { 3, 4 }, new int[] { 1, 2 }, new[] { 1, 2, 3, 4 })]
+    [TestCase(new[] { 1, 2, 3 }, new int[] { 2, 3, 4 }, new[] { 1, 2, 2, 3, 3, 4 })]
+    public void TestMerge(IList<int> seq1, IList<int> seq2, IList<int> expected)
+    {
+        var result = seq1.OrderedMerge(seq2).ToList();
+
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+    [TestCase(new int[] { }, new int[] { }, new int[] { })]
+    [TestCase(new int[] { }, new[] { 2, 4, 6 }, new int[] { })]
+    [TestCase(new[] { 2, 4, 6 }, new int[] { }, new[] { 2, 4, 6 })]
+    [TestCase(new[] { 1, 2, 3, 5, 6, 7 }, new[] { 2, 4, 6 }, new[] { 1, 3, 5, 7 })]
+    public void TestMergeExclude(IList<int> seq, IList<int> exclude, IList<int> expected)
+    {
+        var result = seq.OrderedExclude(exclude).ToList();
+
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+    private static IEnumerable<int> GetNaturalNumbers()
+    {
+        var i = 1;
+        while (true)
+            yield return i++;
+    }
+
+    [Test]
+    public void TestMergeIndefinite()
+    {
+        var result = GetNaturalNumbers().Select(x => x * 3).OrderedMerge(GetNaturalNumbers().Select(x => x * 2))
+            .Take(7);
+        Assert.That(result, Is.EqualTo(new[] { 2, 3, 4, 6, 6, 8, 9 }));
+    }
+
+    [Test]
+    public void TestMergeExcludeIndefinite()
+    {
+        var result = GetNaturalNumbers().Select(x => x * 3).OrderedExclude(GetNaturalNumbers().Select(x => x * 2))
+            .Take(4);
+        Assert.That(result, Is.EqualTo(new[] { 3, 9, 15, 21 }));
+    }
+
+    [Test]
+    public void TestMergeMulti()
+    {
+        var result = CollectionHelpers.OrderedMergeMany([[4], [2], [3], [1]], Comparer<int>.Default);
+        Assert.That(result, Is.EqualTo(new[] { 1, 2, 3, 4 }));
+    }
+
+    [Test]
+    public void TestOrderedDistinct()
+    {
+        var result = new[] { 1, 2, 2, 3 }.OrderedDistinct();
+        Assert.That(result, Is.EqualTo(new[] { 1, 2, 3 }));
     }
 }

--- a/Ical.Net.Tests/DeserializationTests.cs
+++ b/Ical.Net.Tests/DeserializationTests.cs
@@ -473,7 +473,7 @@ END:VCALENDAR
     public void Outlook2007_LineFolds1()
     {
         var iCal = Calendar.Load(IcsFiles.Outlook2007LineFolds);
-        var events = iCal.GetOccurrences(new CalDateTime(2009, 06, 20), new CalDateTime(2009, 06, 22));
+        var events = iCal.GetOccurrences(new CalDateTime(2009, 06, 20), new CalDateTime(2009, 06, 22)).ToList();
         Assert.That(events, Has.Count.EqualTo(1));
     }
 

--- a/Ical.Net.Tests/DocumentationExamples.cs
+++ b/Ical.Net.Tests/DocumentationExamples.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
 using NUnit.Framework;
@@ -39,7 +40,7 @@ public class DocumentationExamples
         // July 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
         var searchStart = DateTime.Parse("2016-07-20");
         var searchEnd = DateTime.Parse("2016-08-05");
-        var occurrences = calendar.GetOccurrences(searchStart, searchEnd);
+        var occurrences = calendar.GetOccurrences(searchStart, searchEnd).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(12));
     }
 
@@ -64,7 +65,7 @@ public class DocumentationExamples
         // The first Tuesday is July 5. There should be 13 in total
         var searchStart = DateTime.Parse("2010-01-01");
         var searchEnd = DateTime.Parse("2016-12-31");
-        var tuesdays = vEvent.GetOccurrences(searchStart, searchEnd);
+        var tuesdays = vEvent.GetOccurrences(searchStart, searchEnd).ToList();
 
         Assert.That(tuesdays, Has.Count.EqualTo(13));
     }
@@ -93,7 +94,7 @@ public class DocumentationExamples
 
         var searchStart = DateTime.Parse("2000-01-01");
         var searchEnd = DateTime.Parse("2017-01-01");
-        var usThanksgivings = vEvent.GetOccurrences(searchStart, searchEnd);
+        var usThanksgivings = vEvent.GetOccurrences(searchStart, searchEnd).ToList();
 
         Assert.That(usThanksgivings, Has.Count.EqualTo(17));
         foreach (var thanksgiving in usThanksgivings)
@@ -126,7 +127,7 @@ public class DocumentationExamples
         // We are essentially counting all the days that aren't Sunday in 2016, so there should be 314
         var searchStart = DateTime.Parse("2015-12-31");
         var searchEnd = DateTime.Parse("2017-01-01");
-        var occurrences = calendar.GetOccurrences(searchStart, searchEnd);
+        var occurrences = calendar.GetOccurrences(searchStart, searchEnd).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(314));
     }
 }

--- a/Ical.Net.Tests/GetOccurrenceTests.cs
+++ b/Ical.Net.Tests/GetOccurrenceTests.cs
@@ -145,7 +145,7 @@ END:VCALENDAR";
 
         var calendar = GetCalendars(ical);
         var date = new DateTime(2016, 10, 11);
-        var occurrences = calendar.GetOccurrences(date);
+        var occurrences = calendar.GetOccurrences(date).ToList();
 
         //We really want to make sure this doesn't explode
         Assert.That(occurrences, Has.Count.EqualTo(1));
@@ -209,9 +209,7 @@ END:VCALENDAR";
 
         var collection = Calendar.Load(ical);
         var startCheck = new DateTime(2016, 11, 11);
-        var occurrences = collection.GetOccurrences<CalendarEvent>(startCheck, startCheck.AddMonths(1))
-            .OrderBy(x => x)
-            .ToList();
+        var occurrences = collection.GetOccurrences<CalendarEvent>(startCheck, startCheck.AddMonths(1)).ToList();
 
         CalDateTime[] expectedStartDates = [
             new CalDateTime("20161114T000100", "W. Europe Standard Time"),
@@ -227,7 +225,6 @@ END:VCALENDAR";
         // Specify end time that is between the original occurrence ta 20161128T0001 and the overridden one at 20161128T0030.
         // The overridden one shouldn't be returned, because it was replaced and the other one is in the future.
         var occurrences2 = collection.GetOccurrences<CalendarEvent>(new CalDateTime(startCheck), new CalDateTime("20161128T002000", "W. Europe Standard Time"))
-            .OrderBy(x => x)
             .ToList();
 
         Assert.Multiple(() =>
@@ -267,11 +264,9 @@ END:VCALENDAR";
         var collection = Calendar.Load(ical);
         var startCheck = new DateTime(2023, 10, 1);
         var occurrences = collection.GetOccurrences<CalendarEvent>(startCheck, startCheck.AddMonths(1))
-            .OrderBy(x => x)
             .ToList();
 
         var occurrences2 = collection.GetOccurrences<CalendarEvent>(new CalDateTime(startCheck), new CalDateTime(2023, 12, 31))
-            .OrderBy(x => x)
             .ToList();
 
         CalDateTime[] expectedStartDates = [

--- a/Ical.Net.Tests/GetOccurrenceTests.cs
+++ b/Ical.Net.Tests/GetOccurrenceTests.cs
@@ -145,7 +145,7 @@ END:VCALENDAR";
 
         var calendar = GetCalendars(ical);
         var date = new DateTime(2016, 10, 11);
-        var occurrences = calendar.GetOccurrencesOfDay(date).ToList();
+        var occurrences = calendar.GetOccurrences(date, date.AddDays(1)).ToList();
 
         //We really want to make sure this doesn't explode
         Assert.That(occurrences, Has.Count.EqualTo(1));

--- a/Ical.Net.Tests/GetOccurrenceTests.cs
+++ b/Ical.Net.Tests/GetOccurrenceTests.cs
@@ -145,7 +145,7 @@ END:VCALENDAR";
 
         var calendar = GetCalendars(ical);
         var date = new DateTime(2016, 10, 11);
-        var occurrences = calendar.GetOccurrences(date).ToList();
+        var occurrences = calendar.GetOccurrencesOfDay(date).ToList();
 
         //We really want to make sure this doesn't explode
         Assert.That(occurrences, Has.Count.EqualTo(1));

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -3810,4 +3810,31 @@ END:VCALENDAR
 
         Assert.That(occurrences, Is.Empty);
     }
+
+    [Test]
+    public void TestGetOccurrenceIndefinite()
+    {
+        var ical = """
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            BEGIN:VEVENT
+            DTSTART:20241130
+            RRULE:FREQ=DAILY;BYDAY=MO,TU,WE,TH,FR,SA
+            EXRULE:FREQ=DAILY;INTERVAL=3
+            RDATE:20241201
+            EXDATE:20241202
+            END:VEVENT
+            END:VCALENDAR
+            """;
+
+        var calendar = Calendar.Load(ical);
+
+        // Although the occurrences are unbounded, we can still call GetOccurrences without
+        // specifying bounds, because the instances are only generated on enumeration.
+        var occurrences = calendar.GetOccurrences();
+
+        var instances = occurrences.Take(100).ToList();
+
+        Assert.That(instances.Count(), Is.EqualTo(100));
+    }
 }

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -3806,7 +3806,7 @@ END:VCALENDAR
 
         var calendar = Calendar.Load(ical);
         // Set start date for occurrences to search to the end date of the event
-        var occurrences = calendar.GetOccurrencesOfDay(new CalDateTime(2024, 12, 2));
+        var occurrences = calendar.GetOccurrences(new CalDateTime(2024, 12, 2), new CalDateTime(2024, 12, 3));
 
         Assert.That(occurrences, Is.Empty);
     }

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -3806,7 +3806,7 @@ END:VCALENDAR
 
         var calendar = Calendar.Load(ical);
         // Set start date for occurrences to search to the end date of the event
-        var occurrences = calendar.GetOccurrences(new CalDateTime(2024, 12, 2));
+        var occurrences = calendar.GetOccurrencesOfDay(new CalDateTime(2024, 12, 2));
 
         Assert.That(occurrences, Is.Empty);
     }

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -1198,8 +1198,8 @@ public class RecurrenceTests
         var rpe1 = new RecurrencePatternEvaluator(new RecurrencePattern("FREQ=YEARLY;WKST=MO;BYDAY=MO;BYWEEKNO=1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53"));
         var rpe2 = new RecurrencePatternEvaluator(new RecurrencePattern("FREQ=YEARLY;WKST=MO;BYDAY=MO;BYWEEKNO=53,51,49,47,45,43,41,39,37,35,33,31,29,27,25,23,21,19,17,15,13,11,9,7,5,3,1"));
 
-        var recurringPeriods1 = rpe1.Evaluate(new CalDateTime(start), start, end, false);
-        var recurringPeriods2 = rpe2.Evaluate(new CalDateTime(start), start, end, false);
+        var recurringPeriods1 = rpe1.Evaluate(new CalDateTime(start), start, end, false).ToList();
+        var recurringPeriods2 = rpe2.Evaluate(new CalDateTime(start), start, end, false).ToList();
 
         Assert.That(recurringPeriods2, Has.Count.EqualTo(recurringPeriods1.Count));
     }
@@ -2507,7 +2507,7 @@ public class RecurrenceTests
         var end = new DateTime(2019, 12, 31);
         var rpe = new RecurrencePatternEvaluator(new RecurrencePattern("FREQ=WEEKLY;BYDAY=MO;BYWEEKNO=2"));
 
-        var recurringPeriods = rpe.Evaluate(new CalDateTime(start, false), start, end, false);
+        var recurringPeriods = rpe.Evaluate(new CalDateTime(start, false), start, end, false).ToList();
 
         Assert.That(recurringPeriods, Has.Count.EqualTo(1));
         Assert.That(recurringPeriods.First().StartTime, Is.EqualTo(new CalDateTime(2019, 1, 7)));
@@ -2552,7 +2552,7 @@ public class RecurrenceTests
 
         evt.RecurrenceRules.Add(pattern);
 
-        var occurrences = evt.GetOccurrences(new DateTime(2018, 1, 1), DateTime.MaxValue);
+        var occurrences = evt.GetOccurrences(new DateTime(2018, 1, 1), DateTime.MaxValue).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(10), "There should be 10 occurrences of this event.");
     }
 
@@ -2591,7 +2591,7 @@ public class RecurrenceTests
             var serializer = new RecurrencePatternSerializer();
             var rp = (RecurrencePattern)serializer.Deserialize(sr);
             var rpe = new RecurrencePatternEvaluator(rp);
-            var recurringPeriods = rpe.Evaluate(new CalDateTime(start), start, rp.Until, false);
+            var recurringPeriods = rpe.Evaluate(new CalDateTime(start), start, rp.Until, false).ToList();
 
             var period = recurringPeriods.ElementAt(recurringPeriods.Count - 1);
 
@@ -2623,7 +2623,7 @@ public class RecurrenceTests
 
         evt.RecurrenceRules.Add(pattern);
 
-        var occurrences = evt.GetOccurrences(new DateTime(2011, 1, 1), new DateTime(2012, 1, 1));
+        var occurrences = evt.GetOccurrences(new DateTime(2011, 1, 1), new DateTime(2012, 1, 1)).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(10), "There should be 10 occurrences of this event, one for each month except February and December.");
     }
 
@@ -2669,19 +2669,19 @@ public class RecurrenceTests
             var checkTime = DateTime.Parse("2019-01-04T08:00Z");
             checkTime = checkTime.AddDays(i);
             //Valid asking for the exact moment
-            var occurrences = vEvent.GetOccurrences(checkTime, checkTime);
+            var occurrences = vEvent.GetOccurrences(checkTime, checkTime).ToList();
             Assert.That(occurrences, Has.Count.EqualTo(1));
 
             //Valid if asking for a range starting at the same moment
-            occurrences = vEvent.GetOccurrences(checkTime, checkTime.AddSeconds(1));
+            occurrences = vEvent.GetOccurrences(checkTime, checkTime.AddSeconds(1)).ToList();
             Assert.That(occurrences, Has.Count.EqualTo(1));
 
             //Valid if asking for a range starting before and ending after
-            occurrences = vEvent.GetOccurrences(checkTime.AddSeconds(-1), checkTime.AddSeconds(1));
+            occurrences = vEvent.GetOccurrences(checkTime.AddSeconds(-1), checkTime.AddSeconds(1)).ToList();
             Assert.That(occurrences, Has.Count.EqualTo(1));
 
             //Not valid if asking for a range starting before but ending at the same moment
-            occurrences = vEvent.GetOccurrences(checkTime.AddSeconds(-1), checkTime);
+            occurrences = vEvent.GetOccurrences(checkTime.AddSeconds(-1), checkTime).ToList();
             Assert.That(occurrences.Count, Is.EqualTo(0));
         }
     }
@@ -2740,7 +2740,8 @@ public class RecurrenceTests
 
         var occurrences = iCal.GetOccurrences(
             new CalDateTime(2006, 1, 1),
-            new CalDateTime(2006, 12, 31));
+            new CalDateTime(2006, 12, 31))
+            .ToList();
 
         Assert.That(occurrences, Has.Count.EqualTo(items.Count), "The number of holidays did not evaluate correctly.");
         foreach (var o in occurrences)
@@ -2875,32 +2876,32 @@ public class RecurrenceTests
         var laterDateAndTime = new CalDateTime(2009, 11, 19, 11, 0, 0);
         var end = new CalDateTime(2009, 11, 23, 0, 0, 0);
 
-        var occurrences = evt.GetOccurrences(previousDateAndTime, end);
+        var occurrences = evt.GetOccurrences(previousDateAndTime, end).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(5));
 
-        occurrences = evt.GetOccurrences(previousDateOnly, end);
+        occurrences = evt.GetOccurrences(previousDateOnly, end).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(5));
 
-        occurrences = evt.GetOccurrences(laterDateOnly, end);
+        occurrences = evt.GetOccurrences(laterDateOnly, end).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(4));
 
-        occurrences = evt.GetOccurrences(laterDateAndTime, end);
+        occurrences = evt.GetOccurrences(laterDateAndTime, end).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(3));
 
         // Add ByHour "9" and "12"            
         evt.RecurrenceRules[0].ByHour.Add(9);
         evt.RecurrenceRules[0].ByHour.Add(12);
 
-        occurrences = evt.GetOccurrences(previousDateAndTime, end);
+        occurrences = evt.GetOccurrences(previousDateAndTime, end).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(10));
 
-        occurrences = evt.GetOccurrences(previousDateOnly, end);
+        occurrences = evt.GetOccurrences(previousDateOnly, end).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(10));
 
-        occurrences = evt.GetOccurrences(laterDateOnly, end);
+        occurrences = evt.GetOccurrences(laterDateOnly, end).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(8));
 
-        occurrences = evt.GetOccurrences(laterDateAndTime, end);
+        occurrences = evt.GetOccurrences(laterDateAndTime, end).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(7));
     }
 
@@ -3214,21 +3215,21 @@ END:VCALENDAR";
         var searchStart = _now.AddDays(-1);
         var searchEnd = _now.AddDays(7);
         var e = GetEventWithRecurrenceRules();
-        var occurrences = e.GetOccurrences(searchStart, searchEnd);
+        var occurrences = e.GetOccurrences(searchStart, searchEnd).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(5));
 
         var exDate = _now.AddDays(1);
         var period = new Period(new CalDateTime(exDate, false));
         var periodList = new PeriodList { period };
         e.ExceptionDates.Add(periodList);
-        occurrences = e.GetOccurrences(searchStart, searchEnd);
+        occurrences = e.GetOccurrences(searchStart, searchEnd).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(4));
 
         //Specifying just a date should "black out" that date
         var excludeTwoDaysFromNow = _now.AddDays(2).Date;
         period = new Period(new CalDateTime(excludeTwoDaysFromNow, false));
         periodList.Add(period);
-        occurrences = e.GetOccurrences(searchStart, searchEnd);
+        occurrences = e.GetOccurrences(searchStart, searchEnd).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(3));
     }
 
@@ -3319,7 +3320,7 @@ END:VCALENDAR";
             checkTime = checkTime.AddDays(i);
 
             //Valid if asking for a range starting at the same moment
-            var occurrences = vEvent.GetOccurrences(checkTime, checkTime.AddDays(1));
+            var occurrences = vEvent.GetOccurrences(checkTime, checkTime.AddDays(1)).ToList();
             Assert.That(occurrences, Has.Count.EqualTo(i == 0 ? 1 : 0));
         }
     }
@@ -3342,19 +3343,19 @@ END:VCALENDAR";
         // Exactly on start time
         var testingTime = new DateTime(2019, 6, 7, 9, 0, 0);
 
-        var occurrences = vEvent.GetOccurrences(testingTime, testingTime);
+        var occurrences = vEvent.GetOccurrences(testingTime, testingTime).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(1));
 
         // One second before end time
         testingTime = new DateTime(2019, 6, 7, 16, 59, 59);
 
-        occurrences = vEvent.GetOccurrences(testingTime, testingTime);
+        occurrences = vEvent.GetOccurrences(testingTime, testingTime).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(1));
 
         // Exactly on end time
         testingTime = new DateTime(2019, 6, 7, 17, 0, 0);
 
-        occurrences = vEvent.GetOccurrences(testingTime, testingTime);
+        occurrences = vEvent.GetOccurrences(testingTime, testingTime).ToList();
         Assert.That(occurrences.Count, Is.EqualTo(0));
     }
 
@@ -3611,7 +3612,7 @@ END:VCALENDAR
         var startSearch = new CalDateTime(DateTime.Parse("2017-07-01T00:00:00"), timeZoneId);
         var endSearch = new CalDateTime(DateTime.Parse("2018-07-01T00:00:00"), timeZoneId);
 
-        var occurrences = firstEvent.GetOccurrences(startSearch, endSearch);
+        var occurrences = firstEvent.GetOccurrences(startSearch, endSearch).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(5));
     }
 

--- a/Ical.Net.Tests/SimpleDeserializationTests.cs
+++ b/Ical.Net.Tests/SimpleDeserializationTests.cs
@@ -506,7 +506,7 @@ END:VCALENDAR
     public void Outlook2007_LineFolds1()
     {
         var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Outlook2007LineFolds)).Cast<Calendar>().Single();
-        var events = iCal.GetOccurrences(new CalDateTime(2009, 06, 20), new CalDateTime(2009, 06, 22));
+        var events = iCal.GetOccurrences(new CalDateTime(2009, 06, 20), new CalDateTime(2009, 06, 22)).ToList();
         Assert.That(events, Has.Count.EqualTo(1));
     }
 

--- a/Ical.Net/Calendar.cs
+++ b/Ical.Net/Calendar.cs
@@ -204,13 +204,13 @@ public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, I
     /// </summary>
     /// <param name="dt">The date for which to return occurrences. Time is ignored on this parameter.</param>
     /// <returns>A list of occurrences that occur on the given date (<paramref name="dt"/>).</returns>
-    public virtual IEnumerable<Occurrence> GetOccurrences(IDateTime dt)
+    public virtual IEnumerable<Occurrence> GetOccurrencesOfDay(IDateTime dt)
     {
         return GetOccurrences<IRecurringComponent>(new CalDateTime(dt.Date), new CalDateTime(dt.Date.AddDays(1)));
     }
 
-    /// <inheritdoc cref="GetOccurrences(IDateTime)"/>
-    public virtual IEnumerable<Occurrence> GetOccurrences(DateTime dt)
+    /// <inheritdoc cref="GetOccurrencesOfDay(IDateTime)"/>
+    public virtual IEnumerable<Occurrence> GetOccurrencesOfDay(DateTime dt)
     {
         return GetOccurrences<IRecurringComponent>(new CalDateTime(DateOnly.FromDateTime(dt)), new CalDateTime(DateOnly.FromDateTime(dt.Date.AddDays(1))));
     }
@@ -246,7 +246,7 @@ public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, I
         return GetOccurrences<T>(new CalDateTime(dt.Date), new CalDateTime(dt.Date.AddDays(1)));
     }
 
-    /// <inheritdoc cref="GetOccurrences(IDateTime)"/>
+    /// <inheritdoc cref="GetOccurrencesOfDay(IDateTime)"/>
     public virtual IEnumerable<Occurrence> GetOccurrences<T>(DateTime dt) where T : IRecurringComponent
     {
         return GetOccurrences<T>(new CalDateTime(DateOnly.FromDateTime(dt)), new CalDateTime(DateOnly.FromDateTime(dt.Date.AddDays(1))));

--- a/Ical.Net/Calendar.cs
+++ b/Ical.Net/Calendar.cs
@@ -222,12 +222,12 @@ public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, I
     /// <param name="startTime">The beginning date/time of the range.</param>
     /// <param name="endTime">The end date/time of the range.</param>
     /// <returns>A list of occurrences that fall between the date/time arguments provided.</returns>
-    public virtual IEnumerable<Occurrence> GetOccurrences(IDateTime startTime, IDateTime endTime)
+    public virtual IEnumerable<Occurrence> GetOccurrences(IDateTime startTime = null, IDateTime endTime = null)
         => GetOccurrences<IRecurringComponent>(startTime, endTime);
 
     /// <inheritdoc cref="GetOccurrences(IDateTime, IDateTime)"/>
-    public virtual IEnumerable<Occurrence> GetOccurrences(DateTime startTime, DateTime endTime)
-        => GetOccurrences<IRecurringComponent>(new CalDateTime(DateOnly.FromDateTime(startTime), TimeOnly.FromDateTime(startTime)), new CalDateTime(DateOnly.FromDateTime(endTime), TimeOnly.FromDateTime(endTime)));
+    public virtual IEnumerable<Occurrence> GetOccurrences(DateTime? startTime, DateTime? endTime)
+        => GetOccurrences<IRecurringComponent>(startTime?.AsCalDateTime(), endTime?.AsCalDateTime());
 
     /// <summary>
     /// Returns all occurrences of components of type T that start on the date provided.
@@ -253,8 +253,8 @@ public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, I
     }
 
     /// <inheritdoc cref="GetOccurrences(IDateTime, IDateTime)"/>
-    public virtual IEnumerable<Occurrence> GetOccurrences<T>(DateTime startTime, DateTime endTime) where T : IRecurringComponent
-        => GetOccurrences<T>(new CalDateTime(startTime), new CalDateTime(endTime));
+    public virtual IEnumerable<Occurrence> GetOccurrences<T>(DateTime? startTime, DateTime? endTime) where T : IRecurringComponent
+        => GetOccurrences<T>(startTime?.AsCalDateTime(), endTime?.AsCalDateTime());
 
     /// <summary>
     /// Returns all occurrences of components of type T that start within the date range provided.
@@ -263,7 +263,7 @@ public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, I
     /// </summary>
     /// <param name="startTime">The starting date range</param>
     /// <param name="endTime">The ending date range</param>
-    public virtual IEnumerable<Occurrence> GetOccurrences<T>(IDateTime startTime, IDateTime endTime) where T : IRecurringComponent
+    public virtual IEnumerable<Occurrence> GetOccurrences<T>(IDateTime startTime = null, IDateTime endTime = null) where T : IRecurringComponent
     {
         // These are the UID/RECURRENCE-ID combinations that replace other occurrences.
         var recurrenceIdsAndUids = this.Children.OfType<IRecurrable>()

--- a/Ical.Net/Calendar.cs
+++ b/Ical.Net/Calendar.cs
@@ -238,7 +238,7 @@ public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, I
             // Enumerate the list of occurrences (not the occurrences themselves) now to ensure
             // the initialization code is run, including validation and error handling.
             // This way we receive validation errors early, not only when enumeration starts.
-            .ToList()
+            .ToList() //NOSONAR - deliberately enumerate here
 
             // Merge the individual sequences into a single one. Take advantage of them
             // being ordered to avoid full enumeration.

--- a/Ical.Net/Calendar.cs
+++ b/Ical.Net/Calendar.cs
@@ -197,24 +197,6 @@ public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, I
         return tz;
     }
 
-
-    /// <summary>
-    /// Returns a list of occurrences of each recurring component
-    /// for the date provided (<paramref name="dt"/>).
-    /// </summary>
-    /// <param name="dt">The date for which to return occurrences. Time is ignored on this parameter.</param>
-    /// <returns>A list of occurrences that occur on the given date (<paramref name="dt"/>).</returns>
-    public virtual IEnumerable<Occurrence> GetOccurrencesOfDay(IDateTime dt)
-    {
-        return GetOccurrences<IRecurringComponent>(new CalDateTime(dt.Date), new CalDateTime(dt.Date.AddDays(1)));
-    }
-
-    /// <inheritdoc cref="GetOccurrencesOfDay(IDateTime)"/>
-    public virtual IEnumerable<Occurrence> GetOccurrencesOfDay(DateTime dt)
-    {
-        return GetOccurrences<IRecurringComponent>(new CalDateTime(DateOnly.FromDateTime(dt)), new CalDateTime(DateOnly.FromDateTime(dt.Date.AddDays(1))));
-    }
-
     /// <summary>
     /// Returns a list of occurrences of each recurring component
     /// that occur between <paramref name="startTime"/> and <paramref name="endTime"/>.
@@ -228,29 +210,6 @@ public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, I
     /// <inheritdoc cref="GetOccurrences(IDateTime, IDateTime)"/>
     public virtual IEnumerable<Occurrence> GetOccurrences(DateTime? startTime, DateTime? endTime)
         => GetOccurrences<IRecurringComponent>(startTime?.AsCalDateTime(), endTime?.AsCalDateTime());
-
-    /// <summary>
-    /// Returns all occurrences of components of type T that start on the date provided.
-    /// All components starting between 12:00:00AM and 11:59:59 PM will be
-    /// returned.
-    /// <note>
-    /// This will first Evaluate() the date range required in order to
-    /// determine the occurrences for the date provided, and then return
-    /// the occurrences.
-    /// </note>
-    /// </summary>
-    /// <param name="dt">The date for which to return occurrences. Time is ignored on this parameter.</param>
-    /// <returns>A list of Periods representing the occurrences of this object.</returns>
-    public virtual IEnumerable<Occurrence> GetOccurrences<T>(IDateTime dt) where T : IRecurringComponent
-    {
-        return GetOccurrences<T>(new CalDateTime(dt.Date), new CalDateTime(dt.Date.AddDays(1)));
-    }
-
-    /// <inheritdoc cref="GetOccurrencesOfDay(IDateTime)"/>
-    public virtual IEnumerable<Occurrence> GetOccurrences<T>(DateTime dt) where T : IRecurringComponent
-    {
-        return GetOccurrences<T>(new CalDateTime(DateOnly.FromDateTime(dt)), new CalDateTime(DateOnly.FromDateTime(dt.Date.AddDays(1))));
-    }
 
     /// <inheritdoc cref="GetOccurrences(IDateTime, IDateTime)"/>
     public virtual IEnumerable<Occurrence> GetOccurrences<T>(DateTime? startTime, DateTime? endTime) where T : IRecurringComponent

--- a/Ical.Net/CalendarCollection.cs
+++ b/Ical.Net/CalendarCollection.cs
@@ -49,7 +49,7 @@ public class CalendarCollection : List<Calendar>
         // Enumerate the list of occurrences (not the occurrences themselves) now to ensure
         // the initialization code is run, including validation and error handling.
         // This way we receive validation errors early, not only when enumeration starts.
-        .ToArray()
+        .ToArray() //NOSONAR - deliberately enumerate here
 
         // Merge the individual sequences into a single one. Take advantage of them
         // being ordered to avoid full enumeration.

--- a/Ical.Net/CalendarCollection.cs
+++ b/Ical.Net/CalendarCollection.cs
@@ -55,13 +55,13 @@ public class CalendarCollection : List<Calendar>
         // being ordered to avoid full enumeration.
         .OrderedMergeMany();
 
-    public IEnumerable<Occurrence> GetOccurrences(IDateTime startTime, IDateTime endTime)
+    public IEnumerable<Occurrence> GetOccurrences(IDateTime startTime = null, IDateTime endTime = null)
         => GetOccurrences(iCal => iCal.GetOccurrences(startTime, endTime));
 
     public IEnumerable<Occurrence> GetOccurrences(DateTime? startTime, DateTime? endTime)
         => GetOccurrences(iCal => iCal.GetOccurrences(startTime, endTime));
 
-    public IEnumerable<Occurrence> GetOccurrences<T>(IDateTime startTime, IDateTime endTime) where T : IRecurringComponent
+    public IEnumerable<Occurrence> GetOccurrences<T>(IDateTime startTime = null, IDateTime endTime = null) where T : IRecurringComponent
         => GetOccurrences(iCal => iCal.GetOccurrences<T>(startTime, endTime));
 
     public IEnumerable<Occurrence> GetOccurrences<T>(DateTime? startTime, DateTime? endTime) where T : IRecurringComponent

--- a/Ical.Net/CalendarCollection.cs
+++ b/Ical.Net/CalendarCollection.cs
@@ -39,16 +39,6 @@ public class CalendarCollection : List<Calendar>
         return collection;
     }
 
-    public HashSet<Occurrence> GetOccurrencesOfDay(IDateTime dt)
-    {
-        var occurrences = new HashSet<Occurrence>();
-        foreach (var iCal in this)
-        {
-            occurrences.UnionWith(iCal.GetOccurrencesOfDay(dt));
-        }
-        return occurrences;
-    }
-
     private IEnumerable<Occurrence> GetOccurrences(Func<Calendar, IEnumerable<Occurrence>> f)
         =>
 
@@ -65,20 +55,11 @@ public class CalendarCollection : List<Calendar>
         // being ordered to avoid full enumeration.
         .OrderedMergeMany();
 
-    public IEnumerable<Occurrence> GetOccurrencesOfDay(DateTime dt)
-        => GetOccurrences(iCal => iCal.GetOccurrencesOfDay(dt));
-
     public IEnumerable<Occurrence> GetOccurrences(IDateTime startTime, IDateTime endTime)
         => GetOccurrences(iCal => iCal.GetOccurrences(startTime, endTime));
 
     public IEnumerable<Occurrence> GetOccurrences(DateTime? startTime, DateTime? endTime)
         => GetOccurrences(iCal => iCal.GetOccurrences(startTime, endTime));
-
-    public IEnumerable<Occurrence> GetOccurrences<T>(IDateTime dt) where T : IRecurringComponent
-        => GetOccurrences(iCal => iCal.GetOccurrencesOfDay(dt));
-
-    public IEnumerable<Occurrence> GetOccurrences<T>(DateTime dt) where T : IRecurringComponent
-        => GetOccurrences(iCal => iCal.GetOccurrences<T>(dt));
 
     public IEnumerable<Occurrence> GetOccurrences<T>(IDateTime startTime, IDateTime endTime) where T : IRecurringComponent
         => GetOccurrences(iCal => iCal.GetOccurrences<T>(startTime, endTime));

--- a/Ical.Net/CalendarCollection.cs
+++ b/Ical.Net/CalendarCollection.cs
@@ -49,47 +49,42 @@ public class CalendarCollection : List<Calendar>
         return occurrences;
     }
 
-    public IEnumerable<Occurrence> GetOccurrencesOfDay(DateTime dt)
-        => this
-        .Select(iCal => iCal.GetOccurrencesOfDay(dt))
+    private IEnumerable<Occurrence> GetOccurrences(Func<Calendar, IEnumerable<Occurrence>> f)
+        =>
+
+        // Get the sequence of occurrences for each calendar in the collection,
+        // which will result in a sequence of sequences of occurrences.
+        this.Select(f)
+
+        // Enumerate the list of occurrences (not the occurrences themselves) now to ensure
+        // the initialization code is run, including validation and error handling.
+        // This way we receive validation errors early, not only when enumeration starts.
         .ToArray()
+
+        // Merge the individual sequences into a single one. Take advantage of them
+        // being ordered to avoid full enumeration.
         .OrderedMergeMany();
+
+    public IEnumerable<Occurrence> GetOccurrencesOfDay(DateTime dt)
+        => GetOccurrences(iCal => iCal.GetOccurrencesOfDay(dt));
 
     public IEnumerable<Occurrence> GetOccurrences(IDateTime startTime, IDateTime endTime)
-        => this
-        .Select(iCal => iCal.GetOccurrences(startTime, endTime))
-        .ToArray()
-        .OrderedMergeMany();
+        => GetOccurrences(iCal => iCal.GetOccurrences(startTime, endTime));
 
     public IEnumerable<Occurrence> GetOccurrences(DateTime? startTime, DateTime? endTime)
-        => this
-        .Select(iCal => iCal.GetOccurrences(startTime, endTime))
-        .ToArray()
-        .OrderedMergeMany();
+        => GetOccurrences(iCal => iCal.GetOccurrences(startTime, endTime));
 
     public IEnumerable<Occurrence> GetOccurrences<T>(IDateTime dt) where T : IRecurringComponent
-        => this
-        .Select(iCal => iCal.GetOccurrencesOfDay(dt))
-        .ToArray()
-        .OrderedMergeMany();
+        => GetOccurrences(iCal => iCal.GetOccurrencesOfDay(dt));
 
     public IEnumerable<Occurrence> GetOccurrences<T>(DateTime dt) where T : IRecurringComponent
-        => this
-        .Select(iCal => iCal.GetOccurrences<T>(dt))
-        .ToArray()
-        .OrderedMergeMany();
+        => GetOccurrences(iCal => iCal.GetOccurrences<T>(dt));
 
     public IEnumerable<Occurrence> GetOccurrences<T>(IDateTime startTime, IDateTime endTime) where T : IRecurringComponent
-        => this
-        .Select(iCal => iCal.GetOccurrences<T>(startTime, endTime))
-        .ToArray()
-        .OrderedMergeMany();
+        => GetOccurrences(iCal => iCal.GetOccurrences<T>(startTime, endTime));
 
     public IEnumerable<Occurrence> GetOccurrences<T>(DateTime? startTime, DateTime? endTime) where T : IRecurringComponent
-        => this
-        .Select(iCal => iCal.GetOccurrences<T>(startTime, endTime))
-        .ToArray()
-        .OrderedMergeMany();
+        => GetOccurrences(iCal => iCal.GetOccurrences<T>(startTime, endTime));
 
     private FreeBusy CombineFreeBusy(FreeBusy main, FreeBusy current)
     {

--- a/Ical.Net/CalendarCollection.cs
+++ b/Ical.Net/CalendarCollection.cs
@@ -61,7 +61,7 @@ public class CalendarCollection : List<Calendar>
         .ToArray()
         .OrderedMergeMany();
 
-    public IEnumerable<Occurrence> GetOccurrences(DateTime startTime, DateTime endTime)
+    public IEnumerable<Occurrence> GetOccurrences(DateTime? startTime, DateTime? endTime)
         => this
         .Select(iCal => iCal.GetOccurrences(startTime, endTime))
         .ToArray()
@@ -85,7 +85,7 @@ public class CalendarCollection : List<Calendar>
         .ToArray()
         .OrderedMergeMany();
 
-    public IEnumerable<Occurrence> GetOccurrences<T>(DateTime startTime, DateTime endTime) where T : IRecurringComponent
+    public IEnumerable<Occurrence> GetOccurrences<T>(DateTime? startTime, DateTime? endTime) where T : IRecurringComponent
         => this
         .Select(iCal => iCal.GetOccurrences<T>(startTime, endTime))
         .ToArray()

--- a/Ical.Net/CalendarCollection.cs
+++ b/Ical.Net/CalendarCollection.cs
@@ -49,75 +49,47 @@ public class CalendarCollection : List<Calendar>
         return occurrences;
     }
 
-    public HashSet<Occurrence> GetOccurrences(DateTime dt)
-    {
-        var occurrences = new HashSet<Occurrence>();
-        foreach (var iCal in this)
-        {
-            occurrences.UnionWith(iCal.GetOccurrences(dt));
-        }
-        return occurrences;
-    }
+    public IEnumerable<Occurrence> GetOccurrences(DateTime dt)
+        => this
+        .Select(iCal => iCal.GetOccurrences(dt))
+        .ToArray()
+        .OrderedMergeMany();
 
-    public HashSet<Occurrence> GetOccurrences(IDateTime startTime, IDateTime endTime)
-    {
-        var occurrences = new HashSet<Occurrence>();
-        foreach (var iCal in this)
-        {
-            occurrences.UnionWith(iCal.GetOccurrences(startTime, endTime));
-        }
-        return occurrences;
-    }
+    public IEnumerable<Occurrence> GetOccurrences(IDateTime startTime, IDateTime endTime)
+        => this
+        .Select(iCal => iCal.GetOccurrences(startTime, endTime))
+        .ToArray()
+        .OrderedMergeMany();
 
-    public HashSet<Occurrence> GetOccurrences(DateTime startTime, DateTime endTime)
-    {
-        var occurrences = new HashSet<Occurrence>();
-        foreach (var iCal in this)
-        {
-            occurrences.UnionWith(iCal.GetOccurrences(startTime, endTime));
-        }
-        return occurrences;
-    }
+    public IEnumerable<Occurrence> GetOccurrences(DateTime startTime, DateTime endTime)
+        => this
+        .Select(iCal => iCal.GetOccurrences(startTime, endTime))
+        .ToArray()
+        .OrderedMergeMany();
 
-    public HashSet<Occurrence> GetOccurrences<T>(IDateTime dt) where T : IRecurringComponent
-    {
-        var occurrences = new HashSet<Occurrence>();
-        foreach (var iCal in this)
-        {
-            occurrences.UnionWith(iCal.GetOccurrences<T>(dt));
-        }
-        return occurrences;
-    }
+    public IEnumerable<Occurrence> GetOccurrences<T>(IDateTime dt) where T : IRecurringComponent
+        => this
+        .Select(iCal => iCal.GetOccurrences(dt))
+        .ToArray()
+        .OrderedMergeMany();
 
-    public HashSet<Occurrence> GetOccurrences<T>(DateTime dt) where T : IRecurringComponent
-    {
-        var occurrences = new HashSet<Occurrence>();
-        foreach (var iCal in this)
-        {
-            occurrences.UnionWith(iCal.GetOccurrences<T>(dt));
-        }
-        return occurrences;
-    }
+    public IEnumerable<Occurrence> GetOccurrences<T>(DateTime dt) where T : IRecurringComponent
+        => this
+        .Select(iCal => iCal.GetOccurrences<T>(dt))
+        .ToArray()
+        .OrderedMergeMany();
 
-    public HashSet<Occurrence> GetOccurrences<T>(IDateTime startTime, IDateTime endTime) where T : IRecurringComponent
-    {
-        var occurrences = new HashSet<Occurrence>();
-        foreach (var iCal in this)
-        {
-            occurrences.UnionWith(iCal.GetOccurrences<T>(startTime, endTime));
-        }
-        return occurrences;
-    }
+    public IEnumerable<Occurrence> GetOccurrences<T>(IDateTime startTime, IDateTime endTime) where T : IRecurringComponent
+        => this
+        .Select(iCal => iCal.GetOccurrences<T>(startTime, endTime))
+        .ToArray()
+        .OrderedMergeMany();
 
-    public HashSet<Occurrence> GetOccurrences<T>(DateTime startTime, DateTime endTime) where T : IRecurringComponent
-    {
-        var occurrences = new HashSet<Occurrence>();
-        foreach (var iCal in this)
-        {
-            occurrences.UnionWith(iCal.GetOccurrences<T>(startTime, endTime));
-        }
-        return occurrences;
-    }
+    public IEnumerable<Occurrence> GetOccurrences<T>(DateTime startTime, DateTime endTime) where T : IRecurringComponent
+        => this
+        .Select(iCal => iCal.GetOccurrences<T>(startTime, endTime))
+        .ToArray()
+        .OrderedMergeMany();
 
     private FreeBusy CombineFreeBusy(FreeBusy main, FreeBusy current)
     {

--- a/Ical.Net/CalendarCollection.cs
+++ b/Ical.Net/CalendarCollection.cs
@@ -39,19 +39,19 @@ public class CalendarCollection : List<Calendar>
         return collection;
     }
 
-    public HashSet<Occurrence> GetOccurrences(IDateTime dt)
+    public HashSet<Occurrence> GetOccurrencesOfDay(IDateTime dt)
     {
         var occurrences = new HashSet<Occurrence>();
         foreach (var iCal in this)
         {
-            occurrences.UnionWith(iCal.GetOccurrences(dt));
+            occurrences.UnionWith(iCal.GetOccurrencesOfDay(dt));
         }
         return occurrences;
     }
 
-    public IEnumerable<Occurrence> GetOccurrences(DateTime dt)
+    public IEnumerable<Occurrence> GetOccurrencesOfDay(DateTime dt)
         => this
-        .Select(iCal => iCal.GetOccurrences(dt))
+        .Select(iCal => iCal.GetOccurrencesOfDay(dt))
         .ToArray()
         .OrderedMergeMany();
 
@@ -69,7 +69,7 @@ public class CalendarCollection : List<Calendar>
 
     public IEnumerable<Occurrence> GetOccurrences<T>(IDateTime dt) where T : IRecurringComponent
         => this
-        .Select(iCal => iCal.GetOccurrences(dt))
+        .Select(iCal => iCal.GetOccurrencesOfDay(dt))
         .ToArray()
         .OrderedMergeMany();
 

--- a/Ical.Net/CalendarComponents/RecurringComponent.cs
+++ b/Ical.Net/CalendarComponents/RecurringComponent.cs
@@ -178,9 +178,9 @@ public class RecurringComponent : UniqueComponent, IRecurringComponent
         Initialize();
     }
 
-    public virtual IEnumerable<Occurrence> GetOccurrences(IDateTime dt) => RecurrenceUtil.GetOccurrences(this, dt, EvaluationIncludesReferenceDate);
+    public virtual IEnumerable<Occurrence> GetOccurrencesOfDay(IDateTime dt) => RecurrenceUtil.GetOccurrences(this, dt, EvaluationIncludesReferenceDate);
 
-    public virtual IEnumerable<Occurrence> GetOccurrences(DateTime dt)
+    public virtual IEnumerable<Occurrence> GetOccurrencesOfDay(DateTime dt)
         => RecurrenceUtil.GetOccurrences(this, new CalDateTime(dt), EvaluationIncludesReferenceDate);
 
     public virtual IEnumerable<Occurrence> GetOccurrences(IDateTime startTime, IDateTime endTime)

--- a/Ical.Net/CalendarComponents/RecurringComponent.cs
+++ b/Ical.Net/CalendarComponents/RecurringComponent.cs
@@ -178,11 +178,6 @@ public class RecurringComponent : UniqueComponent, IRecurringComponent
         Initialize();
     }
 
-    public virtual IEnumerable<Occurrence> GetOccurrencesOfDay(IDateTime dt) => RecurrenceUtil.GetOccurrences(this, dt, EvaluationIncludesReferenceDate);
-
-    public virtual IEnumerable<Occurrence> GetOccurrencesOfDay(DateTime dt)
-        => RecurrenceUtil.GetOccurrences(this, new CalDateTime(dt), EvaluationIncludesReferenceDate);
-
     public virtual IEnumerable<Occurrence> GetOccurrences(IDateTime startTime, IDateTime endTime)
         => RecurrenceUtil.GetOccurrences(this, startTime, endTime, EvaluationIncludesReferenceDate);
 

--- a/Ical.Net/CalendarComponents/RecurringComponent.cs
+++ b/Ical.Net/CalendarComponents/RecurringComponent.cs
@@ -178,7 +178,7 @@ public class RecurringComponent : UniqueComponent, IRecurringComponent
         Initialize();
     }
 
-    public virtual IEnumerable<Occurrence> GetOccurrences(IDateTime startTime, IDateTime endTime)
+    public virtual IEnumerable<Occurrence> GetOccurrences(IDateTime startTime = null, IDateTime endTime = null)
         => RecurrenceUtil.GetOccurrences(this, startTime, endTime, EvaluationIncludesReferenceDate);
 
     public virtual IEnumerable<Occurrence> GetOccurrences(DateTime? startTime, DateTime? endTime)

--- a/Ical.Net/CalendarComponents/RecurringComponent.cs
+++ b/Ical.Net/CalendarComponents/RecurringComponent.cs
@@ -178,15 +178,15 @@ public class RecurringComponent : UniqueComponent, IRecurringComponent
         Initialize();
     }
 
-    public virtual HashSet<Occurrence> GetOccurrences(IDateTime dt) => RecurrenceUtil.GetOccurrences(this, dt, EvaluationIncludesReferenceDate);
+    public virtual IEnumerable<Occurrence> GetOccurrences(IDateTime dt) => RecurrenceUtil.GetOccurrences(this, dt, EvaluationIncludesReferenceDate);
 
-    public virtual HashSet<Occurrence> GetOccurrences(DateTime dt)
+    public virtual IEnumerable<Occurrence> GetOccurrences(DateTime dt)
         => RecurrenceUtil.GetOccurrences(this, new CalDateTime(dt), EvaluationIncludesReferenceDate);
 
-    public virtual HashSet<Occurrence> GetOccurrences(IDateTime startTime, IDateTime endTime)
+    public virtual IEnumerable<Occurrence> GetOccurrences(IDateTime startTime, IDateTime endTime)
         => RecurrenceUtil.GetOccurrences(this, startTime, endTime, EvaluationIncludesReferenceDate);
 
-    public virtual HashSet<Occurrence> GetOccurrences(DateTime startTime, DateTime endTime)
+    public virtual IEnumerable<Occurrence> GetOccurrences(DateTime startTime, DateTime endTime)
         => RecurrenceUtil.GetOccurrences(this, new CalDateTime(startTime), new CalDateTime(endTime), EvaluationIncludesReferenceDate);
 
     public virtual IList<AlarmOccurrence> PollAlarms() => PollAlarms(null, null);

--- a/Ical.Net/CalendarComponents/RecurringComponent.cs
+++ b/Ical.Net/CalendarComponents/RecurringComponent.cs
@@ -186,8 +186,8 @@ public class RecurringComponent : UniqueComponent, IRecurringComponent
     public virtual IEnumerable<Occurrence> GetOccurrences(IDateTime startTime, IDateTime endTime)
         => RecurrenceUtil.GetOccurrences(this, startTime, endTime, EvaluationIncludesReferenceDate);
 
-    public virtual IEnumerable<Occurrence> GetOccurrences(DateTime startTime, DateTime endTime)
-        => RecurrenceUtil.GetOccurrences(this, new CalDateTime(startTime), new CalDateTime(endTime), EvaluationIncludesReferenceDate);
+    public virtual IEnumerable<Occurrence> GetOccurrences(DateTime? startTime, DateTime? endTime)
+        => RecurrenceUtil.GetOccurrences(this, startTime?.AsCalDateTime(), endTime?.AsCalDateTime(), EvaluationIncludesReferenceDate);
 
     public virtual IList<AlarmOccurrence> PollAlarms() => PollAlarms(null, null);
 

--- a/Ical.Net/Evaluation/Evaluator.cs
+++ b/Ical.Net/Evaluation/Evaluator.cs
@@ -75,5 +75,5 @@ public abstract class Evaluator : IEvaluator
         protected set => _mAssociatedObject = value;
     }
 
-    public abstract HashSet<Period> Evaluate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd, bool includeReferenceDateInResults);
+    public abstract IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd, bool includeReferenceDateInResults);
 }

--- a/Ical.Net/Evaluation/Evaluator.cs
+++ b/Ical.Net/Evaluation/Evaluator.cs
@@ -75,5 +75,5 @@ public abstract class Evaluator : IEvaluator
         protected set => _mAssociatedObject = value;
     }
 
-    public abstract IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd, bool includeReferenceDateInResults);
+    public abstract IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime? periodStart, DateTime? periodEnd, bool includeReferenceDateInResults);
 }

--- a/Ical.Net/Evaluation/EventEvaluator.cs
+++ b/Ical.Net/Evaluation/EventEvaluator.cs
@@ -38,7 +38,7 @@ public class EventEvaluator : RecurringEvaluator
     /// <param name="periodEnd">The end date of the range to evaluate.</param>
     /// <param name="includeReferenceDateInResults"></param>
     /// <returns></returns>
-    public override IEnumerable<Period> Evaluate(IDateTime referenceTime, DateTime periodStart, DateTime periodEnd, bool includeReferenceDateInResults)
+    public override IEnumerable<Period> Evaluate(IDateTime referenceTime, DateTime? periodStart, DateTime? periodEnd, bool includeReferenceDateInResults)
     {
         Period WithDuration(Period period)
         {

--- a/Ical.Net/Evaluation/IEvaluator.cs
+++ b/Ical.Net/Evaluation/IEvaluator.cs
@@ -30,6 +30,8 @@ public interface IEvaluator
     /// This method evaluates using the <paramref name="periodStart" /> as the beginning
     /// point.  For example, for a WEEKLY occurrence, the <paramref name="periodStart"/>
     /// determines the day of week that this item will recur on.
+    ///
+    /// Items are returned in ascending order.
     /// <note type="caution">
     ///     For events with very complex recurrence rules, this method may be a bottleneck
     ///     during processing time, especially when this method is called for a large number
@@ -41,8 +43,8 @@ public interface IEvaluator
     /// <param name="periodEnd"></param>
     /// <param name="includeReferenceDateInResults"></param>
     /// <returns>
-    ///     A list of <see cref="System.DateTime"/> objects for
+    ///     A sequence of <see cref="Ical.Net.DataTypes.Period"/> objects for
     ///     each date/time when this item occurs/recurs.
     /// </returns>
-    HashSet<Period> Evaluate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd, bool includeReferenceDateInResults);
+    IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd, bool includeReferenceDateInResults);
 }

--- a/Ical.Net/Evaluation/IEvaluator.cs
+++ b/Ical.Net/Evaluation/IEvaluator.cs
@@ -46,5 +46,5 @@ public interface IEvaluator
     ///     A sequence of <see cref="Ical.Net.DataTypes.Period"/> objects for
     ///     each date/time when this item occurs/recurs.
     /// </returns>
-    IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd, bool includeReferenceDateInResults);
+    IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime? periodStart, DateTime? periodEnd, bool includeReferenceDateInResults);
 }

--- a/Ical.Net/Evaluation/PeriodListEvaluator.cs
+++ b/Ical.Net/Evaluation/PeriodListEvaluator.cs
@@ -18,7 +18,7 @@ public class PeriodListEvaluator : Evaluator
         _mPeriodList = rdt;
     }
 
-    public override IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd, bool includeReferenceDateInResults)
+    public override IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime? periodStart, DateTime? periodEnd, bool includeReferenceDateInResults)
     {
         var periods = new SortedSet<Period>();
 

--- a/Ical.Net/Evaluation/PeriodListEvaluator.cs
+++ b/Ical.Net/Evaluation/PeriodListEvaluator.cs
@@ -18,9 +18,9 @@ public class PeriodListEvaluator : Evaluator
         _mPeriodList = rdt;
     }
 
-    public override HashSet<Period> Evaluate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd, bool includeReferenceDateInResults)
+    public override IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd, bool includeReferenceDateInResults)
     {
-        var periods = new HashSet<Period>();
+        var periods = new SortedSet<Period>();
 
         if (includeReferenceDateInResults)
         {

--- a/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
@@ -203,7 +203,7 @@ public class RecurrencePatternEvaluator : Evaluator
     /// For example, if the search start date (start) is Wed, Mar 23, 12:19PM, but the recurrence is Mon - Fri, 9:00AM - 5:00PM,
     /// the start dates returned should all be at 9:00AM, and not 12:19PM.
     /// </summary>
-    private IEnumerable<DateTime> GetDates(IDateTime seed, DateTime periodStart, DateTime periodEnd, int maxCount, RecurrencePattern pattern,
+    private IEnumerable<DateTime> GetDates(IDateTime seed, DateTime? periodStart, DateTime? periodEnd, int maxCount, RecurrencePattern pattern,
          bool includeReferenceDateInResults)
     {
         // In the first step, we work with DateTime values, so we need to convert the IDateTime to DateTime
@@ -236,7 +236,7 @@ public class RecurrencePatternEvaluator : Evaluator
         return EnumerateDates(originalDate, seedCopy, periodStart, periodEnd, maxCount, pattern);
     }
 
-    private IEnumerable<DateTime> EnumerateDates(DateTime originalDate, DateTime seedCopy, DateTime periodStart, DateTime periodEnd, int maxCount, RecurrencePattern pattern)
+    private IEnumerable<DateTime> EnumerateDates(DateTime originalDate, DateTime seedCopy, DateTime? periodStart, DateTime? periodEnd, int maxCount, RecurrencePattern pattern)
     {
         var expandBehavior = RecurrenceUtil.GetExpandBehaviorList(pattern);
 
@@ -954,7 +954,7 @@ public class RecurrencePatternEvaluator : Evaluator
     /// <param name="periodEnd">End (excl.) of the period occurrences are generated for.</param>
     /// <param name="includeReferenceDateInResults">Whether the referenceDate itself should be returned. Ignored as the reference data MUST equal the first occurrence of an RRULE.</param>
     /// <returns></returns>
-    public override IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd, bool includeReferenceDateInResults)
+    public override IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime? periodStart, DateTime? periodEnd, bool includeReferenceDateInResults)
     {
         if (Pattern.Frequency != FrequencyType.None && Pattern.Frequency < FrequencyType.Daily && !referenceDate.HasTime)
         {

--- a/Ical.Net/Evaluation/RecurrenceUtil.cs
+++ b/Ical.Net/Evaluation/RecurrenceUtil.cs
@@ -14,18 +14,15 @@ namespace Ical.Net.Evaluation;
 
 internal class RecurrenceUtil
 {
-    public static HashSet<Occurrence> GetOccurrences(IRecurrable recurrable, IDateTime dt, bool includeReferenceDateInResults)
-    {
-        return GetOccurrences(recurrable,
-        new CalDateTime(dt.Date, dt.Time), new CalDateTime(dt.Date.AddDays(1)), includeReferenceDateInResults);
-    }
+    public static IEnumerable<Occurrence> GetOccurrences(IRecurrable recurrable, IDateTime dt, bool includeReferenceDateInResults) => GetOccurrences(recurrable,
+        new CalDateTime(dt.Date), new CalDateTime(dt.Date.AddDays(1)), includeReferenceDateInResults);
 
-    public static HashSet<Occurrence> GetOccurrences(IRecurrable recurrable, IDateTime periodStart, IDateTime periodEnd, bool includeReferenceDateInResults)
+    public static IEnumerable<Occurrence> GetOccurrences(IRecurrable recurrable, IDateTime periodStart, IDateTime periodEnd, bool includeReferenceDateInResults)
     {
         var evaluator = recurrable.GetService(typeof(IEvaluator)) as IEvaluator;
         if (evaluator == null || recurrable.Start == null)
         {
-            return new HashSet<Occurrence>();
+            return [];
         }
 
         // Ensure the start time is associated with the object being queried
@@ -41,15 +38,15 @@ internal class RecurrenceUtil
         var periods = evaluator.Evaluate(start, DateUtil.GetSimpleDateTimeData(periodStart), DateUtil.GetSimpleDateTimeData(periodEnd),
             includeReferenceDateInResults);
 
-        var otherOccurrences = from p in periods
-                               let endTime = p.EndTime ?? p.StartTime
-                               where
-                                   (endTime.GreaterThan(periodStart) && p.StartTime.LessThan(periodEnd) ||
-                                    (periodStart.Equals(periodEnd) && p.StartTime.LessThanOrEqual(periodStart) && endTime.GreaterThan(periodEnd))) || //A period that starts at the same time it ends
-                                   (p.StartTime.Equals(endTime) && periodStart.Equals(p.StartTime)) //An event that starts at the same time it ends
-                               select new Occurrence(recurrable, p);
+        var occurrences =
+            from p in periods
+            let endTime = p.EndTime ?? p.StartTime
+            where
+                (endTime.GreaterThan(periodStart) && p.StartTime.LessThan(periodEnd) ||
+                (periodStart.Equals(periodEnd) && p.StartTime.LessThanOrEqual(periodStart) && endTime.GreaterThan(periodEnd))) || //A period that starts at the same time it ends
+                (p.StartTime.Equals(endTime) && periodStart.Equals(p.StartTime)) //An event that starts at the same time it ends
+            select new Occurrence(recurrable, p);
 
-        var occurrences = new HashSet<Occurrence>(otherOccurrences);
         return occurrences;
     }
 

--- a/Ical.Net/Evaluation/RecurrenceUtil.cs
+++ b/Ical.Net/Evaluation/RecurrenceUtil.cs
@@ -32,19 +32,21 @@ internal class RecurrenceUtil
         // Change the time zone of periodStart/periodEnd as needed
         // so they can be used during the evaluation process.
 
-        periodStart = new CalDateTime(periodStart.Date, periodStart.Time, start.TzId);
-        periodEnd = new CalDateTime(periodEnd.Date, periodEnd.Time, start.TzId);
+        if (periodStart != null)
+            periodStart = new CalDateTime(periodStart.Date, periodStart.Time, start.TzId);
+        if (periodEnd != null)
+            periodEnd = new CalDateTime(periodEnd.Date, periodEnd.Time, start.TzId);
 
-        var periods = evaluator.Evaluate(start, DateUtil.GetSimpleDateTimeData(periodStart), DateUtil.GetSimpleDateTimeData(periodEnd),
+        var periods = evaluator.Evaluate(start, periodStart?.Value, periodEnd?.Value,
             includeReferenceDateInResults);
 
         var occurrences =
             from p in periods
             let endTime = p.EndTime ?? p.StartTime
             where
-                (endTime.GreaterThan(periodStart) && p.StartTime.LessThan(periodEnd) ||
+                (((periodStart == null) || endTime.GreaterThan(periodStart)) && ((periodEnd == null) || p.StartTime.LessThan(periodEnd)) ||
                 (periodStart.Equals(periodEnd) && p.StartTime.LessThanOrEqual(periodStart) && endTime.GreaterThan(periodEnd))) || //A period that starts at the same time it ends
-                (p.StartTime.Equals(endTime) && periodStart.Equals(p.StartTime)) //An event that starts at the same time it ends
+                (p.StartTime.Equals(endTime) && p.StartTime.Equals(periodStart)) //An event that starts at the same time it ends
             select new Occurrence(recurrable, p);
 
         return occurrences;

--- a/Ical.Net/Evaluation/RecurringEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurringEvaluator.cs
@@ -41,7 +41,7 @@ public class RecurringEvaluator : Evaluator
     /// <param name="periodStart">The beginning date of the range to evaluate.</param>
     /// <param name="periodEnd">The end date of the range to evaluate.</param>
     /// <param name="includeReferenceDateInResults"></param>
-    protected IEnumerable<Period> EvaluateRRule(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd, bool includeReferenceDateInResults)
+    protected IEnumerable<Period> EvaluateRRule(IDateTime referenceDate, DateTime? periodStart, DateTime? periodEnd, bool includeReferenceDateInResults)
     {
         if (Recurrable.RecurrenceRules == null || !Recurrable.RecurrenceRules.Any())
             return [];
@@ -71,7 +71,7 @@ public class RecurringEvaluator : Evaluator
     }
 
     /// <summary> Evaluates the RDate component. </summary>
-    protected IEnumerable<Period> EvaluateRDate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd)
+    protected IEnumerable<Period> EvaluateRDate(IDateTime referenceDate, DateTime? periodStart, DateTime? periodEnd)
     {
         if (Recurrable.RecurrenceDates == null || !Recurrable.RecurrenceDates.Any())
             return [];
@@ -86,7 +86,7 @@ public class RecurringEvaluator : Evaluator
     /// <param name="referenceDate"></param>
     /// <param name="periodStart">The beginning date of the range to evaluate.</param>
     /// <param name="periodEnd">The end date of the range to evaluate.</param>
-    protected IEnumerable<Period> EvaluateExRule(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd)
+    protected IEnumerable<Period> EvaluateExRule(IDateTime referenceDate, DateTime? periodStart, DateTime? periodEnd)
     {
         if (Recurrable.ExceptionRules == null || !Recurrable.ExceptionRules.Any())
             return [];
@@ -114,7 +114,7 @@ public class RecurringEvaluator : Evaluator
     /// <param name="referenceDate"></param>
     /// <param name="periodStart">The beginning date of the range to evaluate.</param>
     /// <param name="periodEnd">The end date of the range to evaluate.</param>
-    protected IEnumerable<Period> EvaluateExDate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd)
+    protected IEnumerable<Period> EvaluateExDate(IDateTime referenceDate, DateTime? periodStart, DateTime? periodEnd)
     {
         if (Recurrable.ExceptionDates == null || !Recurrable.ExceptionDates.Any())
             return [];
@@ -123,7 +123,7 @@ public class RecurringEvaluator : Evaluator
         return exDates;
     }
 
-    public override IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd, bool includeReferenceDateInResults)
+    public override IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime? periodStart, DateTime? periodEnd, bool includeReferenceDateInResults)
     {
         var rruleOccurrences = EvaluateRRule(referenceDate, periodStart, periodEnd, includeReferenceDateInResults);
         //Only add referenceDate if there are no RecurrenceRules defined

--- a/Ical.Net/Evaluation/RecurringEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurringEvaluator.cs
@@ -58,7 +58,7 @@ public class RecurringEvaluator : Evaluator
             // Enumerate the outer sequence (not the inner sequences of periods themselves) now to ensure
             // the initialization code is run, including validation and error handling.
             // This way we receive validation errors early, not only when enumeration starts.
-            .ToList();
+            .ToList(); //NOSONAR - deliberately enumerate here
 
 
         //Only add referenceDate if there are no RecurrenceRules defined
@@ -103,7 +103,7 @@ public class RecurringEvaluator : Evaluator
             // Enumerate the outer sequence (not the inner sequences of periods themselves) now to ensure
             // the initialization code is run, including validation and error handling.
             // This way we receive validation errors early, not only when enumeration starts.
-            .ToList();
+            .ToList(); //NOSONAR - deliberately enumerate here
 
         return exRuleEvaluatorQueries.OrderedMergeMany();
     }

--- a/Ical.Net/Evaluation/RecurringEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurringEvaluator.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
+using Ical.Net.Utility;
 
 namespace Ical.Net.Evaluation;
 
@@ -40,14 +41,12 @@ public class RecurringEvaluator : Evaluator
     /// <param name="periodStart">The beginning date of the range to evaluate.</param>
     /// <param name="periodEnd">The end date of the range to evaluate.</param>
     /// <param name="includeReferenceDateInResults"></param>
-    protected HashSet<Period> EvaluateRRule(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd, bool includeReferenceDateInResults)
+    protected IEnumerable<Period> EvaluateRRule(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd, bool includeReferenceDateInResults)
     {
         if (Recurrable.RecurrenceRules == null || !Recurrable.RecurrenceRules.Any())
-        {
-            return new HashSet<Period>();
-        }
+            return [];
 
-        var periodsQuery = Recurrable.RecurrenceRules.SelectMany(rule =>
+        var periodsQueries = Recurrable.RecurrenceRules.Select(rule =>
         {
             var ruleEvaluator = rule.GetService(typeof(IEvaluator)) as IEvaluator;
             if (ruleEvaluator == null)
@@ -55,27 +54,29 @@ public class RecurringEvaluator : Evaluator
                 return Enumerable.Empty<Period>();
             }
             return ruleEvaluator.Evaluate(referenceDate, periodStart, periodEnd, includeReferenceDateInResults);
-        });
+        })
+            // Enumerate the outer sequence (not the inner sequences of periods themselves) now to ensure
+            // the initialization code is run, including validation and error handling.
+            // This way we receive validation errors early, not only when enumeration starts.
+            .ToList();
 
-        var periods = new HashSet<Period>(periodsQuery);
 
         //Only add referenceDate if there are no RecurrenceRules defined
         if (includeReferenceDateInResults && (Recurrable.RecurrenceRules == null || !Recurrable.RecurrenceRules.Any()))
         {
-            periods.UnionWith(new[] { new Period(referenceDate) });
+            periodsQueries.Add([new Period(referenceDate)]);
         }
-        return periods;
+
+        return periodsQueries.OrderedMergeMany();
     }
 
     /// <summary> Evaluates the RDate component. </summary>
-    protected HashSet<Period> EvaluateRDate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd)
+    protected IEnumerable<Period> EvaluateRDate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd)
     {
         if (Recurrable.RecurrenceDates == null || !Recurrable.RecurrenceDates.Any())
-        {
-            return new HashSet<Period>();
-        }
+            return [];
 
-        var recurrences = new HashSet<Period>(Recurrable.RecurrenceDates.SelectMany(rdate => rdate));
+        var recurrences = new SortedSet<Period>(Recurrable.RecurrenceDates.SelectMany(rdate => rdate));
         return recurrences;
     }
 
@@ -85,14 +86,12 @@ public class RecurringEvaluator : Evaluator
     /// <param name="referenceDate"></param>
     /// <param name="periodStart">The beginning date of the range to evaluate.</param>
     /// <param name="periodEnd">The end date of the range to evaluate.</param>
-    protected HashSet<Period> EvaluateExRule(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd)
+    protected IEnumerable<Period> EvaluateExRule(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd)
     {
         if (Recurrable.ExceptionRules == null || !Recurrable.ExceptionRules.Any())
-        {
-            return new HashSet<Period>();
-        }
+            return [];
 
-        var exRuleEvaluatorQuery = Recurrable.ExceptionRules.SelectMany(exRule =>
+        var exRuleEvaluatorQueries = Recurrable.ExceptionRules.Select(exRule =>
         {
             var exRuleEvaluator = exRule.GetService(typeof(IEvaluator)) as IEvaluator;
             if (exRuleEvaluator == null)
@@ -100,10 +99,13 @@ public class RecurringEvaluator : Evaluator
                 return Enumerable.Empty<Period>();
             }
             return exRuleEvaluator.Evaluate(referenceDate, periodStart, periodEnd, false);
-        });
+        })
+            // Enumerate the outer sequence (not the inner sequences of periods themselves) now to ensure
+            // the initialization code is run, including validation and error handling.
+            // This way we receive validation errors early, not only when enumeration starts.
+            .ToList();
 
-        var exRuleExclusions = new HashSet<Period>(exRuleEvaluatorQuery);
-        return exRuleExclusions;
+        return exRuleEvaluatorQueries.OrderedMergeMany();
     }
 
     /// <summary>
@@ -112,26 +114,22 @@ public class RecurringEvaluator : Evaluator
     /// <param name="referenceDate"></param>
     /// <param name="periodStart">The beginning date of the range to evaluate.</param>
     /// <param name="periodEnd">The end date of the range to evaluate.</param>
-    protected HashSet<Period> EvaluateExDate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd)
+    protected IEnumerable<Period> EvaluateExDate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd)
     {
         if (Recurrable.ExceptionDates == null || !Recurrable.ExceptionDates.Any())
-        {
-            return new HashSet<Period>();
-        }
+            return [];
 
-        var exDates = new HashSet<Period>(Recurrable.ExceptionDates.SelectMany(exDate => exDate));
+        var exDates = new SortedSet<Period>(Recurrable.ExceptionDates.SelectMany(exDate => exDate));
         return exDates;
     }
 
-    public override HashSet<Period> Evaluate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd, bool includeReferenceDateInResults)
+    public override IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd, bool includeReferenceDateInResults)
     {
-        var periods = new HashSet<Period>();
-
         var rruleOccurrences = EvaluateRRule(referenceDate, periodStart, periodEnd, includeReferenceDateInResults);
         //Only add referenceDate if there are no RecurrenceRules defined
         if (includeReferenceDateInResults && (Recurrable.RecurrenceRules == null || !Recurrable.RecurrenceRules.Any()))
         {
-            rruleOccurrences.UnionWith(new[] { new Period(referenceDate), });
+            rruleOccurrences = rruleOccurrences.Append(new Period(referenceDate));
         }
 
         var rdateOccurrences = EvaluateRDate(referenceDate, periodStart, periodEnd);
@@ -139,22 +137,27 @@ public class RecurringEvaluator : Evaluator
         var exRuleExclusions = EvaluateExRule(referenceDate, periodStart, periodEnd);
         var exDateExclusions = EvaluateExDate(referenceDate, periodStart, periodEnd);
 
-        //Exclusions trump inclusions
-        periods.UnionWith(rruleOccurrences);
-        periods.UnionWith(rdateOccurrences);
-        periods.ExceptWith(exRuleExclusions);
-        periods.ExceptWith(exDateExclusions);
-
-        var dateOverlaps = FindDateOverlaps(periods, exDateExclusions);
-        periods.ExceptWith(dateOverlaps);
+        var periods =
+            rruleOccurrences
+            .OrderedMerge(rdateOccurrences)
+            .OrderedDistinct()
+            .OrderedExclude(exRuleExclusions)
+            .OrderedExclude(exDateExclusions, Comparer<Period>.Create(CompareDateOverlap));
 
         return periods;
     }
 
-    private static HashSet<Period> FindDateOverlaps(HashSet<Period> periods, HashSet<Period> dates)
+    /// <summary>
+    /// Compares whether the given period's date overlaps with the given EXDATE. The dates are
+    /// considered to overlap if they start at the same time, or the EXDATE is an all-day date
+    /// and the period's start date is the same as the EXDATE's date.
+    /// </summary>
+    private static int CompareDateOverlap(Period period, Period exDate)
     {
-        var datesWithoutTimes = new HashSet<DateTime>(dates.Where(d => !d.StartTime.HasTime).Select(d => d.StartTime.Value));
-        var overlaps = new HashSet<Period>(periods.Where(p => datesWithoutTimes.Contains(p.StartTime.Value.Date)));
-        return overlaps;
+        var cmp = period.CompareTo(exDate);
+        if ((cmp != 0) && !exDate.StartTime.HasTime && (period.StartTime.Value.Date == exDate.StartTime.Value))
+            cmp = 0;
+
+        return cmp;
     }
 }

--- a/Ical.Net/Evaluation/TimeZoneInfoEvaluator.cs
+++ b/Ical.Net/Evaluation/TimeZoneInfoEvaluator.cs
@@ -20,14 +20,12 @@ public class TimeZoneInfoEvaluator : RecurringEvaluator
 
     public TimeZoneInfoEvaluator(IRecurrable tzi) : base(tzi) { }
 
-    public override HashSet<Period> Evaluate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd, bool includeReferenceDateInResults)
+    public override IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd, bool includeReferenceDateInResults)
     {
         // Time zones must include an effective start date/time
         // and must provide an evaluator.
         if (TimeZoneInfo == null)
-        {
-            return new HashSet<Period>();
-        }
+            return [];
 
         // Always include the reference date in the results
         var periods = base.Evaluate(referenceDate, periodStart, periodEnd, true);

--- a/Ical.Net/Evaluation/TimeZoneInfoEvaluator.cs
+++ b/Ical.Net/Evaluation/TimeZoneInfoEvaluator.cs
@@ -20,7 +20,7 @@ public class TimeZoneInfoEvaluator : RecurringEvaluator
 
     public TimeZoneInfoEvaluator(IRecurrable tzi) : base(tzi) { }
 
-    public override IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd, bool includeReferenceDateInResults)
+    public override IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime? periodStart, DateTime? periodEnd, bool includeReferenceDateInResults)
     {
         // Time zones must include an effective start date/time
         // and must provide an evaluator.

--- a/Ical.Net/Evaluation/TodoEvaluator.cs
+++ b/Ical.Net/Evaluation/TodoEvaluator.cs
@@ -77,7 +77,7 @@ public class TodoEvaluator : RecurringEvaluator
         }
     }
 
-    public override IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd, bool includeReferenceDateInResults)
+    public override IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime? periodStart, DateTime? periodEnd, bool includeReferenceDateInResults)
     {
         // TODO items can only recur if a start date is specified
         if (Todo.Start == null)

--- a/Ical.Net/Evaluation/TodoEvaluator.cs
+++ b/Ical.Net/Evaluation/TodoEvaluator.cs
@@ -18,7 +18,7 @@ public class TodoEvaluator : RecurringEvaluator
 
     public TodoEvaluator(Todo todo) : base(todo) { }
 
-    internal HashSet<Period> EvaluateToPreviousOccurrence(IDateTime completedDate, IDateTime currDt)
+    internal IEnumerable<Period> EvaluateToPreviousOccurrence(IDateTime completedDate, IDateTime currDt)
     {
         var beginningDate = completedDate.Copy<IDateTime>();
 
@@ -77,19 +77,19 @@ public class TodoEvaluator : RecurringEvaluator
         }
     }
 
-    public override HashSet<Period> Evaluate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd, bool includeReferenceDateInResults)
+    public override IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime periodStart, DateTime periodEnd, bool includeReferenceDateInResults)
     {
         // TODO items can only recur if a start date is specified
         if (Todo.Start == null)
-        {
-            return new HashSet<Period>();
-        }
+            return [];
 
-        var periods = base.Evaluate(referenceDate, periodStart, periodEnd, includeReferenceDateInResults);
-
-        // Ensure each period has a duration
-        foreach (var period in periods.Where(period => period.EndTime == null))
+        Period PeriodWithDuration(Period p)
         {
+            if (p.EndTime != null)
+                return p;
+
+            var period = p.Copy<Period>();
+
             period.Duration = Todo.Duration;
             if (period.Duration != default)
             {
@@ -99,7 +99,11 @@ public class TodoEvaluator : RecurringEvaluator
             {
                 period.Duration = Todo.Duration;
             }
+
+            return period;
         }
-        return periods;
+
+        return base.Evaluate(referenceDate, periodStart, periodEnd, includeReferenceDateInResults)
+            .Select(PeriodWithDuration);
     }
 }

--- a/Ical.Net/IGetOccurrences.cs
+++ b/Ical.Net/IGetOccurrences.cs
@@ -23,7 +23,7 @@ public interface IGetOccurrences
     /// </note>
     /// </summary>
     /// <param name="dt">The date for which to return occurrences.</param>
-    /// <returns>A list of Periods representing the occurrences of this object.</returns>
+    /// <returns>An IEnumerable that calculates and returns Periods representing the occurrences of this object in ascending order.</returns>
     IEnumerable<Occurrence> GetOccurrences(IDateTime dt);
 
     IEnumerable<Occurrence> GetOccurrences(DateTime dt);
@@ -34,9 +34,10 @@ public interface IGetOccurrences
     /// </summary>
     /// <param name="startTime">The starting date range</param>
     /// <param name="endTime">The ending date range</param>
-    IEnumerable<Occurrence> GetOccurrences(IDateTime startTime, IDateTime endTime);
+    /// <returns>An IEnumerable that calculates and returns Periods representing the occurrences of this object in ascending order.</returns>
+    IEnumerable<Occurrence> GetOccurrences(IDateTime startTime = null, IDateTime endTime = null);
 
-    IEnumerable<Occurrence> GetOccurrences(DateTime startTime, DateTime endTime);
+    IEnumerable<Occurrence> GetOccurrences(DateTime? startTime, DateTime? endTime);
 }
 
 public interface IGetOccurrencesTyped : IGetOccurrences
@@ -52,7 +53,7 @@ public interface IGetOccurrencesTyped : IGetOccurrences
     /// </note>
     /// </summary>
     /// <param name="dt">The date for which to return occurrences.</param>
-    /// <returns>A list of Periods representing the occurrences of this object.</returns>
+    /// <returns>An IEnumerable that calculates and returns Periods representing the occurrences of this object in ascending order.</returns>
     IEnumerable<Occurrence> GetOccurrences<T>(IDateTime dt) where T : IRecurringComponent;
 
     IEnumerable<Occurrence> GetOccurrences<T>(DateTime dt) where T : IRecurringComponent;
@@ -62,9 +63,10 @@ public interface IGetOccurrencesTyped : IGetOccurrences
     /// All components occurring between <paramref name="startTime"/> and <paramref name="endTime"/>
     /// will be returned.
     /// </summary>
-    /// <param name="startTime">The starting date range</param>
-    /// <param name="endTime">The ending date range</param>
-    IEnumerable<Occurrence> GetOccurrences<T>(IDateTime startTime, IDateTime endTime) where T : IRecurringComponent;
+    /// <param name="startTime">The starting date range. If set to null, occurrences are returned from the beginning.</param>
+    /// <param name="endTime">The ending date range. If set to null, occurrences are returned until the end.</param>
+    /// <returns>An IEnumerable that calculates and returns Periods representing the occurrences of this object in ascending order.</returns>
+    IEnumerable<Occurrence> GetOccurrences<T>(IDateTime startTime = null, IDateTime endTime = null) where T : IRecurringComponent;
 
-    IEnumerable<Occurrence> GetOccurrences<T>(DateTime startTime, DateTime endTime) where T : IRecurringComponent;
+    IEnumerable<Occurrence> GetOccurrences<T>(DateTime? startTime, DateTime? endTime) where T : IRecurringComponent;
 }

--- a/Ical.Net/IGetOccurrences.cs
+++ b/Ical.Net/IGetOccurrences.cs
@@ -13,22 +13,6 @@ namespace Ical.Net;
 public interface IGetOccurrences
 {
     /// <summary>
-    /// Returns all occurrences of this component that start on the date provided.
-    /// All components starting between 12:00:00AM and 11:59:59 PM will be
-    /// returned.
-    /// <note>
-    /// This will first Evaluate() the date range required in order to
-    /// determine the occurrences for the date provided, and then return
-    /// the occurrences.
-    /// </note>
-    /// </summary>
-    /// <param name="dt">The date for which to return occurrences.</param>
-    /// <returns>An IEnumerable that calculates and returns Periods representing the occurrences of this object in ascending order.</returns>
-    IEnumerable<Occurrence> GetOccurrencesOfDay(IDateTime dt);
-
-    IEnumerable<Occurrence> GetOccurrencesOfDay(DateTime dt);
-
-    /// <summary>
     /// Returns all occurrences of this component that overlap with the date range provided.
     /// All components that overlap with the time range between <paramref name="startTime"/> and <paramref name="endTime"/> will be returned.
     /// </summary>
@@ -42,22 +26,6 @@ public interface IGetOccurrences
 
 public interface IGetOccurrencesTyped : IGetOccurrences
 {
-    /// <summary>
-    /// Returns all occurrences of components of type T that start on the date provided.
-    /// All components starting between 12:00:00AM and 11:59:59 PM will be
-    /// returned.
-    /// <note>
-    /// This will first Evaluate() the date range required in order to
-    /// determine the occurrences for the date provided, and then return
-    /// the occurrences.
-    /// </note>
-    /// </summary>
-    /// <param name="dt">The date for which to return occurrences.</param>
-    /// <returns>An IEnumerable that calculates and returns Periods representing the occurrences of this object in ascending order.</returns>
-    IEnumerable<Occurrence> GetOccurrences<T>(IDateTime dt) where T : IRecurringComponent;
-
-    IEnumerable<Occurrence> GetOccurrences<T>(DateTime dt) where T : IRecurringComponent;
-
     /// <summary>
     /// Returns all occurrences of components of type T that start within the date range provided.
     /// All components occurring between <paramref name="startTime"/> and <paramref name="endTime"/>

--- a/Ical.Net/IGetOccurrences.cs
+++ b/Ical.Net/IGetOccurrences.cs
@@ -24,9 +24,9 @@ public interface IGetOccurrences
     /// </summary>
     /// <param name="dt">The date for which to return occurrences.</param>
     /// <returns>A list of Periods representing the occurrences of this object.</returns>
-    HashSet<Occurrence> GetOccurrences(IDateTime dt);
+    IEnumerable<Occurrence> GetOccurrences(IDateTime dt);
 
-    HashSet<Occurrence> GetOccurrences(DateTime dt);
+    IEnumerable<Occurrence> GetOccurrences(DateTime dt);
 
     /// <summary>
     /// Returns all occurrences of this component that overlap with the date range provided.
@@ -34,9 +34,9 @@ public interface IGetOccurrences
     /// </summary>
     /// <param name="startTime">The starting date range</param>
     /// <param name="endTime">The ending date range</param>
-    HashSet<Occurrence> GetOccurrences(IDateTime startTime, IDateTime endTime);
+    IEnumerable<Occurrence> GetOccurrences(IDateTime startTime, IDateTime endTime);
 
-    HashSet<Occurrence> GetOccurrences(DateTime startTime, DateTime endTime);
+    IEnumerable<Occurrence> GetOccurrences(DateTime startTime, DateTime endTime);
 }
 
 public interface IGetOccurrencesTyped : IGetOccurrences
@@ -53,9 +53,9 @@ public interface IGetOccurrencesTyped : IGetOccurrences
     /// </summary>
     /// <param name="dt">The date for which to return occurrences.</param>
     /// <returns>A list of Periods representing the occurrences of this object.</returns>
-    HashSet<Occurrence> GetOccurrences<T>(IDateTime dt) where T : IRecurringComponent;
+    IEnumerable<Occurrence> GetOccurrences<T>(IDateTime dt) where T : IRecurringComponent;
 
-    HashSet<Occurrence> GetOccurrences<T>(DateTime dt) where T : IRecurringComponent;
+    IEnumerable<Occurrence> GetOccurrences<T>(DateTime dt) where T : IRecurringComponent;
 
     /// <summary>
     /// Returns all occurrences of components of type T that start within the date range provided.
@@ -64,7 +64,7 @@ public interface IGetOccurrencesTyped : IGetOccurrences
     /// </summary>
     /// <param name="startTime">The starting date range</param>
     /// <param name="endTime">The ending date range</param>
-    HashSet<Occurrence> GetOccurrences<T>(IDateTime startTime, IDateTime endTime) where T : IRecurringComponent;
+    IEnumerable<Occurrence> GetOccurrences<T>(IDateTime startTime, IDateTime endTime) where T : IRecurringComponent;
 
-    HashSet<Occurrence> GetOccurrences<T>(DateTime startTime, DateTime endTime) where T : IRecurringComponent;
+    IEnumerable<Occurrence> GetOccurrences<T>(DateTime startTime, DateTime endTime) where T : IRecurringComponent;
 }

--- a/Ical.Net/IGetOccurrences.cs
+++ b/Ical.Net/IGetOccurrences.cs
@@ -24,9 +24,9 @@ public interface IGetOccurrences
     /// </summary>
     /// <param name="dt">The date for which to return occurrences.</param>
     /// <returns>An IEnumerable that calculates and returns Periods representing the occurrences of this object in ascending order.</returns>
-    IEnumerable<Occurrence> GetOccurrences(IDateTime dt);
+    IEnumerable<Occurrence> GetOccurrencesOfDay(IDateTime dt);
 
-    IEnumerable<Occurrence> GetOccurrences(DateTime dt);
+    IEnumerable<Occurrence> GetOccurrencesOfDay(DateTime dt);
 
     /// <summary>
     /// Returns all occurrences of this component that overlap with the date range provided.

--- a/Ical.Net/Utility/CollectionHelpers.cs
+++ b/Ical.Net/Utility/CollectionHelpers.cs
@@ -89,4 +89,184 @@ internal static class CollectionHelpers
             destination.Add(element);
         }
     }
+
+    /// <summary>
+    /// Merge the given ordered sequences into a single ordered sequence.
+    /// </summary>
+    /// <remarks>
+    /// Each input sequence must be ordered according to the given comparer. Duplicates are allowed and will be preserved.
+    /// 
+    /// The method operates in a streaming manner, meaning it only enumerates the input sequences while the
+    /// output sequence is being enumerated, and can therefore handle indefinite sequences.
+    /// </remarks>
+    public static IEnumerable<T> OrderedMerge<T>(this IEnumerable<T> items, IEnumerable<T> other)
+        => items.OrderedMerge(other, Comparer<T>.Default);
+
+    /// <summary>
+    /// Merge the given ordered sequences into a single ordered sequence.
+    /// </summary>
+    /// <remarks>
+    /// Each input sequence must be ordered according to the given comparer. Duplicates are allowed and will be preserved.
+    /// 
+    /// The method operates in a streaming manner, meaning it only enumerates the input sequences while the
+    /// output sequence is being enumerated, and can therefore handle indefinite sequences.
+    /// </remarks>
+    public static IEnumerable<T> OrderedMerge<T>(this IEnumerable<T> items, IEnumerable<T> other, IComparer<T> comparer)
+    {
+        using var it1 = items.GetEnumerator();
+        using var it2 = other.GetEnumerator();
+
+        var has1 = it1.MoveNext();
+        var has2 = it2.MoveNext();
+
+        while (has1 || has2)
+        {
+            var cmp = (has1, has2) switch
+            {
+                (true, false) => -1,
+                (false, true) => 1,
+                _ => comparer.Compare(it1.Current, it2.Current)
+            };
+
+            if (cmp <= 0)
+            {
+                yield return it1.Current;
+                has1 = it1.MoveNext();
+            }
+            else
+            {
+                yield return it2.Current;
+                has2 = it2.MoveNext();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Merge the given ordered sequences into a single ordered sequence.
+    /// </summary>
+    /// <remarks>
+    /// Each input sequence must be ordered according to types default comparer. Duplicates are allowed and will be preserved.
+    /// 
+    /// The method operates in a streaming manner, meaning it only enumerates the input sequences while the
+    /// output sequence is being enumerated, and can therefore handle indefinite sequences.
+    /// </remarks>
+    public static IEnumerable<T> OrderedMergeMany<T>(this IEnumerable<IEnumerable<T>> sequences)
+        => OrderedMergeMany(sequences, Comparer<T>.Default);
+
+    /// <summary>
+    /// Merge the given ordered sequences into a single ordered sequence.
+    /// </summary>
+    /// <remarks>
+    /// Each input sequence must be ordered according to the given comparer. Duplicates are allowed and will be preserved.
+    /// 
+    /// The method operates in a streaming manner, meaning it only enumerates the input sequences while the
+    /// output sequence is being enumerated, and can therefore handle indefinite sequences.
+    /// </remarks>
+    public static IEnumerable<T> OrderedMergeMany<T>(this IEnumerable<IEnumerable<T>> sequences, IComparer<T> comparer)
+    {
+        var list = (sequences as IList<IEnumerable<T>>) ?? sequences.ToList();
+        return OrderedMergeMany(list, 0, list.Count, comparer);
+    }
+
+    private static IEnumerable<T> OrderedMergeMany<T>(this IList<IEnumerable<T>> sequences, int offs, int length, IComparer<T> comparer)
+    {
+        if (length == 0)
+            return [];
+
+        if (length == 1)
+            return sequences[offs];
+
+        // Compose as a tree to ensure O(N*log(N)) complexity. Composing as a simple chain
+        // would result in O(N*N) complexity, which wouldn't be a problem either, as
+        // the number of sequences usually is low.
+        var mid = length / 2;
+        var left = OrderedMergeMany(sequences, offs, mid, comparer);
+        var right = OrderedMergeMany(sequences, offs + mid, length - mid, comparer);
+
+        return left.OrderedMerge(right, comparer);
+    }
+
+    /// <summary>
+    /// Returns the elements of the first ordered sequence that are not present in the second ordered sequence.
+    /// </summary>
+    /// <remarks>
+    /// Both sequences must be ordered according to the type's default comparer.
+    ///
+    /// The method operates in a streaming manner, meaning it only enumerates the input sequences while the
+    /// output sequence is being enumerated, and can therefore handle indefinite sequences.
+    /// </remarks>
+    public static IEnumerable<T> OrderedExclude<T>(this IEnumerable<T> items, IEnumerable<T> exclude)
+        => items.OrderedExclude(exclude, Comparer<T>.Default);
+
+    /// <summary>
+    /// Returns the elements of the first ordered sequence that are not present in the second ordered sequence.
+    /// </summary>
+    /// <remarks>
+    /// Both sequences must be ordered according to the specified comparer.
+    ///
+    /// The method operates in a streaming manner, meaning it only enumerates the input sequences while the
+    /// output sequence is being enumerated, and can therefore handle indefinite sequences.
+    /// </remarks>
+    public static IEnumerable<T> OrderedExclude<T>(this IEnumerable<T> items, IEnumerable<T> exclude, IComparer<T> comparer)
+    {
+        using var it = items.GetEnumerator();
+        using var itEx = exclude.GetEnumerator();
+
+        var hasNextIt = it.MoveNext();
+        var hasNextEx = itEx.MoveNext();
+
+        while (hasNextIt)
+        {
+            var cmp = hasNextEx ? comparer.Compare(it.Current, itEx.Current) : -1;
+            if (cmp <= 0)
+            {
+                if (cmp < 0)
+                    yield return it.Current;
+
+                hasNextIt = it.MoveNext();
+            }
+            else
+            {
+                hasNextEx = itEx.MoveNext();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns a sequence containing the items of the ordered input sequence, with duplicates removed.
+    /// </summary>
+    /// <remarks>
+    /// The input sequence must be ordered according to the type's default equality comparer, such
+    /// that equal items are adjacent to each other.
+    ///
+    /// The method operates in a streaming manner, meaning it only enumerates the input sequence while the
+    /// output sequence is enumerated and can therefore handle indefinite sequences.
+    /// </remarks>
+    public static IEnumerable<T> OrderedDistinct<T>(this IEnumerable<T> items)
+        => items.OrderedDistinct(EqualityComparer<T>.Default);
+
+    /// <summary>
+    /// Returns a sequence containing the items of the ordered input sequence, with duplicates removed.
+    /// </summary>
+    /// <remarks>
+    /// The input sequence must be ordered according to the type's default equality comparer, such
+    /// that equal items are adjacent to each other.
+    ///
+    /// The method operates in a streaming manner, meaning it only enumerates the input sequence while the
+    /// output sequence is enumerated and can therefore handle indefinite sequences.
+    /// </remarks>
+    public static IEnumerable<T> OrderedDistinct<T>(this IEnumerable<T> items, IEqualityComparer<T> comparer)
+    {
+        var prev = default(T);
+        var first = true;
+
+        foreach (var item in items)
+        {
+            if (first || !comparer.Equals(prev, item))
+                yield return item;
+
+            prev = item;
+            first = false;
+        }
+    }
 }

--- a/Ical.Net/Utility/DateUtil.cs
+++ b/Ical.Net/Utility/DateUtil.cs
@@ -24,6 +24,9 @@ internal static class DateUtil
     public static DateTime GetSimpleDateTimeData(IDateTime dt)
         => dt.Value;
 
+    public static CalDateTime AsCalDateTime(this DateTime t)
+        => new CalDateTime(t);
+
     public static DateTime AddWeeks(DateTime dt, int interval, DayOfWeek firstDayOfWeek)
     {
         // NOTE: fixes WeeklyUntilWkst2() eval.

--- a/Ical.Net/VTimeZoneInfo.cs
+++ b/Ical.Net/VTimeZoneInfo.cs
@@ -160,10 +160,10 @@ public class VTimeZoneInfo : CalendarComponent, IRecurrable
         set => Properties.Set("RECURRENCE-ID", value);
     }
 
-    public virtual IEnumerable<Occurrence> GetOccurrences(IDateTime dt)
+    public virtual IEnumerable<Occurrence> GetOccurrencesOfDay(IDateTime dt)
         => RecurrenceUtil.GetOccurrences(this, dt, true);
 
-    public virtual IEnumerable<Occurrence> GetOccurrences(DateTime dt)
+    public virtual IEnumerable<Occurrence> GetOccurrencesOfDay(DateTime dt)
         => RecurrenceUtil.GetOccurrences(this, new CalDateTime(dt), true);
 
     public virtual IEnumerable<Occurrence> GetOccurrences(IDateTime startTime, IDateTime endTime)

--- a/Ical.Net/VTimeZoneInfo.cs
+++ b/Ical.Net/VTimeZoneInfo.cs
@@ -56,6 +56,18 @@ public class VTimeZoneInfo : CalendarComponent, IRecurrable
         return base.Equals(obj);
     }
 
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = TimeZoneName?.GetHashCode() ?? 0;
+            hashCode = (hashCode * 397) ^ (OffsetFrom?.GetHashCode() ?? 0);
+            hashCode = (hashCode * 397) ^ (OffsetTo?.GetHashCode() ?? 0);
+
+            return hashCode;
+        }
+    }
+
     public virtual string TzId
     {
         get =>

--- a/Ical.Net/VTimeZoneInfo.cs
+++ b/Ical.Net/VTimeZoneInfo.cs
@@ -159,15 +159,15 @@ public class VTimeZoneInfo : CalendarComponent, IRecurrable
         set => Properties.Set("RECURRENCE-ID", value);
     }
 
-    public virtual HashSet<Occurrence> GetOccurrences(IDateTime dt)
+    public virtual IEnumerable<Occurrence> GetOccurrences(IDateTime dt)
         => RecurrenceUtil.GetOccurrences(this, dt, true);
 
-    public virtual HashSet<Occurrence> GetOccurrences(DateTime dt)
+    public virtual IEnumerable<Occurrence> GetOccurrences(DateTime dt)
         => RecurrenceUtil.GetOccurrences(this, new CalDateTime(dt), true);
 
-    public virtual HashSet<Occurrence> GetOccurrences(IDateTime startTime, IDateTime endTime)
+    public virtual IEnumerable<Occurrence> GetOccurrences(IDateTime startTime, IDateTime endTime)
         => RecurrenceUtil.GetOccurrences(this, startTime, endTime, true);
 
-    public virtual HashSet<Occurrence> GetOccurrences(DateTime startTime, DateTime endTime)
+    public virtual IEnumerable<Occurrence> GetOccurrences(DateTime startTime, DateTime endTime)
         => RecurrenceUtil.GetOccurrences(this, new CalDateTime(startTime), new CalDateTime(endTime), true);
 }

--- a/Ical.Net/VTimeZoneInfo.cs
+++ b/Ical.Net/VTimeZoneInfo.cs
@@ -172,12 +172,6 @@ public class VTimeZoneInfo : CalendarComponent, IRecurrable
         set => Properties.Set("RECURRENCE-ID", value);
     }
 
-    public virtual IEnumerable<Occurrence> GetOccurrencesOfDay(IDateTime dt)
-        => RecurrenceUtil.GetOccurrences(this, dt, true);
-
-    public virtual IEnumerable<Occurrence> GetOccurrencesOfDay(DateTime dt)
-        => RecurrenceUtil.GetOccurrences(this, new CalDateTime(dt), true);
-
     public virtual IEnumerable<Occurrence> GetOccurrences(IDateTime startTime, IDateTime endTime)
         => RecurrenceUtil.GetOccurrences(this, startTime, endTime, true);
 

--- a/Ical.Net/VTimeZoneInfo.cs
+++ b/Ical.Net/VTimeZoneInfo.cs
@@ -9,6 +9,7 @@ using System.Runtime.Serialization;
 using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
 using Ical.Net.Evaluation;
+using Ical.Net.Utility;
 
 namespace Ical.Net;
 
@@ -168,6 +169,6 @@ public class VTimeZoneInfo : CalendarComponent, IRecurrable
     public virtual IEnumerable<Occurrence> GetOccurrences(IDateTime startTime, IDateTime endTime)
         => RecurrenceUtil.GetOccurrences(this, startTime, endTime, true);
 
-    public virtual IEnumerable<Occurrence> GetOccurrences(DateTime startTime, DateTime endTime)
-        => RecurrenceUtil.GetOccurrences(this, new CalDateTime(startTime), new CalDateTime(endTime), true);
+    public virtual IEnumerable<Occurrence> GetOccurrences(DateTime? startTime, DateTime? endTime)
+        => RecurrenceUtil.GetOccurrences(this, startTime?.AsCalDateTime(), endTime?.AsCalDateTime(), true);
 }

--- a/Ical.Net/VTimeZoneInfo.cs
+++ b/Ical.Net/VTimeZoneInfo.cs
@@ -172,7 +172,7 @@ public class VTimeZoneInfo : CalendarComponent, IRecurrable
         set => Properties.Set("RECURRENCE-ID", value);
     }
 
-    public virtual IEnumerable<Occurrence> GetOccurrences(IDateTime startTime, IDateTime endTime)
+    public virtual IEnumerable<Occurrence> GetOccurrences(IDateTime startTime = null, IDateTime endTime = null)
         => RecurrenceUtil.GetOccurrences(this, startTime, endTime, true);
 
     public virtual IEnumerable<Occurrence> GetOccurrences(DateTime? startTime, DateTime? endTime)


### PR DESCRIPTION
This PR modifies `Calendar.GetOccurrences()` and related methods to return an ordered `IEnumerable` that generates the actual occurrences as they are enumerated, rather than returning a fully populated `HashSet`. When invoking `GetOccurrences`, the start- and endTime can now be omitted. The change brings several benefits:

* Even a calendar with undefinite recurrences can be enumerated without specifying an endTime, which can be helpful, if the endTime isn't known.
* A consumer of the lib can now easily find the first occurrence or the next after a certain date by calling something like`GetOccurrences(startTime: t).GetFirstOrDefault()`
* The occurrences are generated in ascending order
* The number of generated occurrences can be reduced, if not all are enumerated.
* The overall performance is increased, even if all occurrences are returned, because the implementation requires less sorting operations.

Modifications implemented:
* Return `IEnumerable` from `GetOccurrences` and `IEvaluator.Evaluate`
* Allow omitting `startTime` and `endTime` when calling `GetOccurrences`
* Rename the overload of `GetOccurrences` that returns the occurrences of a single day to `GetOccurrencesOfDay`, to avoid ambiguities with the other overloads, now that start/end time can be omitted.
