### PR TITLE
Remove obsolete recurrence restriction and evaluation types

### DIFF
--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -36,9 +36,7 @@ public class RecurrenceTests
     {
         var evt = cal.Events.Skip(eventIndex).First();
         var rule = evt.RecurrenceRules.FirstOrDefault();
-#pragma warning disable 0618
-        if (rule != null) rule.RestrictionType = RecurrenceRestrictionType.NoRestriction;
-#pragma warning restore 0618
+
         if (fromDate != null)
             fromDate.AssociatedObject = cal;
         if (toDate != null)
@@ -2863,9 +2861,6 @@ public class RecurrenceTests
         // This case (DTSTART of type DATE and FREQ=MINUTELY) is undefined in RFC 5545.
         // ical.net handles the case by pretending DTSTART has the time set to midnight.
         evt.RecurrenceRules.Add(new RecurrencePattern($"FREQ={freq};INTERVAL=10;COUNT=5"));
-#pragma warning disable 0618
-        evt.RecurrenceRules[0].RestrictionType = RecurrenceRestrictionType.NoRestriction;
-#pragma warning restore 0618
 
         var occurrences = evt.GetOccurrences(evt.Start.AddDays(-1), evt.Start.AddDays(100))
             .OrderBy(x => x)
@@ -2890,9 +2885,6 @@ public class RecurrenceTests
         // NOTE: evaluators are not generally meant to be used directly like this.
         // However, this does make a good test to ensure they behave as they should.
         var pattern = new RecurrencePattern("FREQ=SECONDLY;INTERVAL=10");
-#pragma warning disable 0618
-        pattern.RestrictionType = RecurrenceRestrictionType.NoRestriction;
-#pragma warning restore 0618
 
         var us = new CultureInfo("en-US");
 

--- a/Ical.Net/Calendar.cs
+++ b/Ical.Net/Calendar.cs
@@ -171,20 +171,6 @@ public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, I
         set => Properties.Set("METHOD", value);
     }
 
-    [Obsolete("Usage may cause undesired results or exceptions. Will be removed.", false)]
-    public virtual RecurrenceRestrictionType RecurrenceRestriction
-    {
-        get => Properties.Get<RecurrenceRestrictionType>("X-DDAY-ICAL-RECURRENCE-RESTRICTION");
-        set => Properties.Set("X-DDAY-ICAL-RECURRENCE-RESTRICTION", value);
-    }
-
-    [Obsolete("Usage may cause undesired results or exceptions. Will be removed.", false)]
-    public virtual RecurrenceEvaluationModeType RecurrenceEvaluationMode
-    {
-        get => Properties.Get<RecurrenceEvaluationModeType>("X-DDAY-ICAL-RECURRENCE-EVALUATION-MODE");
-        set => Properties.Set("X-DDAY-ICAL-RECURRENCE-EVALUATION-MODE", value);
-    }
-
     /// <summary>
     /// Adds a time zone to the iCalendar.  This time zone may
     /// then be used in date/time objects contained in the

--- a/Ical.Net/Constants.cs
+++ b/Ical.Net/Constants.cs
@@ -223,58 +223,6 @@ public enum FrequencyOccurrence
     Fifth = 5
 }
 
