### PR TITLE
Fix: Calculation for occurrences include DST transitions correctly

### DIFF
--- a/Ical.Net.Tests/CalendarEventTest.cs
+++ b/Ical.Net.Tests/CalendarEventTest.cs
@@ -491,7 +491,7 @@ END:VCALENDAR";
         {
             Assert.That(evt.DtStart.Value, Is.EqualTo(dt));
             Assert.That(evt.DtEnd.Value, Is.EqualTo(dt.AddHours(1)));
-            Assert.That(evt.CalcFirstNominalDuration(), Is.EqualTo(TimeSpan.FromHours(1)));
+            Assert.That(evt.GetTimeSpanToAddToPeriodStartTime(), Is.EqualTo(TimeSpan.FromHours(1)));
         });
 
         evt = new CalendarEvent
@@ -503,7 +503,7 @@ END:VCALENDAR";
         Assert.Multiple(() =>
         {
             Assert.That(evt.DtStart.Value, Is.EqualTo(dt.Date));
-            Assert.That(evt.CalcFirstNominalDuration(), Is.EqualTo(TimeSpan.Zero));
+            Assert.That(evt.GetTimeSpanToAddToPeriodStartTime(), Is.EqualTo(TimeSpan.Zero));
         });
 
         evt = new CalendarEvent
@@ -515,7 +515,7 @@ END:VCALENDAR";
         {
             Assert.That(evt.DtStart.Value, Is.EqualTo(dt.Date));
             Assert.That(evt.Duration, Is.Null);
-            Assert.That(evt.CalcFirstNominalDuration(), Is.EqualTo(TimeSpan.FromDays(1)));
+            Assert.That(evt.GetTimeSpanToAddToPeriodStartTime(), Is.EqualTo(TimeSpan.FromDays(1)));
         });
 
         evt = new CalendarEvent
@@ -527,7 +527,7 @@ END:VCALENDAR";
         Assert.Multiple(() => {
             Assert.That(evt.DtStart.Value, Is.EqualTo(dt));
             Assert.That(evt.DtEnd, Is.Null);
-            Assert.That(evt.CalcFirstNominalDuration(), Is.EqualTo(TimeSpan.FromHours(2)));
+            Assert.That(evt.GetTimeSpanToAddToPeriodStartTime(), Is.EqualTo(TimeSpan.FromHours(2)));
         });
 
         evt = new CalendarEvent()
@@ -538,7 +538,7 @@ END:VCALENDAR";
 
         Assert.Multiple(() => {
             Assert.That(evt.DtStart.Value, Is.EqualTo(dt.Date));
-            Assert.That(evt.CalcFirstNominalDuration(), Is.EqualTo(TimeSpan.FromHours(2)));
+            Assert.That(evt.GetTimeSpanToAddToPeriodStartTime(), Is.EqualTo(TimeSpan.FromHours(2)));
         });
 
         evt = new CalendarEvent()
@@ -549,7 +549,7 @@ END:VCALENDAR";
 
         Assert.Multiple(() => {
             Assert.That(evt.DtStart.Value, Is.EqualTo(dt.Date));
-            Assert.That(evt.CalcFirstNominalDuration(), Is.EqualTo(TimeSpan.FromDays(1)));
+            Assert.That(evt.GetTimeSpanToAddToPeriodStartTime(), Is.EqualTo(TimeSpan.FromDays(1)));
         });
     }
 

--- a/Ical.Net.Tests/CollectionHelpersTests.cs
+++ b/Ical.Net.Tests/CollectionHelpersTests.cs
@@ -24,7 +24,6 @@ internal class CollectionHelpersTests
     {
         Assert.Multiple(() =>
         {
-            Assert.That(GetExceptionDates(), Is.EqualTo(GetExceptionDates()));
             Assert.That(GetExceptionDates(), Is.Not.Null);
             Assert.That(GetExceptionDates(), Is.Not.EqualTo(null));
         });

--- a/Ical.Net.Tests/CopyComponentTests.cs
+++ b/Ical.Net.Tests/CopyComponentTests.cs
@@ -60,7 +60,6 @@ public class CopyComponentTests
     {
         DtStart = new CalDateTime(_now),
         DtEnd = new CalDateTime(_later),
-        Duration = TimeSpan.FromHours(1),
     };
 
     private static string SerializeEvent(CalendarEvent e) => new CalendarSerializer().SerializeToString(new Calendar { Events = { e } });

--- a/Ical.Net.Tests/EqualityAndHashingTests.cs
+++ b/Ical.Net.Tests/EqualityAndHashingTests.cs
@@ -79,7 +79,6 @@ public class EqualityAndHashingTests
     {
         DtStart = new CalDateTime(_nowTime),
         DtEnd = new CalDateTime(_later),
-        Duration = TimeSpan.FromHours(1),
     };
 
     private static string SerializeEvent(CalendarEvent e) => new CalendarSerializer().SerializeToString(new Calendar { Events = { e } });
@@ -112,7 +111,6 @@ public class EqualityAndHashingTests
         var e = new CalendarEvent
         {
             DtStart = new CalDateTime(_nowTime),
-            DtEnd = new CalDateTime(_later),
             Duration = TimeSpan.FromHours(1),
             RecurrenceRules = new List<RecurrencePattern> { rruleA },
         };
@@ -130,7 +128,6 @@ public class EqualityAndHashingTests
         expectedCalendar.Events.Add(new CalendarEvent
         {
             DtStart = new CalDateTime(_nowTime),
-            DtEnd = new CalDateTime(_later),
             Duration = TimeSpan.FromHours(1),
             RecurrenceRules = new List<RecurrencePattern> { rruleB },
         });

--- a/Ical.Net.Tests/PeriodTests.cs
+++ b/Ical.Net.Tests/PeriodTests.cs
@@ -1,0 +1,97 @@
+﻿//
+// Copyright ical.net project maintainers and contributors.
+// Licensed under the MIT license.
+//
+
+#nullable enable
+using System;
+using Ical.Net.DataTypes;
+using NUnit.Framework;
+
+namespace Ical.Net.Tests;
+
+[TestFixture]
+public class PeriodTests
+{
+    [Test]
+    public void CreatePeriodWithArguments()
+    {
+        var period = new Period(new CalDateTime(2025, 1, 1, 0, 0, 0, "America/New_York"));
+        var periodWithEndTime = new Period(new CalDateTime(2025, 1, 1, 0, 0, 0, "America/New_York"), new CalDateTime(2025, 1, 1, 1, 0, 0, "America/New_York"));
+        var periodWithDuration = new Period(new CalDateTime(2025, 1, 1, 0, 0, 0, "America/New_York"), new TimeSpan(1, 0, 0));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(period.StartTime, Is.EqualTo(new CalDateTime(2025, 1, 1, 0, 0, 0, "America/New_York")));
+            Assert.That(period.EndTime, Is.Null);
+            Assert.That(period.Duration, Is.Null);
+            
+            Assert.That(periodWithEndTime.StartTime, Is.EqualTo(new CalDateTime(2025, 1, 1, 0, 0, 0, "America/New_York")));
+            Assert.That(periodWithEndTime.EndTime, Is.EqualTo(new CalDateTime(2025, 1, 1, 1, 0, 0, "America/New_York")));
+            Assert.That(periodWithEndTime.Duration, Is.EqualTo(new TimeSpan(1, 0, 0)));
+
+            Assert.That(periodWithDuration.StartTime, Is.EqualTo(new CalDateTime(2025, 1, 1, 0, 0, 0, "America/New_York")));
+            Assert.That(periodWithDuration.EndTime, Is.EqualTo(new CalDateTime(2025, 1, 1, 1, 0, 0, "America/New_York")));
+            Assert.That(periodWithDuration.Duration, Is.EqualTo(new TimeSpan(1, 0, 0)));
+        });
+    }
+
+    [Test]
+    public void CreatePeriodWithInvalidArgumentsShouldThrow()
+    {
+        Assert.Throws<ArgumentException>(() => _ = new Period(new CalDateTime(2025, 1, 1, 0, 0, 0, "America/New_York"),
+            new CalDateTime(2025, 1, 1, 0, 0, 0, "America/New_York")));
+        Assert.Throws<ArgumentException>(() =>
+            _ = new Period(new CalDateTime(2025, 1, 1, 0, 0, 0, "America/New_York"), new TimeSpan(-1, 0, 0)));
+    }
+    [Test]
+    public void SetAndGetStartTime()
+    {
+        var period = new Period(new CalDateTime(DateTime.UtcNow));
+        var startTime = new CalDateTime(2025, 1, 1, 0, 0, 0);
+        period.StartTime = startTime;
+
+        Assert.That(period.StartTime, Is.EqualTo(startTime));
+    }
+
+    [Test]
+    public void SetEndTime_GetDuration()
+    {
+        var period = new Period(new CalDateTime(2025, 1, 1, 0, 0, 0));
+        var endTime = new CalDateTime(2025, 1, 31, 0, 0, 0);
+        period.EndTime = endTime;
+
+        Assert.That(period.EndTime, Is.EqualTo(endTime));
+        Assert.That(period.GetOriginalValues().EndTime, Is.EqualTo(endTime));
+        Assert.That(period.GetOriginalValues().Duration, Is.Null);
+        Assert.That(period.Duration, Is.EqualTo(new TimeSpan(30, 0, 0, 0)));
+    }
+
+    [Test]
+    public void SetDuration_GetEndTime()
+    {
+        var period = new Period(new CalDateTime(2025, 1, 1, 0, 0, 0));
+        var duration = new TimeSpan(1, 0, 0);
+        period.Duration = duration;
+
+        Assert.That(period.Duration, Is.EqualTo(duration));
+        Assert.That(period.GetOriginalValues().Duration, Is.EqualTo(duration));
+        Assert.That(period.GetOriginalValues().EndTime, Is.Null);
+        Assert.That(period.EndTime, Is.EqualTo(new CalDateTime(2025, 1, 1, 1, 0, 0)));
+    }
+
+    [Test]
+    public void CollidesWithPeriod()
+    {
+        var period1 = new Period(new CalDateTime(2025, 1, 1, 0, 0, 0), new TimeSpan(1, 0, 0));
+        var period2 = new Period(new CalDateTime(2025, 1, 1, 0, 30, 0), new TimeSpan(1, 0, 0));
+        var period3 = new Period(new CalDateTime(2025, 1, 1, 1, 30, 0), new TimeSpan(1, 0, 0));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(period1.CollidesWith(period2), Is.True);
+            Assert.That(period1.CollidesWith(period3), Is.False);
+            Assert.That(period2.CollidesWith(period3), Is.True);
+        });
+    }
+}

