### PR TITLE
Fix incorrect handling of UNTIL if falling into DST change and some related improvements

### DIFF
--- a/Ical.Net.Benchmarks/OccurencePerfTests.cs
+++ b/Ical.Net.Benchmarks/OccurencePerfTests.cs
@@ -60,7 +60,7 @@ public class OccurencePerfTests
             {
                 var rrule = new RecurrencePattern(FrequencyType.Daily, 1)
                 {
-                    Until = startTime.AddDays(10),
+                    Until = new CalDateTime(startTime.AddDays(10)),
                 };
 
                 var e = new CalendarEvent

--- a/Ical.Net.Tests/DocumentationExamples.cs
+++ b/Ical.Net.Tests/DocumentationExamples.cs
@@ -21,14 +21,14 @@ public class DocumentationExamples
         // We want it to recur through the end of July.
         var vEvent = new CalendarEvent
         {
-            DtStart = new CalDateTime(DateTime.Parse("2016-07-01T07:00")),
-            DtEnd = new CalDateTime(DateTime.Parse("2016-07-01T08:00")),
+            DtStart = new CalDateTime("20160701T070000"),
+            DtEnd = new CalDateTime("20160701T080000"),
         };
 
         //Recur daily through the end of the day, July 31, 2016
         var recurrenceRule = new RecurrencePattern(FrequencyType.Daily, 1)
         {
-            Until = DateTime.Parse("2016-07-31T23:59:59")
+            Until = new CalDateTime("20160731T235959")
         };
 
         vEvent.RecurrenceRules = new List<RecurrencePattern> { recurrenceRule };
@@ -57,7 +57,7 @@ public class DocumentationExamples
         // Recurring every other Tuesday until Dec 31
         var rrule = new RecurrencePattern(FrequencyType.Weekly, 2)
         {
-            Until = DateTime.Parse("2016-12-31T11:59:59")
+            Until = new CalDateTime("20161231T115959")
         };
         vEvent.RecurrenceRules = new List<RecurrencePattern> { rrule };
 
@@ -88,7 +88,6 @@ public class DocumentationExamples
             Interval = 1,
             ByMonth = new List<int> { 11 },
             ByDay = new List<WeekDay> { new WeekDay { DayOfWeek = DayOfWeek.Thursday, Offset = 4 } },
-            Until = DateTime.MaxValue
         };
         vEvent.RecurrenceRules = new List<RecurrencePattern> { rrule };
 

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -76,6 +76,52 @@ public class RecurrenceTests
         EventOccurrenceTest(cal, fromDate, toDate, expectedPeriods, timeZones, 0);
     }
 
+    private static TestCaseData[] EventOccurrenceTestCases = new TestCaseData[]
+    {
+        new("""
+            DTSTART;TZID=Europe/Amsterdam:20201024T023000
+            DURATION:PT5M
+            RRULE:FREQ=DAILY;UNTIL=20201025T010000Z
+            """,
+            new []
+            {
+                "20201024T023000/PT5M",
+                "20201025T023000/PT5M"
+            }
+        ),
+    };
+
+    [Test, Category("Recurrence")]
+    [TestCaseSource(nameof(EventOccurrenceTestCases))]
+    public void EventOccurrenceTest(
+        string eventIcal,
+        string[] expectedPeriods)
+    {
+        var eventSerializer = new EventSerializer();
+        var calendarIcalStr = $"""
+            BEGIN:VCALENDAR
+            VERSION:2.0
+            BEGIN:VEVENT
+            {eventIcal}
+            END:VEVENT
+            END:VCALENDAR
+            """;
+
+        var cal = Calendar.Load(calendarIcalStr);
+        var tzid = cal.Events.Single().Start.TzId;
+
+        var periodSerializer = new PeriodSerializer();
+        var periods = expectedPeriods
+            .Select(p => (Period) periodSerializer.Deserialize(new StringReader(p)))
+            .Select(p =>
+                p.Duration is null
+                    ? new Period(p.StartTime.ToTimeZone(tzid), p.EndTime)
+                    : new Period(p.StartTime.ToTimeZone(tzid), p.Duration.Value))
+            .ToArray();
+
+        EventOccurrenceTest(cal, null, null, periods, null, 0);
+    }
+
     /// <summary>
     /// See Page 45 of RFC 2445 - RRULE:FREQ=YEARLY;INTERVAL=2;BYMONTH=1;BYDAY=SU;BYHOUR=8,9;BYMINUTE=30
     /// </summary>

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -3134,7 +3134,7 @@ END:VCALENDAR";
 
         var rrule = new RecurrencePattern(FrequencyType.Weekly, interval: 1)
         {
-            Until = DateTime.Parse("2016-08-31T07:00:00"),
+            Until = new CalDateTime("20160831T070000"),
             ByDay = new List<WeekDay> { new WeekDay(DayOfWeek.Wednesday) },
         };
 
