### PR TITLE
CalDateTime Arithmetic Operations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -84,7 +84,7 @@ csharp_prefer_braces = false:suggestion
 #Style - expression bodied member options
 
 # Expression-bodied members
-csharp_style_expression_bodied_methods = false:suggestion
+csharp_style_expression_bodied_methods = when_on_single_line:suggestion
 csharp_style_expression_bodied_properties = true
 csharp_style_expression_bodied_properties = when_on_single_line:suggestion
 csharp_style_expression_bodied_indexers = false:warning

--- a/Ical.Net.Tests/CalDateTimeTests.cs
+++ b/Ical.Net.Tests/CalDateTimeTests.cs
@@ -234,20 +234,20 @@ public class CalDateTimeTests
     }
 
 
-    [Test, TestCaseSource(nameof(DateOnlyArithmeticTestCases))]
-    public (DateTime Value, bool HasTime) DateOnlyArithmeticTests(Func<IDateTime, IDateTime> operation)
+    [Test, TestCaseSource(nameof(DateOnlyValidArithmeticTestCases))]
+    public (DateTime Value, bool HasTime) DateOnlyValidArithmeticTests(Func<IDateTime, IDateTime> operation)
     {
         var result = operation(new CalDateTime(2025, 1, 15));
         return (result.Value, result.HasTime);
     }
 
-    public static IEnumerable DateOnlyArithmeticTestCases()
+    public static IEnumerable DateOnlyValidArithmeticTestCases()
     {
         var dateTime = new DateTime(2025, 1, 15);
 
         yield return new TestCaseData(new Func<IDateTime, IDateTime>(dt => dt.Subtract(TimeSpan.FromDays(1))))
             .Returns((dateTime.AddDays(-1), false))
-            .SetName($"{nameof(IDateTime.Subtract)} 1 day TimeSpan HasTime=false");
+            .SetName($"{nameof(IDateTime.Subtract)} 1 day TimeSpan");
 
         yield return new TestCaseData(new Func<IDateTime, IDateTime>(dt => dt.AddYears(1)))
             .Returns((dateTime.AddYears(1), false))
@@ -263,31 +263,37 @@ public class CalDateTimeTests
 
         yield return new TestCaseData(new Func<IDateTime, IDateTime>(dt => dt.AddHours(24)))
             .Returns((dateTime.AddHours(24), false))
-            .SetName($"{nameof(IDateTime.AddHours)} 24 hours HasTime=false");
-
-        yield return new TestCaseData(new Func<IDateTime, IDateTime>(dt => dt.AddHours(1)))
-            .Returns((dateTime.AddHours(1), true))
-            .SetName($"{nameof(IDateTime.AddHours)} 1 hour HasTime=true");
+            .SetName($"{nameof(IDateTime.AddHours)} 24 hours");
 
         yield return new TestCaseData(new Func<IDateTime, IDateTime>(dt => dt.AddMinutes(24 * 60)))
             .Returns((dateTime.AddMinutes(24 * 60), false))
-            .SetName($"{nameof(IDateTime.AddMinutes)} 1 day in minutes HasTime=false");
-
-        yield return new TestCaseData(new Func<IDateTime, IDateTime>(dt => dt.AddMinutes(23 * 60)))
-            .Returns((dateTime.AddMinutes(23 * 60), true))
-            .SetName($"{nameof(IDateTime.AddMinutes)} 23 hours in minutes HasTime=true");
+            .SetName($"{nameof(IDateTime.AddMinutes)} 1 day in minutes");
 
         yield return new TestCaseData(new Func<IDateTime, IDateTime>(dt => dt.AddSeconds(TimeSpan.FromDays(1).Seconds)))
             .Returns((dateTime.AddSeconds(TimeSpan.FromDays(1).Seconds), false))
-            .SetName($"{nameof(IDateTime.AddSeconds)} 1 day in seconds HasTime=false");
+            .SetName($"{nameof(IDateTime.AddSeconds)} 1 day in seconds");
 
         yield return new TestCaseData(new Func<IDateTime, IDateTime>(dt => dt.Add(TimeSpan.FromDays(1))))
             .Returns((dateTime.Add(TimeSpan.FromDays(1)), false))
-            .SetName($"{nameof(IDateTime.Add)} 1 day TimeSpan HasTime=false");
+            .SetName($"{nameof(IDateTime.Add)} 1 day TimeSpan");
 
-        yield return new TestCaseData(new Func<IDateTime, IDateTime>(dt => dt.Add(TimeSpan.FromSeconds(30))))
-            .Returns((dateTime.Add(TimeSpan.FromSeconds(30)), true))
-            .SetName($"{nameof(IDateTime.Add)} 30 seconds TimeSpan HasTime=true");
+        yield return new TestCaseData(new Func<IDateTime, IDateTime>(dt => dt.Add(TimeSpan.Zero)))
+            .Returns((dateTime.Add(TimeSpan.Zero), false))
+            .SetName($"{nameof(IDateTime.Add)} TimeSpan.Zero");
+    }
+
+    [Test]
+    public void DateOnlyInvalidArithmeticTests()
+    {
+        var dt = new CalDateTime(2025, 1, 15);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(() => dt.Add(TimeSpan.FromHours(1)), Throws.TypeOf<InvalidOperationException>());
+            Assert.That(() => dt.AddHours(2), Throws.TypeOf<InvalidOperationException>());
+            Assert.That(() => dt.AddMinutes(3), Throws.TypeOf<InvalidOperationException>());
+            Assert.That(() => dt.AddSeconds(4), Throws.TypeOf<InvalidOperationException>());
+        });
     }
 
     [Test]