--- a/Ical.Net.Tests/RecurrenceTests_From_Issues.cs
+++ b/Ical.Net.Tests/RecurrenceTests_From_Issues.cs
@@ -155,7 +155,7 @@ public class RecurrenceTests_From_Issues
             Assert.That(occurrence.Source, Is.SameAs(myEvent));
             Assert.That(occurrence.Period.StartTime.HasTime, Is.False);
             Assert.That(occurrence.Period.StartTime, Is.EqualTo(myEvent.Start));
-            Assert.That(occurrence.Period.EndTime.HasTime, Is.False);
+            Assert.That(occurrence.Period.EndTime?.HasTime, Is.False);
             Assert.That(occurrence.Period.EndTime, Is.EqualTo(myEvent.End));
         });
     }
@@ -194,7 +194,7 @@ public class RecurrenceTests_From_Issues
             Assert.That(occurrence.Source, Is.SameAs(myEvent));
             Assert.That(occurrence.Period.StartTime.HasTime, Is.False);
             Assert.That(occurrence.Period.StartTime, Is.EqualTo(myEvent.Start));
-            Assert.That(occurrence.Period.EndTime.HasTime, Is.False);
+            Assert.That(occurrence.Period.EndTime?.HasTime, Is.False);
             Assert.That(occurrence.Period.EndTime, Is.EqualTo(myEvent.End));
         });
     }
@@ -232,7 +232,7 @@ public class RecurrenceTests_From_Issues
             Assert.That(occurrence.Source, Is.SameAs(myEvent));
             Assert.That(occurrence.Period.StartTime.HasTime, Is.False);
             Assert.That(occurrence.Period.StartTime, Is.EqualTo(myEvent.Start));
-            Assert.That(occurrence.Period.EndTime.HasTime, Is.False);
+            Assert.That(occurrence.Period.EndTime?.HasTime, Is.False);
             Assert.That(occurrence.Period.EndTime, Is.EqualTo(myEvent.End));
         });
     }
@@ -270,7 +270,7 @@ public class RecurrenceTests_From_Issues
             Assert.That(myEvent.IsAllDay, Is.True);
             Assert.That(occurrence.Period.StartTime.HasTime, Is.False);
             Assert.That(occurrence.Period.StartTime, Is.EqualTo(myEvent.Start));
-            Assert.That(occurrence.Period.EndTime.HasTime, Is.False);
+            Assert.That(occurrence.Period.EndTime?.HasTime, Is.False);
             Assert.That(occurrence.Period.EndTime, Is.EqualTo(myEvent.End));
         });
     }

