### PR TITLE
Make parameterless CTOR of CalDateTime internal

### DIFF
--- a/Ical.Net/DataTypes/CalDateTime.cs
+++ b/Ical.Net/DataTypes/CalDateTime.cs
@@ -56,7 +56,7 @@ public sealed class CalDateTime : IComparable<CalDateTime>, IFormattable
     /// <summary>
     /// This constructor is required for the SerializerFactory to work.
     /// </summary>
-    public CalDateTime() { }
+    internal CalDateTime() { }
 
     /// <summary>
     /// Creates a new instance of the <see cref="CalDateTime"/> class.


### PR DESCRIPTION
Reasoning: Should not be part of the public API