-[Obsolete("Usage may cause undesired results or exceptions. Will be removed.", false)]
-public enum RecurrenceRestrictionType
-{
-    /// <summary>
-    /// Same as RestrictSecondly.
-    /// </summary>
-    Default,
-
-    /// <summary>
-    /// Does not restrict recurrence evaluation - WARNING: this may cause very slow performance!
-    /// </summary>
-    NoRestriction,
-
-    /// <summary>
-    /// Disallows use of the SECONDLY frequency for recurrence evaluation
-    /// </summary>
-    RestrictSecondly,
-
-    /// <summary>
-    /// Disallows use of the MINUTELY and SECONDLY frequencies for recurrence evaluation
-    /// </summary>
-    RestrictMinutely,
-
-    /// <summary>
-    /// Disallows use of the HOURLY, MINUTELY, and SECONDLY frequencies for recurrence evaluation
-    /// </summary>
-    RestrictHourly
-}
-
-[Obsolete("Usage may cause undesired results or exceptions. Will be removed.", false)]
-public enum RecurrenceEvaluationModeType
-{
-    /// <summary>
-    /// Same as ThrowException.
-    /// </summary>
-    Default,
-
-    /// <summary>
-    /// Automatically adjusts the evaluation to the next-best frequency based on the restriction type.
-    /// For example, if the restriction were IgnoreSeconds, and the frequency were SECONDLY, then
-    /// this would cause the frequency to be adjusted to MINUTELY, the next closest thing.
-    /// </summary>
-    AdjustAutomatically,
-
-    /// <summary>
-    /// This will throw an exception if a recurrence rule is evaluated that does not meet the minimum
-    /// restrictions.  For example, if the restriction were IgnoreSeconds, and a SECONDLY frequency
-    /// were evaluated, an exception would be thrown.
-    /// </summary>
-    ThrowException
-}
-
 public static class TransparencyType
 {
     public const string Name = "TRANSP";

--- a/Ical.Net/DataTypes/RecurrencePattern.cs
+++ b/Ical.Net/DataTypes/RecurrencePattern.cs
@@ -21,10 +21,7 @@ namespace Ical.Net.DataTypes;
 public class RecurrencePattern : EncodableDataType
 {
     private int? _interval;
-#pragma warning disable 0618
-    private RecurrenceRestrictionType? _restrictionType;
-    private RecurrenceEvaluationModeType? _evaluationMode;
-#pragma warning restore 0618
+
     public FrequencyType Frequency { get; set; }
 
     public DateTime? Until { get; set; }
@@ -76,42 +73,6 @@ public class RecurrencePattern : EncodableDataType
 
     public DayOfWeek FirstDayOfWeek { get; set; } = DayOfWeek.Monday;
 
-#pragma warning disable 0618
-    /// <summary>
-    /// The type of restriction to apply to the evaluation of this recurrence pattern.
-    /// Returns <see cref="RecurrenceRestrictionType.NoRestriction"/> if not set.
-    /// </summary>
-    [Obsolete("Usage may cause undesired results or exceptions. Will be removed.", false)]
-    public RecurrenceRestrictionType RestrictionType
-    {
-        get
-        {
-            // NOTE: Fixes bug #1924358 - Cannot evaluate Secondly patterns
-            if (_restrictionType != null)
-            {
-                return _restrictionType.Value;
-            }
-            return Calendar?.RecurrenceRestriction ?? RecurrenceRestrictionType.Default;
-        }
-        set => _restrictionType = value;
-    }
-
-    [Obsolete("Usage may cause undesired results or exceptions. Will be removed.", false)]
-    public RecurrenceEvaluationModeType EvaluationMode
-    {
-        get
-        {
-            // NOTE: Fixes bug #1924358 - Cannot evaluate Secondly patterns
-            if (_evaluationMode != null)
-            {
-                return _evaluationMode.Value;
-            }
-            return Calendar?.RecurrenceEvaluationMode ?? RecurrenceEvaluationModeType.Default;
-        }
-        set => _evaluationMode = value;
-    }
-#pragma warning restore 0618
-
     public RecurrencePattern()
     {
         SetService(new RecurrencePatternEvaluator(this));
@@ -143,10 +104,6 @@ public class RecurrencePattern : EncodableDataType
     }
 
     protected bool Equals(RecurrencePattern other) => (Interval == other.Interval)
-#pragma warning disable 0618
-                                                      && RestrictionType == other.RestrictionType
-                                                      && EvaluationMode == other.EvaluationMode
-#pragma warning restore 0618
                                                       && Frequency == other.Frequency
                                                       && Until.Equals(other.Until)
                                                       && Count == other.Count
@@ -173,10 +130,6 @@ public class RecurrencePattern : EncodableDataType
         unchecked
         {
             var hashCode = Interval.GetHashCode();
-#pragma warning disable 0618
-            hashCode = (hashCode * 397) ^ RestrictionType.GetHashCode();
-            hashCode = (hashCode * 397) ^ EvaluationMode.GetHashCode();
-#pragma warning restore 0618
             hashCode = (hashCode * 397) ^ (int) Frequency;
             hashCode = (hashCode * 397) ^ Until.GetHashCode();
             hashCode = (hashCode * 397) ^ (Count ?? 0);
@@ -217,10 +170,6 @@ public class RecurrencePattern : EncodableDataType
         ByMonth = new List<int>(r.ByMonth);
         BySetPosition = new List<int>(r.BySetPosition);
         FirstDayOfWeek = r.FirstDayOfWeek;
-#pragma warning disable 0618
-        RestrictionType = r.RestrictionType;
-        EvaluationMode = r.EvaluationMode;
-#pragma warning restore 0618
     }
 
     private static bool CollectionEquals<T>(IEnumerable<T> c1, IEnumerable<T> c2) => c1.SequenceEqual(c2);

--- a/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
@@ -101,102 +101,7 @@ public class RecurrencePatternEvaluator : Evaluator
 
         return r;
     }
-#pragma warning disable 0618
-    private void EnforceEvaluationRestrictions(RecurrencePattern pattern)
-    {
-        RecurrenceEvaluationModeType? evaluationMode = pattern.EvaluationMode;
-        RecurrenceRestrictionType? evaluationRestriction = pattern.RestrictionType;
 
-        if (evaluationRestriction != RecurrenceRestrictionType.NoRestriction)
-        {
-            switch (evaluationMode)
-            {
-                case RecurrenceEvaluationModeType.AdjustAutomatically:
-                    switch (pattern.Frequency)
-                    {
-                        case FrequencyType.Secondly:
-                            {
-                                switch (evaluationRestriction)
-                                {
-                                    case RecurrenceRestrictionType.Default:
-                                    case RecurrenceRestrictionType.RestrictSecondly:
-                                        pattern.Frequency = FrequencyType.Minutely;
-                                        break;
-                                    case RecurrenceRestrictionType.RestrictMinutely:
-                                        pattern.Frequency = FrequencyType.Hourly;
-                                        break;
-                                    case RecurrenceRestrictionType.RestrictHourly:
-                                        pattern.Frequency = FrequencyType.Daily;
-                                        break;
-                                }
-                            }
-                            break;
-                        case FrequencyType.Minutely:
-                            {
-                                switch (evaluationRestriction)
-                                {
-                                    case RecurrenceRestrictionType.RestrictMinutely:
-                                        pattern.Frequency = FrequencyType.Hourly;
-                                        break;
-                                    case RecurrenceRestrictionType.RestrictHourly:
-                                        pattern.Frequency = FrequencyType.Daily;
-                                        break;
-                                }
-                            }
-                            break;
-                        case FrequencyType.Hourly:
-                            {
-                                switch (evaluationRestriction)
-                                {
-                                    case RecurrenceRestrictionType.RestrictHourly:
-                                        pattern.Frequency = FrequencyType.Daily;
-                                        break;
-                                }
-                            }
-                            break;
-                    }
-                    break;
-                case RecurrenceEvaluationModeType.ThrowException:
-                case RecurrenceEvaluationModeType.Default:
-                    switch (pattern.Frequency)
-                    {
-                        case FrequencyType.Secondly:
-                            {
-                                switch (evaluationRestriction)
-                                {
-                                    case RecurrenceRestrictionType.Default:
-                                    case RecurrenceRestrictionType.RestrictSecondly:
-                                    case RecurrenceRestrictionType.RestrictMinutely:
-                                    case RecurrenceRestrictionType.RestrictHourly:
-                                        throw new ArgumentException();
-                                }
-                            }
-                            break;
-                        case FrequencyType.Minutely:
-                            {
-                                switch (evaluationRestriction)
-                                {
-                                    case RecurrenceRestrictionType.RestrictMinutely:
-                                    case RecurrenceRestrictionType.RestrictHourly:
-                                        throw new ArgumentException();
-                                }
-                            }
-                            break;
-                        case FrequencyType.Hourly:
-                            {
-                                switch (evaluationRestriction)
-                                {
-                                    case RecurrenceRestrictionType.RestrictHourly:
-                                        throw new ArgumentException();
-                                }
-                            }
-                            break;
-                    }
-                    break;
-            }
-        }
-    }
-#pragma warning restore 0618
     /// <summary>
     /// Returns a list of start dates in the specified period represented by this recurrence pattern.
     /// This method includes a base date argument, which indicates the start of the first occurrence of this recurrence.
@@ -974,9 +879,6 @@ public class RecurrencePatternEvaluator : Evaluator
 
         // Create a recurrence pattern suitable for use during evaluation.
         var pattern = ProcessRecurrencePattern(referenceDate);
-
-        // Enforce evaluation restrictions on the pattern.
-        EnforceEvaluationRestrictions(pattern);
 
         var periodQuery = GetDates(referenceDate, periodStart, periodEnd, -1, pattern, includeReferenceDateInResults)
             .Select(dt => CreatePeriod(dt, referenceDate));


### PR DESCRIPTION
The changes remove the usage of `RecurrenceRestrictionType` and `RecurrenceEvaluationModeType` from various parts of the codebase. These types and their associated properties and methods were marked as obsolete and have now been completely removed.

- In `RecurrenceTests.cs`, the code that set the `RestrictionType` property on recurrence rules has been removed.
- In `Calendar.cs`, the obsolete properties `RecurrenceRestriction` and `RecurrenceEvaluationMode` have been removed.
- In `Constants.cs`, the obsolete enums `RecurrenceRestrictionType` and `RecurrenceEvaluationModeType` have been removed.
- In `RecurrencePattern.cs`, the properties `RestrictionType` and `EvaluationMode` have been removed, along with their associated logic.
- In `RecurrencePatternEvaluator.cs`, the method `EnforceEvaluationRestrictions` and its calls have been removed.

The changes also include some adjustments to ensure that the removal of these properties and methods does not affect the overall functionality of the code.