--- a/Ical.Net.Tests/RecurrenceTests_From_Issues.cs
+++ b/Ical.Net.Tests/RecurrenceTests_From_Issues.cs
@@ -1,0 +1,518 @@
+﻿//
+// Copyright ical.net project maintainers and contributors.
+// Licensed under the MIT license.
+//
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ical.Net.CalendarComponents;
+using Ical.Net.DataTypes;
+using NUnit.Framework;
+
+namespace Ical.Net.Tests;
+
+/// <summary>
+/// The class contains the tests for submitted issues from the GitHub repository,
+/// slightly modified to fit the testing environment and the current version of the library.
+/// </summary>
+[TestFixture]
+public class RecurrenceTests_From_Issues
+{
+    [Test]
+    public void GetOccurrence_DtEnd_ShouldBeExcluded()
+    {
+        // VEVENT duration not handled correctly in case of a DST change between DTSTART and DTEND #660 
+
+        // DST transition occurs on 2024-10-27, 02:00:00,
+        // when the clocks go back one hour from BST to GMT.
+        var startDate = new CalDateTime("20241001T000000", "Europe/London");
+        var endDate = new CalDateTime("20241027T020000", "Europe/London");
+
+        var ical =
+            $"""
+             BEGIN:VCALENDAR
+             VERSION:2.0
+             PRODID:Video Wall
+             BEGIN:VEVENT
+             UID:VW6
+             DTSTAMP:20240630T000000Z
+             DTSTART;TZID=Europe/London:{startDate}
+             DTEND;TZID=Europe/London:{endDate}
+             SUMMARY:New home speech.mp4
+             COMMENT:New location announcement; may need update before Thanksgiving
+             END:VEVENT
+             END:VCALENDAR
+             """;
+
+        var calendar = Calendar.Load(ical);
+        // Event ends on 2024-10-27, at 02:00:00 GMT (when DST ends). The end time is excluded by RFC 5545 definition.
+        var occurrences = calendar.GetOccurrences(endDate, new CalDateTime("20250101T000000", "Europe/London")).ToList();
+
+        Assert.That(occurrences, Is.Empty);
+    }
+
+    [Test]
+    public void ClockGoingForwardTest()
+    {
+        // Daylight saving transition bugs #623
+
+        // Arrange
+        var tzId = "Europe/London";
+
+        var myEvent = new CalendarEvent
+        {
+            Start = new CalDateTime(2025, 3, 30, 0, 0, 0, tzId),
+            End = new CalDateTime(2025, 3, 30, 2, 0, 0, tzId)
+            // Either the Duration OR the Ende time can be used to calculate the period.
+        };
+        
+        var calendar = new Calendar();
+        calendar.Events.Add(myEvent);
+
+        // Act
+        IDateTime start = new CalDateTime(2025, 3, 30, 0, 0, 0, tzId);
+        IDateTime end = new CalDateTime(2025, 3, 31, 0, 0, 0, tzId);
+
+        var occurrences = calendar.GetOccurrences<CalendarEvent>(start, end).ToList();
+        var occurrence = occurrences.Single();
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(occurrences.Count(), Is.EqualTo(1));
+            Assert.That(occurrence.Source, Is.SameAs(myEvent));
+            Assert.That(occurrence.Period.StartTime, Is.EqualTo(myEvent.Start));
+            Assert.That(occurrence.Period.EndTime, Is.EqualTo(myEvent.End));
+        });
+    }
+
+    [Test]
+    public void ClockGoingBackTest()
+    {
+        // Daylight saving transition bugs #623 
+
+        // Arrange
+        var tzId = "Europe/London";
+
+        var myEvent = new CalendarEvent
+        {
+            Start = new CalDateTime(2024, 10, 27, 1, 0, 0, tzId),
+            End = new CalDateTime(2024, 10, 27, 2, 0, 0, tzId)
+        };
+
+        var calendar = new Calendar();
+        calendar.Events.Add(myEvent);
+
+        // Act
+        IDateTime start = new CalDateTime(2024, 10, 27, 0, 0, 0, tzId);
+        IDateTime end = new CalDateTime(2024, 10, 28, 0, 0, 0, tzId);
+
+        var occurrences = calendar.GetOccurrences<CalendarEvent>(start, end).ToList();
+        var occurrence = occurrences.Single();
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(occurrences.Count(), Is.EqualTo(1));
+            Assert.That(occurrence.Source, Is.SameAs(myEvent));
+            Assert.That(occurrence.Period.StartTime, Is.EqualTo(myEvent.Start));
+            Assert.That(occurrence.Period.EndTime, Is.EqualTo(myEvent.End));
+        });
+    }
+
+    [Test]
+    public void ClockGoingForwardAllDayTest()
+    {
+        // Daylight saving transition bugs #623 
+
+        // Arrange
+        var timeZoneId = "Europe/London";
+
+        var myEvent = new CalendarEvent
+        {
+            Start = new CalDateTime(2025, 3, 30),
+            End = new CalDateTime(2025, 3, 31)
+        };
+
+        Assert.That(myEvent.IsAllDay, Is.True);
+
+        var calendar = new Calendar();
+        calendar.Events.Add(myEvent);
+
+        // Act
+        IDateTime start = new CalDateTime(2025, 3, 30, 0, 0, 0, timeZoneId);
+        IDateTime end = new CalDateTime(2025, 3, 31, 0, 0, 0, timeZoneId);
+
+        var occurrences = calendar.GetOccurrences<CalendarEvent>(start, end).ToList();
+        var occurrence = occurrences.Single();
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(occurrences.Count, Is.EqualTo(1));
+            Assert.That(occurrence.Source, Is.SameAs(myEvent));
+            Assert.That(occurrence.Period.StartTime.HasTime, Is.False);
+            Assert.That(occurrence.Period.StartTime, Is.EqualTo(myEvent.Start));
+            Assert.That(occurrence.Period.EndTime.HasTime, Is.False);
+            Assert.That(occurrence.Period.EndTime, Is.EqualTo(myEvent.End));
+        });
+    }
+
+    [Test]
+    public void ClockGoingBackAllDayTest()
+    {
+        // Daylight saving transition bugs #623 
+
+        // Arrange
+        var timeZoneId = "GMT Standard Time";
+
+        var myEvent = new CalendarEvent
+        {
+            Start = new CalDateTime(2024, 10, 27),
+            End = new CalDateTime(2024, 10, 28)
+        };
+
+        Assert.That(myEvent.IsAllDay, Is.True);
+
+        var calendar = new Calendar();
+        calendar.Events.Add(myEvent);
+
+        // Act
+        IDateTime start = new CalDateTime(2024, 10, 27, 0, 0, 0, timeZoneId);
+        IDateTime end = new CalDateTime(2024, 10, 28, 0, 0, 0, timeZoneId);
+        // Duration can't be used at the same time as End.
+
+        var occurrences = calendar.GetOccurrences<CalendarEvent>(start, end).ToList();
+        var occurrence = occurrences.Single();
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(occurrences.Count, Is.EqualTo(1));
+            Assert.That(occurrence.Source, Is.SameAs(myEvent));
+            Assert.That(occurrence.Period.StartTime.HasTime, Is.False);
+            Assert.That(occurrence.Period.StartTime, Is.EqualTo(myEvent.Start));
+            Assert.That(occurrence.Period.EndTime.HasTime, Is.False);
+            Assert.That(occurrence.Period.EndTime, Is.EqualTo(myEvent.End));
+        });
+    }
+
+    [Test]
+    public void ClockGoingBackAllDayNonLocalTest()
+    {
+        // Daylight saving transition bugs #623 
+
+        // Arrange
+        var timeZoneId = "Pacific Standard Time";
+
+        var myEvent = new CalendarEvent
+        {
+            Start = new CalDateTime(2024, 10, 27),
+            End = new CalDateTime(2024, 10, 28)
+            // Duration can't be used at the same time as End.
+        };
+
+        var calendar = new Calendar();
+        calendar.Events.Add(myEvent);
+
+        // Act
+        IDateTime start = new CalDateTime(2024, 10, 27, 0, 0, 0, timeZoneId);
+        IDateTime end = new CalDateTime(2024, 10, 28, 0, 0, 0, timeZoneId);
+
+        var occurrences = calendar.GetOccurrences<CalendarEvent>(start, end).ToList();
+        var occurrence = occurrences.Single();
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(myEvent.IsAllDay, Is.True);
+            Assert.That(occurrences.Count, Is.EqualTo(1));
+            Assert.That(occurrence.Source, Is.SameAs(myEvent));
+            Assert.That(occurrence.Period.StartTime.HasTime, Is.False);
+            Assert.That(occurrence.Period.StartTime, Is.EqualTo(myEvent.Start));
+            Assert.That(occurrence.Period.EndTime.HasTime, Is.False);
+            Assert.That(occurrence.Period.EndTime, Is.EqualTo(myEvent.End));
+        });
+    }
+
+    [Test]
+    public void ClockGoingForwardAllDayNonLocalTest()
+    {
+        // Daylight saving transition bugs #623 
+
+        // Arrange
+        var timeZoneId = "Pacific Standard Time";
+
+        var myEvent = new CalendarEvent
+        {
+            Start = new CalDateTime(2025, 3, 30),
+            End = new CalDateTime(2025, 3, 31)
+            // Duration can't be used at the same time as End.
+        };
+
+        var calendar = new Calendar();
+        calendar.Events.Add(myEvent);
+
+        // Act
+        IDateTime start = new CalDateTime(2025, 3, 30, 0, 0, 0, timeZoneId);
+        IDateTime end = new CalDateTime(2025, 3, 31, 0, 0, 0, timeZoneId);
+
+        var occurrences = calendar.GetOccurrences<CalendarEvent>(start, end).ToList();
+        var occurrence = occurrences.Single();
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(occurrences.Count, Is.EqualTo(1));
+            Assert.That(occurrence.Source, Is.SameAs(myEvent));
+            Assert.That(myEvent.IsAllDay, Is.True);
+            Assert.That(occurrence.Period.StartTime.HasTime, Is.False);
+            Assert.That(occurrence.Period.StartTime, Is.EqualTo(myEvent.Start));
+            Assert.That(occurrence.Period.EndTime.HasTime, Is.False);
+            Assert.That(occurrence.Period.EndTime, Is.EqualTo(myEvent.End));
+        });
+    }
+
+    [Test]
+    public void CheckCalendarZone()
+    {
+        // GetOccurrences does not work properly when used with TimeZones #671 
+
+        var zone = "America/Los_Angeles";
+        var calendar = new Ical.Net.Calendar();
+        var blockDate = new DateTime(2024, 12, 2, 8, 0, 0, DateTimeKind.Utc);
+        calendar.Events.Add(new CalendarEvent
+        {
+            Summary = "Unavailable Before Work",
+            DtStart = new CalDateTime(blockDate, zone), //.ToTimeZone(zone),
+            DtEnd = new CalDateTime(blockDate.Add(new TimeSpan(8, 0, 0)), zone), //.ToTimeZone(zone),
+            RecurrenceRules = new List<RecurrencePattern>
+            {
+                new RecurrencePattern
+                {
+                    Frequency = Ical.Net.FrequencyType.Weekly,
+                    Interval = 1,
+                    ByDay = new List<WeekDay>
+                    {
+                        new WeekDay(DayOfWeek.Monday)
+                    }
+                }
+            }
+        });
+
+        var start = new DateTime(2024, 12, 9, 8, 5, 0, DateTimeKind.Utc);
+        var end = new DateTime(2024, 12, 10, 7, 59, 59, DateTimeKind.Utc);
+        var occurrence = calendar.GetOccurrences(start, end);
+
+        Assert.That(occurrence.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Daylight_Savings_Changes_567()
+    {
+        //  GetOccurrences Creates event with invalid time due to Daylight Savings changes #567 
+
+        var calStart = new CalDateTime(DateTimeOffset.Parse("2023-01-14T19:21:03.700Z").UtcDateTime, "UTC");
+        var calFinish = new CalDateTime(DateTimeOffset.Parse("2023-03-14T18:21:03.700Z").UtcDateTime, "UTC");
+        var tz = "Pacific Standard Time";
+        var pattern = new RecurrencePattern(
+            "FREQ=WEEKLY;BYDAY=SU,MO,TU,WE"); //Adjust the date to today so that the times remain constant
+        var localTzStartAdjust = (DateTime.Now.Add(TimeSpan.FromHours(2).Add(TimeSpan.FromMinutes(35))));
+        var localTzFinishAdjust = DateTime.Now.Add(TimeSpan.FromHours(17));
+        var ev = new Ical.Net.CalendarComponents.CalendarEvent
+        {
+            Class = "PUBLIC",
+            Start = new CalDateTime(localTzStartAdjust, tz),
+            End = new CalDateTime(localTzFinishAdjust, tz),
+            Sequence = 0,
+            RecurrenceRules = new List<RecurrencePattern> { pattern }
+        };
+        var col = ev.GetOccurrences(calStart, calFinish);
+
+        Assert.That(col, Is.Empty);
+    }
+
+    #region Bug - Invalid recurring event occurrences after New Year #342 
+
+    private static void CheckDates(DateTime startDate, DateTime endDate, CalDateTime[] expectedDates)
+    {
+        var rule = new RecurrencePattern(FrequencyType.Weekly, 2)
+        {
+            ByDay = new List<WeekDay>
+            {
+                new WeekDay(DayOfWeek.Monday),
+                new WeekDay(DayOfWeek.Tuesday),
+                new WeekDay(DayOfWeek.Wednesday),
+                new WeekDay(DayOfWeek.Thursday),
+                new WeekDay(DayOfWeek.Friday),
+                new WeekDay(DayOfWeek.Saturday),
+                new WeekDay(DayOfWeek.Sunday),
+            }
+        };
+
+        var calendarEvent = new CalendarEvent
+        {
+            DtStart = new CalDateTime(startDate),
+            DtEnd = new CalDateTime(endDate),
+            RecurrenceRules = new List<RecurrencePattern> { rule }
+        };
+
+        var occurrences = calendarEvent.GetOccurrences(startDate, endDate);
+        var occurrencesDates = occurrences.Select(o => new CalDateTime(o.Period.StartTime.Date)).ToList();
+
+        // Sort both collections to ensure they are in the same order
+        occurrencesDates.Sort();
+        var sortedExpectedDates = expectedDates.OrderBy(d => d).ToList();
+
+        Assert.That(occurrencesDates, Is.EquivalentTo(sortedExpectedDates));
+    }
+
+    [Test]
+    public void NewYear_EachOtherWeek()
+    {
+        var startDate = new DateTime(2017, 12, 30);
+        var endDate = new DateTime(2018, 1, 29);
+        var expectedDates = new[]
+        {
+                new CalDateTime(2017, 12, 30),
+                new CalDateTime(2017, 12, 31),
+
+                // 1-7 no events
+                
+                new CalDateTime(2018, 1, 8),
+                new CalDateTime(2018, 1, 9),
+                new CalDateTime(2018, 1, 10),
+                new CalDateTime(2018, 1, 11),
+                new CalDateTime(2018, 1, 12),
+                new CalDateTime(2018, 1, 13),
+                new CalDateTime(2018, 1, 14),
+
+                // 15 - 21 no events
+
+                new CalDateTime(2018, 1, 22),
+                new CalDateTime(2018, 1, 23),
+                new CalDateTime(2018, 1, 24),
+                new CalDateTime(2018, 1, 25),
+                new CalDateTime(2018, 1, 26),
+                new CalDateTime(2018, 1, 27),
+                new CalDateTime(2018, 1, 28),
+            };
+
+        //PASS
+        CheckDates(startDate, endDate, expectedDates);
+    }
+
+    [Test]
+    public void December_EachOtherWeek()
+    {
+        var startDate = new DateTime(2017, 12, 1);
+        var endDate = new DateTime(2017, 12, 31);
+        var expectedDates = new[]
+        {
+                new CalDateTime(2017, 12, 1),
+                new CalDateTime(2017, 12, 2),
+                new CalDateTime(2017, 12, 3),
+                // 4-10 no events
+                
+                new CalDateTime(2017, 12, 11),
+                new CalDateTime(2017, 12, 12),
+                new CalDateTime(2017, 12, 13),
+                new CalDateTime(2017, 12, 14),
+                new CalDateTime(2017, 12, 15),
+                new CalDateTime(2017, 12, 16),
+                new CalDateTime(2017, 12, 17),
+
+                // 18 - 24 no events
+
+                new CalDateTime(2017, 12, 25),
+                new CalDateTime(2017, 12, 26),
+                new CalDateTime(2017, 12, 27),
+                new CalDateTime(2017, 12, 28),
+                new CalDateTime(2017, 12, 29),
+                new CalDateTime(2017, 12, 30),
+               // new CalDateTime(2017, 12, 31), 
+            };
+
+        //PASS
+        CheckDates(startDate, endDate, expectedDates);
+    }
+
+    [Test]
+    public void NovemberEnd_December_EachOtherWeek()
+    {
+        var startDate = new DateTime(2017, 11, 30);
+        var endDate = new DateTime(2017, 12, 31);
+        var expectedDates = new[]
+        {
+                new CalDateTime(2017, 11, 30),
+                new CalDateTime(2017, 12, 1),
+                new CalDateTime(2017, 12, 2),
+                new CalDateTime(2017, 12, 3),
+                // 4-10 no events
+                
+                new CalDateTime(2017, 12, 11),
+                new CalDateTime(2017, 12, 12),
+                new CalDateTime(2017, 12, 13),
+                new CalDateTime(2017, 12, 14),
+                new CalDateTime(2017, 12, 15),
+                new CalDateTime(2017, 12, 16),
+                new CalDateTime(2017, 12, 17),
+
+                // 18 - 24 no events
+
+                new CalDateTime(2017, 12, 25),
+                new CalDateTime(2017, 12, 26),
+                new CalDateTime(2017, 12, 27),
+                new CalDateTime(2017, 12, 28),
+                new CalDateTime(2017, 12, 29),
+                new CalDateTime(2017, 12, 30),
+            };
+
+        // PASS
+        CheckDates(startDate, endDate, expectedDates);
+    }
+    #endregion
+
+    [Test]
+    public void Except_Tuesday_Thursday_Saturday_Sunday()
+    {
+        // Every day for all of time, except Tuesday,Thursday,Saturday,and Sunday" Not working #298 
+
+        var vEvent = new CalendarEvent
+        {
+            Summary = "BIO CLASS",//subject
+            Description = "Details at CLASS",//description of meeting
+            Location = "Building 101",//location
+            DtStart = new CalDateTime(DateTime.Parse("2017-06-01T08:00")),
+            DtEnd = new CalDateTime(DateTime.Parse("2017-06-01T09:30")),
+            RecurrenceRules = new List<RecurrencePattern> { new RecurrencePattern(FrequencyType.Daily, 1) },
+        };
+
+        //Define the exceptions: Sunday
+        var exceptionRule = new RecurrencePattern(FrequencyType.Weekly, 1)
+        {
+            ByDay = new List<WeekDay> { new WeekDay(DayOfWeek.Sunday), new WeekDay(DayOfWeek.Saturday),
+                new WeekDay(DayOfWeek.Tuesday),new WeekDay(DayOfWeek.Thursday)}
+        };
+        vEvent.ExceptionRules = new List<RecurrencePattern> { exceptionRule };
+
+        var calendar = new Calendar();
+        calendar.Events.Add(vEvent);
+
+        var occurrences = vEvent.GetOccurrences(DateTime.Parse("2017-06-01T00:00"), DateTime.Parse("2017-06-30T23:59")).ToList();
+
+        var excludedDays = new List<DayOfWeek> { DayOfWeek.Sunday, DayOfWeek.Saturday, DayOfWeek.Tuesday, DayOfWeek.Thursday };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(occurrences.Count, Is.EqualTo(13));
+            // Assert that none of the occurrences contain a weekday from the ByDay list
+            foreach (var occurrence in occurrences)
+            {
+                Assert.That(excludedDays, Does.Not.Contain(occurrence.Period.StartTime.DayOfWeek));
+            }
+        });
+    }
+}

