### PR TITLE
Disable NRT warnings for netstandard2.0

### DIFF
--- a/Ical.Net.Tests/Ical.Net.Tests.csproj
+++ b/Ical.Net.Tests/Ical.Net.Tests.csproj
@@ -5,6 +5,10 @@
         <AssemblyOriginatorKeyFile>..\IcalNetStrongnameKey.snk</AssemblyOriginatorKeyFile>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
+    <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <!-- netstandard2.0 does not support NRT -->
+        <NoWarn>$(NoWarn);CS8600;CS8601;CS8602;CS8603;CS8604;CS8618;CS8620;CS8714</NoWarn>
+    </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
         <PackageReference Include="NUnit" Version="4.2.2" />

--- a/Ical.Net/DataTypes/Organizer.cs
+++ b/Ical.Net/DataTypes/Organizer.cs
@@ -84,7 +84,8 @@ public class Organizer : EncodableDataType
         }
 
         var serializer = new OrganizerSerializer();
-        CopyFrom(serializer.Deserialize(new StringReader(value)) as ICopyable);
+        if (serializer.Deserialize(new StringReader(value)) is ICopyable deserialized)
+            CopyFrom(deserialized);
     }
 
     protected bool Equals(Organizer other) => Equals(Value, other.Value);
@@ -109,7 +110,7 @@ public class Organizer : EncodableDataType
     public override int GetHashCode() => Value?.GetHashCode() ?? 0;
 
     /// <inheritdoc/>
-    public override void CopyFrom(ICopyable obj)
+    public sealed override void CopyFrom(ICopyable obj)
     {
         base.CopyFrom(obj);
 

--- a/Ical.Net/Directory.Build.props
+++ b/Ical.Net/Directory.Build.props
@@ -13,6 +13,10 @@
         <PackageIcon>assets/icon.png</PackageIcon>
         <PackageReadmeFile>assets/readme.md</PackageReadmeFile>
     </PropertyGroup>
+    <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <!-- netstandard2.0 does not support NRT -->
+        <NoWarn>$(NoWarn);CS8600;CS8601;CS8602;CS8603;CS8604;CS8618;CS8620;CS8714</NoWarn>
+    </PropertyGroup>
     <ItemGroup>
         <None Include="..\readme.md">
             <Pack>true</Pack>


### PR DESCRIPTION
Reasoning: netstandard2.0 does not support NRT, so these warnings are useless
Resolve possible null reference in `Organizer` class