### PR TITLE
Remove remaining usages of MinValue and clean up related code

### DIFF
--- a/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
@@ -246,16 +246,16 @@ public class RecurrencePatternEvaluator : Evaluator
         var expandBehavior = RecurrenceUtil.GetExpandBehaviorList(pattern);
 
         var noCandidateIncrementCount = 0;
-        var candidate = DateTime.MinValue;
+        DateTime? candidate = null;
         var dateCount = 0;
         while (maxCount < 0 || dateCount < maxCount)
         {
-            if (pattern.Until is not null && candidate != DateTime.MinValue && candidate > pattern.Until)
+            if (pattern.Until is not null && candidate > pattern.Until)
             {
                 break;
             }
 
-            if (candidate != DateTime.MinValue && candidate > periodEnd)
+            if (candidate > periodEnd)
             {
                 break;
             }
@@ -297,7 +297,7 @@ public class RecurrencePatternEvaluator : Evaluator
 
                     if (pattern.Until is null || candidate <= pattern.Until)
                     {
-                        yield return candidate;
+                        yield return candidate.Value;
                         dateCount++;
                     }
                 }

--- a/Ical.Net/Serialization/DataTypes/RecurrencePatternSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/RecurrencePatternSerializer.cs
@@ -88,24 +88,11 @@ public class RecurrencePatternSerializer : EncodableDataTypeSerializer
         }
     }
 
-    public virtual void CheckMutuallyExclusive<T, TU>(string name1, string name2, T obj1, TU obj2)
+    public virtual void CheckMutuallyExclusive<T, TU>(string name1, string name2, T? obj1, TU? obj2)
+        where T : struct
+        where TU : struct
     {
-        if (Equals(obj1, default(T)) || Equals(obj2, default(TU)))
-        {
-            return;
-        }
-        // If the object is MinValue instead of its default, consider
-        // that to be unassigned.
-
-        var t1 = obj1.GetType();
-        var t2 = obj2.GetType();
-
-        var fi1 = t1.GetField("MinValue");
-        var fi2 = t2.GetField("MinValue");
-
-        var isMin1 = fi1 != null && obj1.Equals(fi1.GetValue(null));
-        var isMin2 = fi2 != null && obj2.Equals(fi2.GetValue(null));
-        if (isMin1 || isMin2)
+        if ((obj1 == null) || (obj2 == null))
         {
             return;
         }


### PR DESCRIPTION
Remove remaining usages of MinValue and clean up related code, i.e.

* Replace usage of `DateTime.MinValue` in `RecurrencePatternEvaluator`.
* Simplify `RecurrencePatternSerializer.CheckMutuallyExclusive` to avoid using reflection and checking for `MinValue`