--- a/Ical.Net.Tests/SerializationTests.cs
+++ b/Ical.Net.Tests/SerializationTests.cs
@@ -27,7 +27,7 @@ public class SerializationTests
     private static CalendarSerializer GetNewSerializer() => new CalendarSerializer();
     private static string SerializeToString(Calendar c) => GetNewSerializer().SerializeToString(c);
     private static string SerializeToString(CalendarEvent e) => SerializeToString(new Calendar { Events = { e } });
-    private static CalendarEvent GetSimpleEvent() => new CalendarEvent { DtStart = new CalDateTime(_nowTime), DtEnd = new CalDateTime(_later), Duration = _later - _nowTime };
+    private static CalendarEvent GetSimpleEvent() => new CalendarEvent { DtStart = new CalDateTime(_nowTime), Duration = _later - _nowTime };
     private static Calendar UnserializeCalendar(string s) => Calendar.Load(s);
 
     internal static void CompareCalendars(Calendar cal1, Calendar cal2)
@@ -362,7 +362,7 @@ public class SerializationTests
     [Test]
     public void DurationIsStable_Tests()
     {
-        var e = GetSimpleEvent();
+        var e = GetSimpleEvent(); // DTSTART and DURATION are set
         var originalDuration = e.Duration;
         var c = new Calendar();
         c.Events.Add(e);
@@ -370,7 +370,7 @@ public class SerializationTests
         Assert.Multiple(() =>
         {
             Assert.That(e.Duration, Is.EqualTo(originalDuration));
-            Assert.That(!serialized.Contains("DURATION"), Is.True);
+            Assert.That(serialized.Contains("DURATION"), Is.True);
         });
     }
 