--- a/Ical.Net.Tests/CalDateTimeTests.cs
+++ b/Ical.Net.Tests/CalDateTimeTests.cs
@@ -316,4 +316,26 @@ public class CalDateTimeTests
             Assert.That(new CalDateTime(new CalDateTime(2025, 1, 1)), Is.EqualTo(new CalDateTime(2025, 1, 1)));
         });
     }
+
+    public static IEnumerable<TestCaseData> AddAndSubtractTestCases()
+    {
+     yield return new TestCaseData(new CalDateTime(2024, 10, 27, 0, 0, 0, tzId: null), TimeSpan.FromHours(4))
+        .SetName("Floating");
+
+     yield return new TestCaseData(new CalDateTime(2024, 10, 27, 0, 0, 0, tzId: CalDateTime.UtcTzId), TimeSpan.FromHours(4))
+         .SetName("UTC");
+
+     yield return new TestCaseData(new CalDateTime(2024, 10, 27, 0, 0, 0, tzId: "Europe/Paris"), TimeSpan.FromHours(4))
+         .SetName("Zoned Date/Time with DST change");
+    }
+
+    [Test, TestCaseSource(nameof(AddAndSubtractTestCases))]
+    public void AddAndSubtract_ShouldBeReversible(CalDateTime t, TimeSpan d)
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(t.Add(d).Subtract(d), Is.EqualTo(t));
+            Assert.That(t.Add(d).Subtract(t), Is.EqualTo(d));
+        });
+    }
 }

--- a/Ical.Net/DataTypes/CalDateTime.cs
+++ b/Ical.Net/DataTypes/CalDateTime.cs
@@ -315,31 +315,6 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
     }
 
     /// <summary>
