### PR TITLE
Disallow initializing `CalDateTime` from `DateTimeKind.Local` and some cleanup

### DIFF
--- a/Ical.Net.Tests/CalDateTimeTests.cs
+++ b/Ical.Net.Tests/CalDateTimeTests.cs
@@ -6,6 +6,7 @@
 using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
 using NUnit.Framework;
+using NUnit.Framework.Constraints;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -342,5 +343,22 @@ public class CalDateTimeTests
             Assert.That(t.Add(d).Add(-d), Is.EqualTo(t));
             Assert.That(t.Add(d).SubtractExact(t), Is.EqualTo(d.ToTimeSpan()));
         });
+    }
+
+    private static TestCaseData[] CalDateTime_FromDateTime_HandlesKindCorrectlyTestCases =>
+        [
+            new TestCaseData(DateTimeKind.Unspecified, Is.EqualTo(new CalDateTime(2024, 12, 30, 10, 44, 50, null))),
+            new TestCaseData(DateTimeKind.Utc, Is.EqualTo(new CalDateTime(2024, 12, 30, 10, 44, 50, "UTC"))),
+            new TestCaseData(DateTimeKind.Local, Throws.ArgumentException),
+        ];
+
+    [Test, TestCaseSource(nameof(CalDateTime_FromDateTime_HandlesKindCorrectlyTestCases))]
+
+
+    public void CalDateTime_FromDateTime_HandlesKindCorrectly(DateTimeKind kind, IResolveConstraint constraint)
+    {
+        var dt = new DateTime(2024, 12, 30, 10, 44, 50, kind);
+
+        Assert.That(() => new CalDateTime(dt), constraint);
     }
 }

--- a/Ical.Net.Tests/CopyComponentTests.cs
+++ b/Ical.Net.Tests/CopyComponentTests.cs
@@ -53,7 +53,7 @@ public class CopyComponentTests
         yield return new TestCaseData(IcsFiles.XProperty2).SetName("XProperty2");
     }
 
-    private static readonly DateTime _now = DateTime.Now;
+    private static readonly DateTime _now = DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Unspecified);
     private static readonly DateTime _later = _now.AddHours(1);
 
     private static CalendarEvent GetSimpleEvent() => new CalendarEvent
@@ -154,7 +154,7 @@ public class CopyComponentTests
         {
             Summary = "Test Todo",
             Description = "This is a test todo",
-            Due = new CalDateTime(DateTime.Now.AddDays(10)),
+            Due = new CalDateTime(DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Unspecified).AddDays(10)),
             Priority = 1,
             Contacts = new[] { "John", "Paul" },
             Status = "NeedsAction"
@@ -180,7 +180,7 @@ public class CopyComponentTests
         {
             Summary = "Test Journal",
             Description = "This is a test journal",
-            DtStart = new CalDateTime(DateTime.Now),
+            DtStart = new CalDateTime(DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Unspecified)),
             Categories = new List<string> { "Category1", "Category2" },
             Priority = 1,
             Status = "Draft"

--- a/Ical.Net.Tests/EqualityAndHashingTests.cs
+++ b/Ical.Net.Tests/EqualityAndHashingTests.cs
@@ -19,7 +19,7 @@ namespace Ical.Net.Tests;
 public class EqualityAndHashingTests
 {
     private const string TzId = "America/Los_Angeles";
-    private static readonly DateTime _nowTime = DateTime.Parse("2016-07-16T16:47:02.9310521-04:00");
+    private static readonly DateTime _nowTime = DateTime.SpecifyKind(DateTime.Parse("2016-07-16T16:47:02.9310521-04:00"), DateTimeKind.Unspecified);
     private static readonly DateTime _later = _nowTime.AddHours(1);
 
     [Test, TestCaseSource(nameof(CalDateTime_TestCases))]

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -2740,7 +2740,7 @@ public class RecurrenceTests
         };
         var vEvent = new CalendarEvent
         {
-            Start = new CalDateTime(DateTime.Parse("2019-01-04T08:00Z")),
+            Start = new CalDateTime(DateTime.Parse("2019-01-04T08:00Z").ToUniversalTime()),
         };
 
         vEvent.RecurrenceRules.Add(rrule);