--- a/Ical.Net/CalendarComponents/Alarm.cs
+++ b/Ical.Net/CalendarComponents/Alarm.cs
@@ -101,9 +101,9 @@ public class Alarm : CalendarComponent
                     if (o.Period.EndTime != null)
                     {
                         dt = o.Period.EndTime;
-                        if (d == default(TimeSpan))
+                        if (d == default)
                         {
-                            d = o.Period.Duration;
+                            d = o.Period.Duration!.Value; // the getter always returns a value
                         }
                     }
                     // Use the "last-found" duration as a reference point

--- a/Ical.Net/CalendarComponents/CalendarEvent.cs
+++ b/Ical.Net/CalendarComponents/CalendarEvent.cs
@@ -91,18 +91,18 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
     }
 
     /// <summary>
-    /// Calculates and returns the <b>nominal duration</b> of the first occurrence of this event.
+    /// Gets the time span that gets added to the period start time to get the period end time.
     /// <para/>
     /// If the <see cref="CalendarEvent.Duration"/> property is not null, its value will be returned.<br/>
     /// If <see cref="RecurringComponent.DtStart"/> and <see cref="CalendarEvent.DtEnd"/> are set, it will return <see cref="CalendarEvent.DtEnd"/> minus <see cref="CalendarEvent.DtStart"/>.<br/>
     /// Otherwise, it will return <see cref="TimeSpan.Zero"/>.
     /// </summary>
     /// <remarks>