-    /// Subtracts a <see cref="TimeSpan"/> from the <see cref="CalDateTime"/>.
-    /// </summary>
-    /// <remarks>
-    /// This will also add a <see cref="IDateTime.Time"/> part that did not exist before the operation,
-    /// if the <see cref="TimeSpan"/> is not a multiple of 24 hours.
-    /// </remarks>
-    public static IDateTime operator -(CalDateTime left, TimeSpan right)
-    {
-        return left.Subtract(right);
-    }
-
-
-    /// <summary>
-    /// Adds a <see cref="TimeSpan"/> to the <see cref="CalDateTime"/>.
-    /// </summary>
-    /// <remarks>
-    /// This will also add a <see cref="IDateTime.Time"/> part that did not exist before the operation,
-    /// if the <see cref="TimeSpan"/> is not a multiple of 24 hours.
-    /// </remarks>
-    public static IDateTime operator +(CalDateTime left, TimeSpan right)
-    {
-        return left.Add(right);
-    }
-
-    /// <summary>
     /// Creates a new instance of <see cref="CalDateTime"/> with <see langword="true"/> for <see cref="HasTime"/>
     /// </summary>
     public static implicit operator CalDateTime(DateTime left)

--- a/Ical.Net/DataTypes/CalDateTime.cs
+++ b/Ical.Net/DataTypes/CalDateTime.cs
@@ -432,19 +432,23 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
     }
 
     /// <inheritdoc cref="DateTime.Add"/>
-    /// <remarks>
-    /// This will also add a <see cref="IDateTime.Time"/> part that did not exist before the operation,
-    /// if the hours are not a multiple of 24.
-    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when attempting to add a time span to a date-only instance, 
+    /// and the time span is not a multiple of full days.
+    /// </exception>
     public IDateTime Add(TimeSpan ts)
     {
+        if (!HasTime && (ts.Ticks % TimeSpan.TicksPerDay) != 0)
+        {
+            throw new InvalidOperationException("This instance represents a 'date-only' value. Only multiples of full days can be added to a 'date-only' instance.");
+        }
+
         // Ensure to handle DST transitions correctly when timezones are involved.
         var newDateTime = TzId is null ? Value.Add(ts) : AsUtc.Add(ts);
-        var hasTime = HasTime || (ts.Ticks % TimeSpan.TicksPerDay) != 0;
 
         var copy = Copy<CalDateTime>();
         copy._dateOnly = DateOnly.FromDateTime(newDateTime);
-        copy._timeOnly = hasTime ? TruncateTimeToSeconds(newDateTime) : null;
+        copy._timeOnly = HasTime ? TruncateTimeToSeconds(newDateTime) : null;
         copy._tzId = TzId is null ? null : UtcTzId;
 
         return TzId is null ? copy : copy.ToTimeZone(TzId);
@@ -457,6 +461,10 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
     /// <summary>Returns a new <see cref="IDateTime"/> by subtracting the specified <see cref="TimeSpan" /> from the value of this instance.</summary>
     /// <param name="ts">An interval.</param>
     /// <returns>An object whose value is the difference of the date and time represented by this instance and the time interval represented by <paramref name="ts" />.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when attempting to subtracting a time span from a date-only instance, 
+    /// and the time span is not a multiple of full days.
+    /// </exception>
     public IDateTime Subtract(TimeSpan ts) => Add(-ts);
 
     /// <inheritdoc cref="DateTime.AddYears"/>
@@ -484,24 +492,24 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
     }
 
     /// <inheritdoc cref="DateTime.AddHours"/>
-    /// <remarks>
-    /// This will also add a <see cref="IDateTime.Time"/> part that did not exist before the operation,
-    /// if the hours are not a multiple of 24.
-    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when attempting to add a time span to a date-only instance, 
+    /// and the time span is not a multiple of full days.
+    /// </exception>
     public IDateTime AddHours(int hours) => Add(TimeSpan.FromHours(hours));
 
     /// <inheritdoc cref="DateTime.AddMinutes"/>
-    /// <remarks>
-    /// This will also add a <see cref="IDateTime.Time"/> part that did not exist before the operation,
-    /// if the minutes are not a multiple of 1440.
-    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when attempting to add a time span to a date-only instance, 
+    /// and the time span is not a multiple of full days.
+    /// </exception>
     public IDateTime AddMinutes(int minutes) => Add(TimeSpan.FromMinutes(minutes));
 
     /// <inheritdoc cref="DateTime.AddSeconds"/>
