### PR TITLE
Correction in `RecurrenceDates.GetAllPeriods()`

### DIFF
--- a/Ical.Net/DataTypes/RecurrenceDates.cs
+++ b/Ical.Net/DataTypes/RecurrenceDates.cs
@@ -98,5 +98,5 @@ public class RecurrenceDates : PeriodListWrapperBase
     /// </summary>
     public IEnumerable<Period> GetAllPeriods()
         => ListOfPeriodList.
-            SelectMany(pl => pl.Where(p => p.PeriodKind is PeriodKind.Period)).OrderedDistinct();
+            SelectMany(pl => pl.Where(p => p.PeriodKind is PeriodKind.Period)).Distinct();
 }


### PR DESCRIPTION
Replace `.OrderedDistinct` with `.Distinct()`  because the input sequence is not ordered.