@@ -3307,7 +3307,7 @@ END:VCALENDAR";
     {
         var start = _now.AddYears(-1);
         var end = start.AddHours(1);
-        var rrule = new RecurrencePattern(FrequencyType.Daily) { Until = start.AddYears(2) };
+        var rrule = new RecurrencePattern(FrequencyType.Daily) { Until = new CalDateTime(start.AddYears(2)) };
         var e = new CalendarEvent
         {
             DtStart = new CalDateTime(start),

--- a/Ical.Net.Tests/SerializationTests.cs
+++ b/Ical.Net.Tests/SerializationTests.cs
@@ -502,7 +502,7 @@ public class SerializationTests
     {
         var rrule = new RecurrencePattern(FrequencyType.Daily)
         {
-            Until = _nowTime.AddDays(7),
+            Until = new CalDateTime(_nowTime.AddDays(7)),
         };
         const string someTz = "Europe/Volgograd";
         var e = new CalendarEvent

--- a/Ical.Net/DataTypes/CalDateTime.cs
+++ b/Ical.Net/DataTypes/CalDateTime.cs
@@ -250,28 +250,28 @@ public sealed class CalDateTime : IComparable<CalDateTime>, IFormattable
     {
         return left != null
                && right != null
-               && ((left.IsFloating || right.IsFloating) ? left.Value < right.Value : left.AsUtc < right.AsUtc);
+               && ((left.IsFloating || right.IsFloating || left.TzId == right.TzId) ? left.Value < right.Value : left.AsUtc < right.AsUtc);
     }
 
     public static bool operator >(CalDateTime? left, CalDateTime? right)
     {
         return left != null
                && right != null
-               && ((left.IsFloating || right.IsFloating) ? left.Value > right.Value : left.AsUtc > right.AsUtc);
+               && ((left.IsFloating || right.IsFloating || left.TzId == right.TzId) ? left.Value > right.Value : left.AsUtc > right.AsUtc);
     }
 
     public static bool operator <=(CalDateTime? left, CalDateTime? right)
     {
         return left != null
                && right != null
-               && ((left.IsFloating || right.IsFloating) ? left.Value <= right.Value : left.AsUtc <= right.AsUtc);
+               && ((left.IsFloating || right.IsFloating || left.TzId == right.TzId) ? left.Value <= right.Value : left.AsUtc <= right.AsUtc);
     }
 
     public static bool operator >=(CalDateTime? left, CalDateTime? right)
     {
         return left != null
                && right != null
-               && ((left.IsFloating || right.IsFloating) ? left.Value >= right.Value : left.AsUtc >= right.AsUtc);
+               && ((left.IsFloating || right.IsFloating || left.TzId == right.TzId) ? left.Value >= right.Value : left.AsUtc >= right.AsUtc);
     }
 
     public static bool operator ==(CalDateTime? left, CalDateTime? right)

--- a/Ical.Net/DataTypes/CalDateTime.cs
+++ b/Ical.Net/DataTypes/CalDateTime.cs
@@ -302,14 +302,6 @@ public sealed class CalDateTime : IComparable<CalDateTime>, IFormattable
     }
 
     /// <summary>
-    /// Creates a new instance of <see cref="CalDateTime"/> with <see langword="true"/> for <see cref="HasTime"/>
-    /// </summary>
-    public static implicit operator CalDateTime(DateTime left)
-    {
-        return new CalDateTime(left);
-    }
-
-    /// <summary>
     /// Converts the date/time to UTC (Coordinated Universal Time)
     /// If <see cref="IsFloating"/>==<see langword="true"/>
     /// it means that the <see cref="Value"/> is considered as local time for every timezone:

--- a/Ical.Net/DataTypes/CalDateTime.cs
+++ b/Ical.Net/DataTypes/CalDateTime.cs
@@ -241,7 +241,6 @@ public sealed class CalDateTime : IComparable<CalDateTime>, IFormattable
         {
             var hashCode = Value.GetHashCode();
             hashCode = (hashCode * 397) ^ HasTime.GetHashCode();
-            hashCode = (hashCode * 397) ^ AsUtc.GetHashCode();
             hashCode = (hashCode * 397) ^ (TzId != null ? TzId.GetHashCode() : 0);
             return hashCode;
         }

--- a/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Ical.Net.DataTypes;
-using Ical.Net.Utility;
 
 namespace Ical.Net.Evaluation;
 
@@ -27,12 +26,6 @@ public class RecurrencePatternEvaluator : Evaluator
     {
         var r = new RecurrencePattern();
         r.CopyFrom(Pattern);
-
-        // Convert the UNTIL value to one that matches the same time information as the reference date
-        if (r.Until is not null)
-        {
-            r.Until = MatchTimeZone(referenceDate, r.Until);
-        }
 
         if (referenceDate.HasTime)
         {
@@ -152,12 +145,19 @@ public class RecurrencePatternEvaluator : Evaluator
     {
         var expandBehavior = RecurrenceUtil.GetExpandBehaviorList(pattern);
 
+        // This value is only used for performance reasons to stop incrementing after
+        // until is passed, even if no recurrences are being found.
+        // As a safe heuristic we add 1d to the UNTIL value to cover any time shift and DST changes.
+        // It's just important that we don't miss any recurrences, not that we stop exactly at UNTIL.
+        // Precise UNTIL handling is done outside this method after TZ conversion.
+        var coarseUntil = pattern.Until?.Value.AddDays(1);
+
         var noCandidateIncrementCount = 0;
         DateTime? candidate = null;
         var dateCount = 0;
         while (maxCount < 0 || dateCount < maxCount)
         {
-            if (pattern.Until is not null && candidate > pattern.Until)
+            if (seedCopy > coarseUntil)
             {
                 break;
             }
@@ -202,11 +202,10 @@ public class RecurrencePatternEvaluator : Evaluator
                         continue;
                     }
 
-                    if (pattern.Until is null || candidate <= pattern.Until)
-                    {
-                        yield return candidate.Value;
-                        dateCount++;
-                    }
+                    // UNTIL is applied outside of this method, after TZ conversion has been applied.
+
+                    yield return candidate.Value;
+                    dateCount++;
                 }
             }
             else
@@ -903,42 +902,9 @@ public class RecurrencePatternEvaluator : Evaluator
         var periodQuery = GetDates(referenceDate, periodStart, periodEnd, -1, pattern, includeReferenceDateInResults)
             .Select(dt => CreatePeriod(dt, referenceDate));
 
+        if (pattern.Until is not null)
+            periodQuery = periodQuery.TakeWhile(p => p.StartTime <= pattern.Until);
+
         return periodQuery;
-    }
-
-    private static CalDateTime MatchTimeZone(CalDateTime reference, CalDateTime until)
-    {
-        /*
-           The value of the "UNTIL" rule part MUST have the same value type as the
-           "DTSTART" property.  Furthermore, if the "DTSTART" property is
-           specified as a date with local time, then the UNTIL rule part MUST
-           also be specified as a date with local time.
-
-           If the "DTSTART" property is specified as a date with UTC time or a date with local
-           time and time zone reference, then the UNTIL rule part MUST be
-           specified as a date with UTC time.
-         */
-        string? untilTzId;
-        if (reference.IsFloating)
-        {
-            // If 'reference' is floating, then 'until' must be floating
-            untilTzId = null;
-        }
-        else
-        {
-            // If 'reference' has a timezone, 'until' MUST be UTC,
-            // but in case of UTC rule violation we fall back to the 'reference' timezone
-            untilTzId = until.TzId == CalDateTime.UtcTzId
-                ? CalDateTime.UtcTzId
-                : reference.TzId;
-        }
-
-        var untilCalDt = new CalDateTime(until.Value, untilTzId, reference.HasTime);
-
-        // If 'reference' is floating, then 'until' is floating, too
-        return reference.TzId is null
-            ? untilCalDt
-            // convert to the reference timezone and convert the value to Floating
-            : untilCalDt.ToTimeZone(reference.TzId).ToTimeZone(null);
     }
 }

--- a/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
@@ -141,7 +141,7 @@ public class RecurrencePatternEvaluator : Evaluator
         return EnumerateDates(originalDate, seedCopy, periodStartDt, periodEndDt, maxCount, pattern);
     }
 