-    /// Note: For recurring events, the <b>effective duration</b> of individual occurrences may vary due to DST transitions
+    /// Note: For recurring events, the <b>exact duration</b> of individual occurrences may vary due to DST transitions
     /// of the given <see cref="RecurringComponent.DtStart"/> and <see cref="CalendarEvent.DtEnd"/> timezones.
     /// </remarks>
-    /// <returns>The <b>nominal duration</b> of this event.</returns>
-    public virtual TimeSpan CalcFirstNominalDuration()
+    /// <returns>The time span that gets added to the period start time to get the period end time.</returns>
+    public virtual TimeSpan GetTimeSpanToAddToPeriodStartTime()
     {
         // 3.8.5.3. Recurrence Rule
         // If the duration of the recurring component is specified with the
@@ -126,8 +126,9 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
                 "DTEND" or "DUE" property, then the same EXACT duration will apply
                 to all the members of the generated recurrence set.
 
-                We use the nominal duration here, because the caller will set the period end time to the
-                same timezone as the event end time, finally leading to an exact duration
+                We use the difference from DtStart to DtEnd (neglecting timezone),
+                because the caller will set the period end time to the
+                same timezone as the event end time. This finally leads to an exact duration
                 calculation from the zoned start time to the zoned end time.
              */
             return DtEnd.Value - DtStart.Value;
@@ -143,7 +144,7 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
             return TimeSpan.FromDays(1);
         }
 
-        // For DtStart.HasTime, but also the default case
+        // For DtStart.HasTime but no DtEnd - also the default case
         //
         // RFC 5545 3.6.1:
         // For cases where a "VEVENT" calendar component

--- a/Ical.Net/CalendarComponents/CalendarEvent.cs
+++ b/Ical.Net/CalendarComponents/CalendarEvent.cs
@@ -102,7 +102,7 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
     /// of the given <see cref="RecurringComponent.DtStart"/> and <see cref="CalendarEvent.DtEnd"/> timezones.
     /// </remarks>
     /// <returns>The time span that gets added to the period start time to get the period end time.</returns>
