### PR TITLE
Use `ubuntu-22.04` for GitHub Actions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,8 @@ on:
 
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    # ubuntu-latest = ubuntu-24.04 does not include mono (2025-08-01)
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -7,7 +7,8 @@ on:
 
 jobs:
   test_and_publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    # ubuntu-latest = ubuntu-24.04 does not include mono (2025-08-01)
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,8 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    # ubuntu-latest = ubuntu-24.04 does not include mono (2025-08-01)
 
     steps:
     - name: Checkout main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,8 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    # ubuntu-latest = ubuntu-24.04 does not include mono (2025-08-01)
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
`ubuntu-latest` is now `ubuntu-24.04`, which does not include `mono`, so that building for .NETFramework,Version=v4.8 fails