-    /// <remarks>
-    /// This will also add a <see cref="IDateTime.Time"/> part that did not exist before the operation,
-    /// if the seconds are not a multiple of 86400.
-    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when attempting to add a time span to a date-only instance, 
+    /// and the time span is not a multiple of full days.
+    /// </exception>
     public IDateTime AddSeconds(int seconds) => Add(TimeSpan.FromSeconds(seconds));
 
     /// <summary>

--- a/Ical.Net/DataTypes/CalDateTime.cs
+++ b/Ical.Net/DataTypes/CalDateTime.cs
@@ -222,22 +222,17 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
     /// <inheritdoc/>
     public override void CopyFrom(ICopyable obj)
     {
+        if (obj is not CalDateTime calDt)
+            return;
+
         base.CopyFrom(obj);
 
-        if (obj is not IDateTime dt)
-        {
-            return;
-        }
+        // Maintain the private date/time backing fields
+        _dateOnly = calDt._dateOnly;
+        _timeOnly = TruncateTimeToSeconds(calDt._timeOnly);
+        _tzId = calDt._tzId;
 
-        if (dt is CalDateTime calDt)
-        {
-            // Maintain the private date/time backing fields
-            _dateOnly = calDt._dateOnly;
-            _timeOnly = TruncateTimeToSeconds(calDt._timeOnly);
-            _tzId = calDt._tzId;
-        }
-
-        AssociateWith(dt);
+        AssociateWith(calDt);
     }
 
     public bool Equals(CalDateTime other) => this == other;

--- a/Ical.Net/DataTypes/CalDateTime.cs
+++ b/Ical.Net/DataTypes/CalDateTime.cs
@@ -258,28 +258,28 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
     {
         return left != null
                && right != null
-               && (left.IsFloating || right.IsFloating ? left.Value < right.Value : left.AsUtc < right.AsUtc);
+               && ((left.IsFloating || right.IsFloating) ? left.Value < right.Value : left.AsUtc < right.AsUtc);
     }
 
     public static bool operator >(CalDateTime? left, IDateTime? right)
     {
         return left != null
                && right != null
-               && (left.IsFloating || right.IsFloating ? left.Value > right.Value : left.AsUtc > right.AsUtc);
+               && ((left.IsFloating || right.IsFloating) ? left.Value > right.Value : left.AsUtc > right.AsUtc);
     }
 
     public static bool operator <=(CalDateTime? left, IDateTime? right)
     {
         return left != null
                && right != null
-               && (left.IsFloating || right.IsFloating ? left.Value <= right.Value : left.AsUtc <= right.AsUtc);
+               && ((left.IsFloating || right.IsFloating) ? left.Value <= right.Value : left.AsUtc <= right.AsUtc);
     }
 
     public static bool operator >=(CalDateTime? left, IDateTime? right)
     {
         return left != null
                && right != null
-               && (left.IsFloating || right.IsFloating ? left.Value >= right.Value : left.AsUtc >= right.AsUtc);
+               && ((left.IsFloating || right.IsFloating) ? left.Value >= right.Value : left.AsUtc >= right.AsUtc);
     }
 
     public static bool operator ==(CalDateTime? left, IDateTime? right)


### PR DESCRIPTION
1. **Fix CalDateTime Arithmetic Operations**
   - Ensure `TimeSpan` add and subtract methods are reversible across DST transitions.
   - Consolidate all time-related arithmetic operations into a single method for consistency and maintainability.
   - Add related unit tests

2. **Remove TimeSpan operator overloads from CalDateTime**
Removed `+` and `-` operator overloads for `CalDateTime` that handled adding and subtracting `TimeSpan` objects

3. **Throw for invalid time span operations on date-only instance**
Throw when attempting to add/subtracting a time span to/from a date-only instance,
and the time span is not a multiple of full days.

Resolves #670