-    public virtual TimeSpan GetTimeSpanToAddToPeriodStartTime()
+    internal TimeSpan GetTimeSpanToAddToPeriodStartTime()
     {
         // 3.8.5.3. Recurrence Rule
         // If the duration of the recurring component is specified with the

--- a/Ical.Net/CalendarComponents/CalendarEvent.cs
+++ b/Ical.Net/CalendarComponents/CalendarEvent.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 //
 
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,23 +17,34 @@ namespace Ical.Net.CalendarComponents;
 /// <summary>
 /// A class that represents an RFC 5545 VEVENT component.
 /// </summary>
-/// <note>
-///     TODO: Add support for the following properties:
-///     <list type="bullet">
-///         <item>Add support for the Organizer and Attendee properties</item>
-///         <item>Add support for the Class property</item>
-///         <item>Add support for the Geo property</item>
-///         <item>Add support for the Priority property</item>
-///         <item>Add support for the Related property</item>
-///         <item>Create a TextCollection DataType for 'text' items separated by commas</item>
-///     </list>
-/// </note>
+/// <remarks>
+/// The following properties are not supported by this class:
+/// <para/>
+/// - Organizer and Attendee properties
+/// - Class property
+/// - Priority property
+/// - Related property
+/// - TextCollection DataType for 'text' items separated by commas
+/// </remarks>
 public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<CalendarEvent>
 {
     internal const string ComponentName = "VEVENT";
 
+    private void SetProperty<T>(string group, T value)
+    {
+        if (value is not null)
+        {
+            Properties.Set(group, value);
+            return;
+        }
+
+        Properties.Remove(group);
+    }
+
     /// <summary>
     /// The end date/time of the event.
+    /// <para/>
+    /// Either <see cref="Duration"/> OR <see cref="DtEnd"/> can be present in the event, but not both.
     /// <note>
     /// If the duration has not been set, but
     /// the start/end time of the event is available,
@@ -42,132 +54,136 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
     /// will be extrapolated.
     /// </note>
     /// </summary>
-    public virtual IDateTime DtEnd
+    public virtual IDateTime? DtEnd
     {
-        get => Properties.Get<IDateTime>("DTEND");
+        get => Properties.Get<IDateTime?>("DTEND");
         set
         {
-            if (!Equals(DtEnd, value))
-            {
-                Properties.Set("DTEND", value);
-            }
+            if (Duration is not null) throw new InvalidOperationException("DTEND property cannot be set when DURATION property is not null.");
+            SetProperty("DTEND", value);
         }
     }
 
     /// <summary>
     /// The duration of the event.
-    /// <note>
+    /// <para/>
+    /// Either <see cref="Duration"/> OR <see cref="DtEnd"/> can be present in the event, but not both.
+    /// </summary>
+    /// <remarks>
     /// If a start time and duration is available,
     /// the end time is automatically determined.
-    /// Likewise, if the end time and duration is
-    /// available, but a start time is not determined,
-    /// the start time will be extrapolated from
-    /// available information.
-    /// </note>
-    /// </summary>
-    // NOTE: Duration is not supported by all systems,
-    // (i.e. iPhone) and cannot co-exist with DtEnd.
-    // RFC 5545 states:
-    //
-    //      ; either 'dtend' or 'duration' may appear in
-    //      ; a 'eventprop', but 'dtend' and 'duration'
-    //      ; MUST NOT occur in the same 'eventprop'
-    //
-    // Therefore, Duration is not serialized, as DtEnd
-    // should always be extrapolated from the duration.
-    public virtual TimeSpan Duration
+    /// Likewise, the duration is determined with start/end times
+    /// if it is not explicitly set.
+    /// <para/>
+    /// RFC 5545 states:
+    /// Either 'dtend' or 'duration' may appear in
+    /// an 'eventprop', but 'dtend' and 'duration'
+    /// MUST NOT occur in the same 'eventprop'
+    /// </remarks>
+    public virtual TimeSpan? Duration
     {
-        get => Properties.Get<TimeSpan>("DURATION");
+        get => Properties.Get<TimeSpan?>("DURATION");
         set
         {
-            if (!Equals(Duration, value))
-            {
-                Properties.Set("DURATION", value);
-            }
+            if (DtEnd is not null) throw new InvalidOperationException("DURATION property cannot be set when DTEND property is not null.");
+            SetProperty("DURATION", value); 
         }
     }
 
     /// <summary>
-    /// Calculates and returns the duration of the first occurrence of this event.
+    /// Calculates and returns the <b>nominal duration</b> of the first occurrence of this event.
+    /// <para/>
+    /// If the <see cref="CalendarEvent.Duration"/> property is not null, its value will be returned.<br/>
+    /// If <see cref="RecurringComponent.DtStart"/> and <see cref="CalendarEvent.DtEnd"/> are set, it will return <see cref="CalendarEvent.DtEnd"/> minus <see cref="CalendarEvent.DtStart"/>.<br/>
+    /// Otherwise, it will return <see cref="TimeSpan.Zero"/>.
     /// </summary>
     /// <remarks>
-    /// If the 'DURATION' property is set, this method will return its value.
-    /// Otherwise, if DTSTART and DTEND are set, it will return DTSTART minus DTEND.
-    /// Otherwise it will return `default(TimeSpan)`.
-    /// Note that for recurring events, the duration of individual occurrences may vary
-    /// if they span a DST change.
+    /// Note: For recurring events, the <b>effective duration</b> of individual occurrences may vary due to DST transitions
+    /// of the given <see cref="RecurringComponent.DtStart"/> and <see cref="CalendarEvent.DtEnd"/> timezones.
     /// </remarks>
-    /// <returns>The effective duration of this event.</returns>
-    public virtual TimeSpan GetFirstDuration()
+    /// <returns>The <b>nominal duration</b> of this event.</returns>
+    public virtual TimeSpan CalcFirstNominalDuration()
     {
-        if (Properties.ContainsKey("DURATION"))
-            return Duration;
+        // 3.8.5.3. Recurrence Rule
+        // If the duration of the recurring component is specified with the
+        // "DURATION" property, then the same NOMINAL duration will apply to
+        // all the members of the generated recurrence set and the exact
+        // duration of each recurrence instance will depend on its specific
+        // start time.
+        if (Duration is not null)
+            return Duration.Value;
 
-        if (DtStart is not null)
+        System.Diagnostics.Debug.Assert(DtStart is not null);
+
+        if (DtEnd is not null)
         {
-            if (DtEnd is not null)
-            {
-                // The "DTEND" property
-                // for a "VEVENT" calendar component specifies the non-inclusive end
-                // of the event.
-                return DtEnd.Subtract(DtStart);
-            }
-            else if (!DtStart.HasTime)
-            {
-                // For cases where a "VEVENT" calendar component
-                // specifies a "DTSTART" property with a DATE value type but no
-                // "DTEND" nor "DURATION" property, the event's duration is taken to
-                // be one day.
-                return TimeSpan.FromDays(1);
-            }
-            else
-            {
-                // For cases where a "VEVENT" calendar component
-                // specifies a "DTSTART" property with a DATE-TIME value type but no
-                // "DTEND" property, the event ends on the same calendar date and
-                // time of day specified by the "DTSTART" property.
-                return TimeSpan.Zero;
-            }
+            /*
+                The 'DTEND' property for a 'VEVENT' calendar component specifies the
+                non-inclusive end of the event.
+
+                3.8.5.3. Recurrence Rule:
+                If the duration of the recurring component is specified with the
+                "DTEND" or "DUE" property, then the same EXACT duration will apply
+                to all the members of the generated recurrence set.
+
+                We use the nominal duration here, because the caller will set the period end time to the
+                same timezone as the event end time, finally leading to an exact duration
+                calculation from the zoned start time to the zoned end time.
+             */
+            return DtEnd.Value - DtStart.Value;
         }
 
-        // This is an illegal state. We return zero for compatibility reasons.
+        if (!DtStart.HasTime)
+        {
+            // RFC 5545 3.6.1:
+            // For cases where a "VEVENT" calendar component
+            // specifies a "DTSTART" property with a DATE value type but no
+            // "DTEND" nor "DURATION" property, the event’s duration is taken to
+            // be one day.
+            return TimeSpan.FromDays(1);
+        }
+
+        // For DtStart.HasTime, but also the default case
+        //
+        // RFC 5545 3.6.1:
+        // For cases where a "VEVENT" calendar component
+        // specifies a "DTSTART" property with a DATE-TIME value type but no
+        // "DTEND" property, the event ends on the same calendar date and
+        // time of day specified by the "DTSTART" property.
         return TimeSpan.Zero;
     }
-
 
     /// <summary>
     /// An alias to the DtEnd field (i.e. end date/time).
     /// </summary>
-    public virtual IDateTime End
+    public virtual IDateTime? End
     {
         get => DtEnd;
         set => DtEnd = value;
     }
 
     /// <summary>
-    /// Returns true if the event is an all-day event.
+    /// Returns <see langword="true"/> if the event is an all-day event,
+    /// meaning the <see cref="RecurringComponent.Start"/> is a 'DATE' value type.
     /// </summary>
-    public virtual bool IsAllDay
-    {
-        get => !Start.HasTime;
-    }
+    public virtual bool IsAllDay => !Start.HasTime;
 
     /// <summary>
     /// The geographic location (lat/long) of the event.
     /// </summary>
-    public GeographicLocation GeographicLocation
+    public virtual GeographicLocation? GeographicLocation
     {
-        get => Properties.Get<GeographicLocation>("GEO");
-        set => Properties.Set("GEO", value);
+        get => Properties.Get<GeographicLocation?>("GEO");
+        set => SetProperty("GEO", value);
     }
 
     /// <summary>
     /// The location of the event.
     /// </summary>
-    public string Location
+    public virtual string? Location
     {
-        get => Properties.Get<string>("LOCATION");
-        set => Properties.Set("LOCATION", value);
+        get => Properties.Get<string?>("LOCATION");
+        set => SetProperty("LOCATION", value);
     }
 
     /// <summary>
@@ -180,29 +196,29 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
     public virtual IList<string> Resources
     {
         get => Properties.GetMany<string>("RESOURCES");
-        set => Properties.Set("RESOURCES", value ?? new List<string>());
+        set => Properties.Set("RESOURCES", value);
     }
 
     /// <summary>
-    /// The status of the event.
+    /// The STATUS property of the event.
     /// </summary>
-    public string Status
+    public virtual string? Status
     {
-        get => Properties.Get<string>("STATUS");
-        set => Properties.Set("STATUS", value);
+        get => Properties.Get<string?>("STATUS");
+        set => SetProperty("STATUS", value);
     }
 
     /// <summary>
-    /// The transparency of the event.  In other words,
+    /// The transparency of the event. Determines,
     /// whether the period of time this event
-    /// occupies can contain other events (transparent),
+    /// occupies may overlap with other events (transparent),
     /// or if the time cannot be scheduled for anything
     /// else (opaque).
     /// </summary>
-    public string Transparency
+    public virtual string? Transparency
     {
-        get => Properties.Get<string>(TransparencyType.Key);
-        set => Properties.Set(TransparencyType.Key, value);
+        get => Properties.Get<string?>(TransparencyType.Key);
+        set => SetProperty(TransparencyType.Key, value);
     }
 
     /// <summary>
@@ -217,10 +233,8 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
     private void Initialize()
     {
         Name = EventStatus.Name;
-
         SetService(new EventEvaluator(this));
     }
-
 
     /// <summary>
     /// Determines whether the <see cref="CalendarEvent"/> is actively displayed
@@ -229,8 +243,10 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
     /// <returns>True if the event has not been cancelled, False otherwise.</returns>
     public virtual bool IsActive => !string.Equals(Status, EventStatus.Cancelled, EventStatus.Comparison);
 
+    /// <inheritdoc/>
     protected override bool EvaluationIncludesReferenceDate => true;
 
+    /// <inheritdoc/>
     protected override void OnDeserializing(StreamingContext context)
     {
         base.OnDeserializing(context);
@@ -238,13 +254,10 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
         Initialize();
     }
 
-    protected override void OnDeserialized(StreamingContext context)
+    protected bool Equals(CalendarEvent? other)
     {
-        base.OnDeserialized(context);
-    }
+        if (other is null) return false;
 
-    protected bool Equals(CalendarEvent other)
-    {
         var resourcesSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         resourcesSet.UnionWith(Resources);
 
@@ -269,8 +282,8 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
             return false;
         }
 
-        //RDATEs and EXDATEs are all List<PeriodList>, because the spec allows for multiple declarations of collections.
-        //Consequently we have to contrive a normalized representation before we can determine whether two events are equal
+        // RDATEs and EXDATEs are all List<PeriodList>, because the spec allows for multiple declarations of collections.
+        // Consequently we have to contrive a normalized representation before we can determine whether two events are equal
 
         var exDates = PeriodList.GetGroupedPeriods(ExceptionDates);
         var otherExDates = PeriodList.GetGroupedPeriods(other.ExceptionDates);
@@ -299,13 +312,15 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
         return true;
     }
 
-    public override bool Equals(object obj)
+    /// <inheritdoc/>
+    public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj)) return false;
         if (ReferenceEquals(this, obj)) return true;
         return obj.GetType() == GetType() && Equals((CalendarEvent)obj);
     }
 