@@ -2748,7 +2748,7 @@ public class RecurrenceTests
         //Testing on both the first day and the next, results used to be different
         for (var i = 0; i <= 1; i++)
         {
-            var checkTime = DateTime.Parse("2019-01-04T08:00Z");
+            var checkTime = DateTime.Parse("2019-01-04T08:00Z").ToUniversalTime();
             checkTime = checkTime.AddDays(i);
             //Valid asking for the exact moment
             var occurrences = vEvent.GetOccurrences(checkTime, checkTime).ToList();
@@ -3295,7 +3295,7 @@ END:VCALENDAR";
         Assert.That(occurrences, Has.Count.EqualTo(3));
     }
 
-    private static readonly DateTime _now = DateTime.Now;
+    private static readonly DateTime _now = DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Unspecified);
     private static readonly DateTime _later = _now.AddHours(1);
     private static CalendarEvent GetEventWithRecurrenceRules()
     {

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -1189,8 +1189,8 @@ public class RecurrenceTests
     [Test, Category("Recurrence")]
     public void WeekNoOrderingShouldNotMatter()
     {
-        var start = new DateTime(2019, 1, 1);
-        var end = new DateTime(2019, 12, 31);
+        var start = new CalDateTime(2019, 1, 1);
+        var end = new CalDateTime(2019, 12, 31);
         var rpe1 = new RecurrencePatternEvaluator(new RecurrencePattern("FREQ=YEARLY;WKST=MO;BYDAY=MO;BYWEEKNO=1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53"));
         var rpe2 = new RecurrencePatternEvaluator(new RecurrencePattern("FREQ=YEARLY;WKST=MO;BYDAY=MO;BYWEEKNO=53,51,49,47,45,43,41,39,37,35,33,31,29,27,25,23,21,19,17,15,13,11,9,7,5,3,1"));
 
@@ -2585,11 +2585,11 @@ public class RecurrenceTests
     [Test, Category("Recurrence")]
     public void BugByWeekNoNotWorking()
     {
-        var start = new DateTime(2019, 1, 1);
-        var end = new DateTime(2019, 12, 31);
+        var start = new CalDateTime(2019, 1, 1);
+        var end = new CalDateTime(2019, 12, 31);
         var rpe = new RecurrencePatternEvaluator(new RecurrencePattern("FREQ=WEEKLY;BYDAY=MO;BYWEEKNO=2"));
 
-        var recurringPeriods = rpe.Evaluate(new CalDateTime(start, false), start, end, false).ToList();
+        var recurringPeriods = rpe.Evaluate(start, start, end, false).ToList();
 
         Assert.That(recurringPeriods, Has.Count.EqualTo(1));
         Assert.That(recurringPeriods.First().StartTime, Is.EqualTo(new CalDateTime(2019, 1, 7)));
@@ -2601,11 +2601,11 @@ public class RecurrenceTests
     [Test, Category("Recurrence")]
     public void BugByMonthWhileFreqIsWeekly()
     {
-        var start = new DateTime(2020, 1, 1);
-        var end = new DateTime(2020, 12, 31);
+        var start = new CalDateTime(2020, 1, 1);
+        var end = new CalDateTime(2020, 12, 31);
         var rpe = new RecurrencePatternEvaluator(new RecurrencePattern("FREQ=WEEKLY;BYDAY=MO;BYMONTH=1"));
 
-        var recurringPeriods = rpe.Evaluate(new CalDateTime(start, false), start, end, false).OrderBy(x => x).ToList();
+        var recurringPeriods = rpe.Evaluate(start, start, end, false).OrderBy(x => x).ToList();
 
         Assert.That(recurringPeriods, Has.Count.EqualTo(4));
         Assert.Multiple(() =>
@@ -2644,11 +2644,11 @@ public class RecurrenceTests
     [Test, Category("Recurrence")]
     public void BugByMonthWhileFreqIsMonthly()
     {
-        var start = new DateTime(2020, 1, 1);
-        var end = new DateTime(2020, 12, 31);
+        var start = new CalDateTime(2020, 1, 1);
+        var end = new CalDateTime(2020, 12, 31);
         var rpe = new RecurrencePatternEvaluator(new RecurrencePattern("FREQ=MONTHLY;BYDAY=MO;BYMONTH=1"));
 
-        var recurringPeriods = rpe.Evaluate(new CalDateTime(start, false), start, end, false).OrderBy(x => x).ToList();
+        var recurringPeriods = rpe.Evaluate(start, start, end, false).OrderBy(x => x).ToList();
 
         Assert.That(recurringPeriods, Has.Count.EqualTo(4));
         Assert.Multiple(() =>
@@ -2669,11 +2669,11 @@ public class RecurrenceTests
     {
         using (var sr = new StringReader("FREQ=WEEKLY;UNTIL=20251126T120000;INTERVAL=1;BYDAY=MO"))
         {
-            var start = DateTime.Parse("2010-11-27 9:00:00");
+            var start = new CalDateTime(2010, 11, 27, 9, 0, 0);
             var serializer = new RecurrencePatternSerializer();
             var rp = (RecurrencePattern)serializer.Deserialize(sr);
             var rpe = new RecurrencePatternEvaluator(rp);
-            var recurringPeriods = rpe.Evaluate(new CalDateTime(start), start, rp.Until, false).ToList();
+            var recurringPeriods = rpe.Evaluate(new CalDateTime(start), start, rp.Until?.AsCalDateTime(), false).ToList();
 
             var period = recurringPeriods.ElementAt(recurringPeriods.Count - 1);
 
@@ -2897,8 +2897,8 @@ public class RecurrenceTests
 
         var occurrences = evaluator.Evaluate(
             startDate,
-            SimpleDateTimeToMatch(fromDate, startDate),
-            SimpleDateTimeToMatch(toDate, startDate),
+            fromDate,
+            toDate,
             false)
             .OrderBy(o => o.StartTime)
             .ToList();
@@ -2930,8 +2930,8 @@ public class RecurrenceTests
 
         var occurrences = evaluator.Evaluate(
             startDate,
-            SimpleDateTimeToMatch(fromDate, startDate),
-            SimpleDateTimeToMatch(toDate, startDate),
+            fromDate,
+            toDate,
             false);
         Assert.That(occurrences.Count, Is.Not.EqualTo(0));
     }
@@ -3038,8 +3038,8 @@ public class RecurrenceTests
         // Add the exception dates
         var periods = evaluator.Evaluate(
             evtStart,
-            DateUtil.GetSimpleDateTimeData(evtStart),
-            SimpleDateTimeToMatch(evtEnd, evtStart),
+            evtStart,
+            evtEnd,
             false)
             .OrderBy(p => p.StartTime)
             .ToList();
@@ -3828,23 +3828,6 @@ END:VCALENDAR";
 
         //occurences is 26 here, omitting 4/16/2024
         Assert.That(occurrences.Count, Is.EqualTo(27));
-    }
-
-    private static DateTime SimpleDateTimeToMatch(IDateTime dt, IDateTime toMatch)
-    {
-        if (toMatch.IsUtc && dt.IsUtc)
-        {
-            return dt.Value;
-        }
-        if (toMatch.IsUtc)
-        {
-            return dt.Value.ToUniversalTime();
-        }
-        if (dt.IsUtc)
-        {
-            return dt.Value.ToLocalTime();
-        }
-        return dt.Value;
     }
 
     [Test]

--- a/Ical.Net.Tests/SerializationTests.cs
+++ b/Ical.Net.Tests/SerializationTests.cs
@@ -22,7 +22,7 @@ namespace Ical.Net.Tests;
 [TestFixture]
 public class SerializationTests
 {
-    private static readonly DateTime _nowTime = DateTime.Now;
+    private static readonly DateTime _nowTime = DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Unspecified);
     private static readonly DateTime _later = _nowTime.AddHours(1);
     private static CalendarSerializer GetNewSerializer() => new CalendarSerializer();
     private static string SerializeToString(Calendar c) => GetNewSerializer().SerializeToString(c);

--- a/Ical.Net.Tests/SymmetricSerializationTests.cs
+++ b/Ical.Net.Tests/SymmetricSerializationTests.cs
@@ -22,7 +22,7 @@ public class SymmetricSerializationTests
 {
     private const string _ldapUri = "ldap://example.com:6666/o=eDABC Industries,c=3DUS??(cn=3DBMary Accepted)";
 
-    private static readonly DateTime _nowTime = DateTime.Now;
+    private static readonly DateTime _nowTime = DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Unspecified);
     private static readonly DateTime _later = _nowTime.AddHours(1);
     private static CalendarSerializer GetNewSerializer() => new CalendarSerializer();
     private static string SerializeToString(Calendar c) => GetNewSerializer().SerializeToString(c);

--- a/Ical.Net/DataTypes/CalDateTime.cs
+++ b/Ical.Net/DataTypes/CalDateTime.cs
@@ -78,15 +78,25 @@ public sealed class CalDateTime : EncodableDataType, IDateTime
     /// It will represent an RFC 5545, Section 3.3.4, DATE value, if <see paramref="hasTime"/> is <see langword="false"/>.
     /// <para/>
     /// The <see cref="TzId"/> will be set to "UTC" if the <paramref name="value"/>
-    /// has <see cref="DateTimeKind.Utc"/> and <paramref name="hasTime"/> is <see langword="true"/>.
-    /// Otherwise <see cref="TzId"/> will be <see langword="null"/>.
+    /// has kind <see cref="DateTimeKind.Utc"/> and <paramref name="hasTime"/> is <see langword="true"/>.
+    /// It will be set to <see langword="null"/> if the kind is kind <see cref="DateTimeKind.Unspecified"/>
+    /// and will throw otherwise.
     /// </summary>
     /// <param name="value">The <see cref="DateTime"/> value. Its <see cref="DateTimeKind"/> will be ignored.</param>
     /// <param name="hasTime">
     /// The instance will represent an RFC 5545, Section 3.3.5, DATE-TIME value, if <see paramref="hasTime"/> is <see langword="true"/>.
     /// It will represent an RFC 5545, Section 3.3.4, DATE value, if <see paramref="hasTime"/> is <see langword="false"/>.
     /// </param>
-    public CalDateTime(DateTime value, bool hasTime = true) : this(value, value.Kind == DateTimeKind.Utc ? UtcTzId : null, hasTime)
+    /// <exception cref="System.ArgumentException">If the specified value's kind is <see cref="DateTimeKind.Local"/></exception>
+    public CalDateTime(DateTime value, bool hasTime = true) : this(
+        value,
+        value.Kind switch
+        {
+            DateTimeKind.Utc => UtcTzId,
+            DateTimeKind.Unspecified => null,
+            _ => throw new ArgumentException($"An instance of {nameof(CalDateTime)} can only be initializd from a {nameof(DateTime)} of kind {nameof(DateTimeKind.Utc)} or {nameof(DateTimeKind.Unspecified)}.")
+        },
+        hasTime)
     { }
 
     /// <summary>

--- a/Ical.Net/Evaluation/Evaluator.cs
+++ b/Ical.Net/Evaluation/Evaluator.cs
@@ -23,13 +23,6 @@ public abstract class Evaluator : IEvaluator
         Calendar = CultureInfo.CurrentCulture.Calendar;
     }
 
-    protected IDateTime ConvertToIDateTime(DateTime dt, IDateTime referenceDate)
-    {
-        IDateTime newDt = new CalDateTime(dt, referenceDate.TzId);
-        newDt.AssociateWith(referenceDate);
-        return newDt;
-    }
-
     protected void IncrementDate(ref DateTime dt, RecurrencePattern pattern, int interval)
     {
         if (interval == 0)

--- a/Ical.Net/Evaluation/Evaluator.cs
+++ b/Ical.Net/Evaluation/Evaluator.cs
@@ -56,5 +56,5 @@ public abstract class Evaluator : IEvaluator
 
     public System.Globalization.Calendar Calendar { get; private set; }
 
-    public abstract IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime? periodStart, DateTime? periodEnd, bool includeReferenceDateInResults);
+    public abstract IEnumerable<Period> Evaluate(IDateTime referenceDate, IDateTime? periodStart, IDateTime? periodEnd, bool includeReferenceDateInResults);
 }

--- a/Ical.Net/Evaluation/Evaluator.cs
+++ b/Ical.Net/Evaluation/Evaluator.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 //
 
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -14,11 +15,6 @@ namespace Ical.Net.Evaluation;
 public abstract class Evaluator : IEvaluator
 {
     protected Evaluator()
-    {
-        Initialize();
-    }
-
-    private void Initialize()
     {
         Calendar = CultureInfo.CurrentCulture.Calendar;
     }

--- a/Ical.Net/Evaluation/Evaluator.cs
+++ b/Ical.Net/Evaluation/Evaluator.cs
@@ -13,8 +13,6 @@ namespace Ical.Net.Evaluation;
 
 public abstract class Evaluator : IEvaluator
 {
-    private ICalendarObject _mAssociatedObject;
-
     protected Evaluator()
     {
         Initialize();
@@ -68,12 +66,6 @@ public abstract class Evaluator : IEvaluator
     }
 
     public System.Globalization.Calendar Calendar { get; private set; }
-
-    public virtual ICalendarObject AssociatedObject
-    {
-        get => _mAssociatedObject;
-        protected set => _mAssociatedObject = value;
-    }
 
     public abstract IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime? periodStart, DateTime? periodEnd, bool includeReferenceDateInResults);
 }

--- a/Ical.Net/Evaluation/EventEvaluator.cs
+++ b/Ical.Net/Evaluation/EventEvaluator.cs
@@ -42,7 +42,7 @@ public class EventEvaluator : RecurringEvaluator
     /// <param name="periodEnd">The end date of the range to evaluate.</param>
     /// <param name="includeReferenceDateInResults"></param>
     /// <returns></returns>
-    public override IEnumerable<Period> Evaluate(IDateTime referenceTime, DateTime? periodStart, DateTime? periodEnd, bool includeReferenceDateInResults)
+    public override IEnumerable<Period> Evaluate(IDateTime referenceTime, IDateTime? periodStart, IDateTime? periodEnd, bool includeReferenceDateInResults)
     {
         // Evaluate recurrences normally
         var periods = base.Evaluate(referenceTime, periodStart, periodEnd, includeReferenceDateInResults)

--- a/Ical.Net/Evaluation/IEvaluator.cs
+++ b/Ical.Net/Evaluation/IEvaluator.cs
@@ -42,5 +42,5 @@ public interface IEvaluator
     ///     A sequence of <see cref="Ical.Net.DataTypes.Period"/> objects for
     ///     each date/time when this item occurs/recurs.
     /// </returns>
-    IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime? periodStart, DateTime? periodEnd, bool includeReferenceDateInResults);
+    IEnumerable<Period> Evaluate(IDateTime referenceDate, IDateTime? periodStart, IDateTime? periodEnd, bool includeReferenceDateInResults);
 }

--- a/Ical.Net/Evaluation/IEvaluator.cs
+++ b/Ical.Net/Evaluation/IEvaluator.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 //
 
+#nullable enable
 using System;
 using System.Collections.Generic;
 using Ical.Net.DataTypes;

--- a/Ical.Net/Evaluation/IEvaluator.cs
+++ b/Ical.Net/Evaluation/IEvaluator.cs
@@ -17,11 +17,6 @@ public interface IEvaluator
     System.Globalization.Calendar Calendar { get; }
 
     /// <summary>
-    /// Gets the object associated with this evaluator.
-    /// </summary>
-    ICalendarObject AssociatedObject { get; }
-
-    /// <summary>
     /// Evaluates this item to determine the dates and times for which it occurs/recurs.
     /// This method only evaluates items which occur/recur between <paramref name="periodStart"/>
     /// and <paramref name="periodEnd"/>; therefore, if you require a list of items which

--- a/Ical.Net/Evaluation/PeriodListEvaluator.cs
+++ b/Ical.Net/Evaluation/PeriodListEvaluator.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 //
 
+#nullable enable
 using System;
 using System.Collections.Generic;
 using Ical.Net.DataTypes;

--- a/Ical.Net/Evaluation/PeriodListEvaluator.cs
+++ b/Ical.Net/Evaluation/PeriodListEvaluator.cs
@@ -19,7 +19,7 @@ internal class PeriodListEvaluator : Evaluator
         _mPeriodList = rdt;
     }
 
-    public override IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime? periodStart, DateTime? periodEnd, bool includeReferenceDateInResults)
+    public override IEnumerable<Period> Evaluate(IDateTime referenceDate, IDateTime? periodStart, IDateTime? periodEnd, bool includeReferenceDateInResults)
     {
         var periods = new SortedSet<Period>();
 
@@ -29,7 +29,7 @@ internal class PeriodListEvaluator : Evaluator
             periods.Add(p);
         }
 
-        if (periodEnd < periodStart)
+        if ((periodStart is not null) && (periodEnd is not null) && periodEnd.LessThan(periodStart))
         {
             return periods;
         }

--- a/Ical.Net/Evaluation/RecurrenceUtil.cs
+++ b/Ical.Net/Evaluation/RecurrenceUtil.cs
@@ -37,7 +37,7 @@ internal class RecurrenceUtil
         if (periodEnd != null)
             periodEnd = new CalDateTime(periodEnd.Date, periodEnd.Time, start.TzId);
 
-        var periods = evaluator.Evaluate(start, periodStart?.Value, periodEnd?.Value,
+        var periods = evaluator.Evaluate(start, periodStart, periodEnd,
             includeReferenceDateInResults);
 
         var occurrences =

--- a/Ical.Net/Evaluation/RecurringEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurringEvaluator.cs
@@ -19,19 +19,6 @@ public class RecurringEvaluator : Evaluator
     public RecurringEvaluator(IRecurrable obj)
     {
         Recurrable = obj;
-
-        // We're not sure if the object is a calendar object
-        // or a calendar data type, so we need to assign
-        // the associated object manually
-        if (obj is ICalendarObject)
-        {
-            AssociatedObject = (ICalendarObject)obj;
-        }
-        if (obj is ICalendarDataType)
-        {
-            var dt = (ICalendarDataType)obj;
-            AssociatedObject = dt.AssociatedObject;
-        }
     }
 
     /// <summary>

--- a/Ical.Net/Evaluation/RecurringEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurringEvaluator.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 //
 
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Ical.Net/Evaluation/RecurringEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurringEvaluator.cs
@@ -29,7 +29,7 @@ public class RecurringEvaluator : Evaluator
     /// <param name="periodStart">The beginning date of the range to evaluate.</param>
     /// <param name="periodEnd">The end date of the range to evaluate.</param>
     /// <param name="includeReferenceDateInResults"></param>
-    protected IEnumerable<Period> EvaluateRRule(IDateTime referenceDate, DateTime? periodStart, DateTime? periodEnd, bool includeReferenceDateInResults)
+    protected IEnumerable<Period> EvaluateRRule(IDateTime referenceDate, IDateTime? periodStart, IDateTime? periodEnd, bool includeReferenceDateInResults)
     {
         if (Recurrable.RecurrenceRules == null || !Recurrable.RecurrenceRules.Any())
             return [];
@@ -59,7 +59,7 @@ public class RecurringEvaluator : Evaluator
     }
 
     /// <summary> Evaluates the RDate component. </summary>
-    protected IEnumerable<Period> EvaluateRDate(IDateTime referenceDate, DateTime? periodStart, DateTime? periodEnd)
+    protected IEnumerable<Period> EvaluateRDate(IDateTime referenceDate, IDateTime? periodStart, IDateTime? periodEnd)
     {
         var recurrences =
             new SortedSet<Period>(Recurrable.RecurrenceDates
@@ -74,7 +74,7 @@ public class RecurringEvaluator : Evaluator
     /// <param name="referenceDate"></param>
     /// <param name="periodStart">The beginning date of the range to evaluate.</param>
     /// <param name="periodEnd">The end date of the range to evaluate.</param>
-    protected IEnumerable<Period> EvaluateExRule(IDateTime referenceDate, DateTime? periodStart, DateTime? periodEnd)
+    protected IEnumerable<Period> EvaluateExRule(IDateTime referenceDate, IDateTime? periodStart, IDateTime? periodEnd)
     {
         if (Recurrable.ExceptionRules == null || !Recurrable.ExceptionRules.Any())
             return [];
@@ -102,14 +102,14 @@ public class RecurringEvaluator : Evaluator
     /// <param name="referenceDate"></param>
     /// <param name="periodStart">The beginning date of the range to evaluate.</param>
     /// <param name="periodEnd">The end date of the range to evaluate.</param>
-    protected IEnumerable<Period> EvaluateExDate(IDateTime referenceDate, DateTime? periodStart, DateTime? periodEnd)
+    protected IEnumerable<Period> EvaluateExDate(IDateTime referenceDate, IDateTime? periodStart, IDateTime? periodEnd)
     {
         var exDates = new SortedSet<Period>(Recurrable
             .ExceptionDates.GetAllPeriodsByKind(PeriodKind.DateOnly, PeriodKind.DateTime));
         return exDates;
     }
 
-    public override IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime? periodStart, DateTime? periodEnd, bool includeReferenceDateInResults)
+    public override IEnumerable<Period> Evaluate(IDateTime referenceDate, IDateTime? periodStart, IDateTime? periodEnd, bool includeReferenceDateInResults)
     {
         var rruleOccurrences = EvaluateRRule(referenceDate, periodStart, periodEnd, includeReferenceDateInResults);
         //Only add referenceDate if there are no RecurrenceRules defined

--- a/Ical.Net/Evaluation/TimeZoneInfoEvaluator.cs
+++ b/Ical.Net/Evaluation/TimeZoneInfoEvaluator.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 //
 
+#nullable enable
 using System;
 using System.Collections.Generic;
 using Ical.Net.CalendarComponents;
@@ -14,7 +15,7 @@ public class TimeZoneInfoEvaluator : RecurringEvaluator
 {
     protected VTimeZoneInfo TimeZoneInfo
     {
-        get => Recurrable as VTimeZoneInfo;
+        get => Recurrable as VTimeZoneInfo ?? throw new InvalidOperationException();
         set => Recurrable = value;
     }
 

--- a/Ical.Net/Evaluation/TimeZoneInfoEvaluator.cs
+++ b/Ical.Net/Evaluation/TimeZoneInfoEvaluator.cs
@@ -21,7 +21,7 @@ public class TimeZoneInfoEvaluator : RecurringEvaluator
 
     public TimeZoneInfoEvaluator(IRecurrable tzi) : base(tzi) { }
 
-    public override IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime? periodStart, DateTime? periodEnd, bool includeReferenceDateInResults)
+    public override IEnumerable<Period> Evaluate(IDateTime referenceDate, IDateTime? periodStart, IDateTime? periodEnd, bool includeReferenceDateInResults)
     {
         // Time zones must include an effective start date/time
         // and must provide an evaluator.

--- a/Ical.Net/Evaluation/TodoEvaluator.cs
+++ b/Ical.Net/Evaluation/TodoEvaluator.cs
@@ -44,7 +44,7 @@ public class TodoEvaluator : RecurringEvaluator
 
         DetermineStartingRecurrence(Todo.ExceptionDates.GetAllDates(), ref beginningDate);
 
-        return Evaluate(Todo.Start, DateUtil.GetSimpleDateTimeData(beginningDate), DateUtil.GetSimpleDateTimeData(currDt).AddTicks(1), true);
+        return Evaluate(Todo.Start, beginningDate, currDt.AddSeconds(1), true);
     }
 
     private static void DetermineStartingRecurrence(IEnumerable<Period> rdate, ref IDateTime referenceDateTime)
@@ -79,7 +79,7 @@ public class TodoEvaluator : RecurringEvaluator
         }
     }
 
-    public override IEnumerable<Period> Evaluate(IDateTime referenceDate, DateTime? periodStart, DateTime? periodEnd, bool includeReferenceDateInResults)
+    public override IEnumerable<Period> Evaluate(IDateTime referenceDate, IDateTime? periodStart, IDateTime? periodEnd, bool includeReferenceDateInResults)
     {
         // TODO items can only recur if a start date is specified
         if (Todo.Start == null)

--- a/Ical.Net/Evaluation/TodoEvaluator.cs
+++ b/Ical.Net/Evaluation/TodoEvaluator.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 //
 
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,7 +15,7 @@ namespace Ical.Net.Evaluation;
 
 public class TodoEvaluator : RecurringEvaluator
 {
-    protected Todo Todo => Recurrable as Todo;
+    protected Todo Todo => Recurrable as Todo ?? throw new InvalidOperationException();
 
     public TodoEvaluator(Todo todo) : base(todo) { }
 


### PR DESCRIPTION
Significant efforts were made lately to reduce the ambiguity that comes from dealing with `System.DateTime` with `DateTimeKind.Local`. The latter refers to the system's local time zone, which is not something that ical.net is aware of and wants to deal with. This PR cleans up some of the remaining places where `DateTimeKind.Local` could still appear and dissallows initializing `CalDateTime` instances with a `DateTime` of kind `Local`.

It also changes the parameters of `IEvaluator.Evaluate()` from `System.DateTime` to `IDateTime` to avoid ambiguity and does some other minor cleanup.

Fixes #406 