-    private IEnumerable<DateTime> EnumerateDates(DateTime originalDate, DateTime seedCopy, DateTime? periodStart, DateTime? periodEnd, int maxCount, RecurrencePattern pattern)
+    private IEnumerable<DateTime> EnumerateDates(DateTime originalDate, DateTime intervalRefTime, DateTime? periodStart, DateTime? periodEnd, int maxCount, RecurrencePattern pattern)
     {
         var expandBehavior = RecurrenceUtil.GetExpandBehaviorList(pattern);
 
@@ -153,16 +153,10 @@ public class RecurrencePatternEvaluator : Evaluator
         var coarseUntil = pattern.Until?.Value.AddDays(1);
 
         var noCandidateIncrementCount = 0;
-        DateTime? candidate = null;
         var dateCount = 0;
         while (maxCount < 0 || dateCount < maxCount)
         {
-            if (seedCopy > coarseUntil)
-            {
-                break;
-            }
-
-            if (candidate > periodEnd)
+            if (intervalRefTime > coarseUntil)
             {
                 break;
             }
@@ -173,19 +167,19 @@ public class RecurrencePatternEvaluator : Evaluator
             }
 
             //No need to continue if the seed is after the periodEnd
-            if (seedCopy > periodEnd)
+            if (intervalRefTime > periodEnd)
             {
                 break;
             }
 
-            var candidates = GetCandidates(seedCopy, pattern, expandBehavior);
+            var candidates = GetCandidates(intervalRefTime, pattern, expandBehavior);
             if (candidates.Count > 0)
             {
                 noCandidateIncrementCount = 0;
 
                 foreach (var t in candidates.Where(t => t >= originalDate))
                 {
-                    candidate = t;
+                    var candidate = t;
 
                     // candidates MAY occur before periodStart
                     // For example, FREQ=YEARLY;BYWEEKNO=1 could return dates
@@ -204,7 +198,7 @@ public class RecurrencePatternEvaluator : Evaluator
 
                     // UNTIL is applied outside of this method, after TZ conversion has been applied.
 
-                    yield return candidate.Value;
+                    yield return candidate;
                     dateCount++;
                 }
             }
@@ -217,7 +211,7 @@ public class RecurrencePatternEvaluator : Evaluator
                 }
             }
 