+    /// <inheritdoc/>
     public override int GetHashCode()
     {
         unchecked
@@ -329,8 +344,13 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
         }
     }
 
-    public int CompareTo(CalendarEvent other)
+    /// <inheritdoc/>
+    public int CompareTo(CalendarEvent? other)
     {
+        if (other is null)
+        {
+            return 1;
+        }
         if (DtStart.Equals(other.DtStart))
         {
             return 0;
@@ -339,10 +359,8 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
         {
             return -1;
         }
-        if (DtStart.GreaterThan(other.DtStart))
-        {
-            return 1;
-        }
-        throw new Exception("An error occurred while comparing two CalDateTimes.");
+
+        // meaning DtStart is greater than other
+        return 1;
     }
 }

--- a/Ical.Net/Evaluation/EventEvaluator.cs
+++ b/Ical.Net/Evaluation/EventEvaluator.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 //
 
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,14 +12,17 @@ using Ical.Net.DataTypes;
 
 namespace Ical.Net.Evaluation;
 
+/// <summary>
+/// Evaluates a <see cref="CalendarEvent"/> to determine the dates and times for which the event occurs.
+/// </summary>
 public class EventEvaluator : RecurringEvaluator
 {
-    protected CalendarEvent CalendarEvent
-    {
-        get => Recurrable as CalendarEvent;
-        set => Recurrable = value;
-    }
+    protected CalendarEvent CalendarEvent => (CalendarEvent) Recurrable;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventEvaluator"/> class.
+    /// </summary>
+    /// <param name="evt"></param>
     public EventEvaluator(CalendarEvent evt) : base(evt) { }
 
     /// <summary>
@@ -27,12 +31,12 @@ public class EventEvaluator : RecurringEvaluator
     /// and <paramref name="periodEnd"/>; therefore, if you require a list of events which
     /// occur outside of this range, you must specify a <paramref name="periodStart"/> and
     /// <paramref name="periodEnd"/> which encapsulate the date(s) of interest.
-    /// <note type="caution">
-    ///     For events with very complex recurrence rules, this method may be a bottleneck
-    ///     during processing time, especially when this method in called for a large number
-    ///     of events, in sequence, or for a very large time span.
-    /// </note>
     /// </summary>
+    /// <remarks>
+    /// For events with very complex recurrence rules, this method may be a bottleneck
+    /// during processing time, especially when this method in called for a large number
+    /// of events, in sequence, or for a very large time span.
+    /// </remarks>
     /// <param name="referenceTime"></param>
     /// <param name="periodStart">The beginning date of the range to evaluate.</param>
     /// <param name="periodEnd">The end date of the range to evaluate.</param>
@@ -40,24 +44,56 @@ public class EventEvaluator : RecurringEvaluator
     /// <returns></returns>
     public override IEnumerable<Period> Evaluate(IDateTime referenceTime, DateTime? periodStart, DateTime? periodEnd, bool includeReferenceDateInResults)
     {
-        Period WithDuration(Period period)
-        {
-            var duration = CalendarEvent.GetFirstDuration();
-            var endTime = duration == default
-                ? period.StartTime
-                : period.StartTime.Add(CalendarEvent.GetFirstDuration());
-
-            return new Period(period.StartTime)
-            {
-                Duration = duration,
-                EndTime = endTime,
-            };
-        }
-
         // Evaluate recurrences normally
         var periods = base.Evaluate(referenceTime, periodStart, periodEnd, includeReferenceDateInResults)
-            .Select(WithDuration);
+            .Select(WithEndTime);
 
         return periods;
+    }
+
+    /// <summary>
+    /// The <paramref name="period"/> to evaluate has the <see cref="Period.StartTime"/> set,
+    /// but neither <see cref="Period.EndTime"/> nor <see cref="Period.Duration"/> are set.
+    /// </summary>
+    /// <param name="period">The period where <see cref="Period.EndTime"/> will be set.</param>
+    /// <returns>Returns the <paramref name="period"/> with <see cref="Period.EndTime"/> and exact <see cref="Period.Duration"/> set.</returns>
+    private Period WithEndTime(Period period)
+    {
+        /*
+           Calculate the nominal duration of the event which is the duration of the
+           first occurrence from the event's definition.
+           
+           The nominal duration is used, because the period end time gets the same timezone as the event end time.
+           This ensures that the end time is correct, even for DST transitions.
+           The exact duration is calculated from the zoned end time and the zoned start time,
+           and it may differ from the nominal duration.
+         */
+        var nominalDuration = CalendarEvent.CalcFirstNominalDuration();
+
+        IDateTime endTime;
+        if (nominalDuration == TimeSpan.Zero)
+        {
+            // For a zero-duration event, the end time is the same as the start time.
+            endTime = period.StartTime;
+        }
+        else
+        {
+            // Calculate the end time of the event as a DateTime
+            var endDt = period.StartTime.Value.Add(nominalDuration);
+
+            // Create a CalDateTime object with the calculated end time.
+            // Ensure date-only or date-time consistency with the start time,
+            // and use the timezone from the event's definition.
+            endTime = new CalDateTime(
+                DateOnly.FromDateTime(endDt),
+                period.StartTime.HasTime ? TimeOnly.FromDateTime(endDt) : null,
+                CalendarEvent.End?.TzId ?? CalendarEvent.Start.TzId);
+        }
+
+        // Return the Period object with the calculated end time and duration.
+        period.Duration = endTime.Subtract(period.StartTime); // exact duration
+        period.EndTime = endTime; // Only EndTime is relevant for further processing.
+
+        return period;
     }
 }


### PR DESCRIPTION
Updated `CalendarEvent` and `EventEvaluator` to enhance event handling, particularly around time zones and daylight saving time transitions.

Key changes include:

- Enabled nullable reference types in `CalendarEvent` and `EventEvaluator.`
- Updated `CalendarEvent` to throw `InvalidOperationException` when trying to set both `DtEnd` and `Duration`.
- Event end time and duration calculations in `EventEvaluator` reflect any DST transitions.
- Added new test class `RecurrenceTests_From_Issues` to validate changes with various edge cases and scenarios.

Resolves #660
Resolves #623
Resolves #671
Resolves #567
Resolves #342
Resolves #298