-            IncrementDate(ref seedCopy, pattern, pattern.Interval);
+            IncrementDate(ref intervalRefTime, pattern, pattern.Interval);
         }
     }
 

--- a/Ical.Net/Serialization/DataTypes/RecurrencePatternSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/RecurrencePatternSerializer.cs
@@ -426,10 +426,7 @@ public class RecurrencePatternSerializer : EncodableDataTypeSerializer
                 }
                 else if ((match = RecurUntil.Match(item)).Success)
                 {
-                    var dt = DateTime.Parse(match.Groups["DateTime"].Value);
-                    DateTime.SpecifyKind(dt, DateTimeKind.Utc);
-
-                    r.Until = dt;
+                    r.Until = new CalDateTime(match.Groups["DateTime"].Value);
                 }
                 else if ((match = SpecificRecurrenceCount.Match(item)).Success)
                 {


### PR DESCRIPTION
Reproduce and fix #736. I.e. if `UNTIL` falls into a DST change with ambiguity, then recurrences could have missed, which is fixed with this PR.

Other improvements include:
* Remove implicit conversion operator from `System.DateTime` to `CalDateTime`, which could cause confusion and was a source of bugs.
* Remove `AsUtc` from `CalDateTime.GetHashCode()` to avoid timezone calculations
* Avoid UTC conversion when comparing two `CalDateTime` if they have the same `TzId`
