### PR TITLE
Replace `DateTime` with `CalDateTime` in `RecurrencePatternEvaluator` and related code

### DIFF
--- a/Ical.Net.Benchmarks/OccurencePerfTests.cs
+++ b/Ical.Net.Benchmarks/OccurencePerfTests.cs
@@ -51,7 +51,7 @@ public class OccurencePerfTests
         const string tzid = "America/New_York";
         const int limit = 4;
 
-        var startTime = DateTime.Now.AddDays(-1);
+        var startTime = CalDateTime.Now.AddDays(-1);
         var interval = TimeSpan.FromDays(1);
 
         var events = Enumerable
@@ -65,11 +65,11 @@ public class OccurencePerfTests
 
                 var e = new CalendarEvent
                 {
-                    Start = new CalDateTime(startTime.AddMinutes(5), tzid),
-                    End = new CalDateTime(startTime.AddMinutes(10), tzid),
+                    Start = startTime.AddMinutes(5).ToTimeZone(tzid),
+                    End = startTime.AddMinutes(10).ToTimeZone(tzid),
                     RecurrenceRules = new List<RecurrencePattern> { rrule },
                 };
-                startTime += interval;
+                startTime = startTime.Add(Duration.FromTimeSpanExact(interval));
                 return e;
             });
 
@@ -133,7 +133,7 @@ public class OccurencePerfTests
                     End = new CalDateTime(startTime.AddMinutes(10), tzid),
                     RecurrenceRules = new List<RecurrencePattern> { rrule },
                 };
-                startTime += interval;
+                startTime = startTime.Add(interval);
                 return e;
             });
 

--- a/Ical.Net.Tests/SerializationTests.cs
+++ b/Ical.Net.Tests/SerializationTests.cs
@@ -22,13 +22,13 @@ namespace Ical.Net.Tests;
 [TestFixture]
 public class SerializationTests
 {
-    private static readonly DateTime _nowTime = DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Unspecified);
-    private static readonly DateTime _later = _nowTime.AddHours(1);
+    private static readonly CalDateTime _nowTime = CalDateTime.Now;
+    private static readonly CalDateTime _later = _nowTime.AddHours(1);
     private static CalendarSerializer GetNewSerializer() => new CalendarSerializer();
     private static string SerializeToString(Calendar c) => GetNewSerializer().SerializeToString(c);
     private static string SerializeToString(CalendarEvent e) => SerializeToString(new Calendar { Events = { e } });
-    private static CalendarEvent GetSimpleEvent() => new CalendarEvent { DtStart = new CalDateTime(_nowTime), Duration = (_later - _nowTime).ToDurationExact() };
-    private static Calendar UnserializeCalendar(string s) => Calendar.Load(s);
+    private static CalendarEvent GetSimpleEvent() => new CalendarEvent { DtStart = new CalDateTime(_nowTime), Duration = (_later.Value - _nowTime.Value).ToDurationExact() };
+    private static Calendar DeserializeCalendar(string s) => Calendar.Load(s);
 
     internal static void CompareCalendars(Calendar cal1, Calendar cal2)
     {
@@ -382,7 +382,7 @@ public class SerializationTests
         var serialized = SerializeToString(e);
         Assert.That(serialized.Contains(EventStatus.Confirmed, EventStatus.Comparison), Is.True);
 
-        var calendar = UnserializeCalendar(serialized);
+        var calendar = DeserializeCalendar(serialized);
         var eventStatus = calendar.Events.First().Status;
         Assert.That(string.Equals(EventStatus.Confirmed, eventStatus, EventStatus.Comparison), Is.True);
     }
@@ -399,7 +399,7 @@ public class SerializationTests
         var serialized = SerializeToString(c);
         Assert.That(serialized.Contains(TodoStatus.NeedsAction, TodoStatus.Comparison), Is.True);
 
-        var calendar = UnserializeCalendar(serialized);
+        var calendar = DeserializeCalendar(serialized);
         var status = calendar.Todos.First().Status;
         Assert.That(string.Equals(TodoStatus.NeedsAction, status, TodoStatus.Comparison), Is.True);
     }
@@ -416,7 +416,7 @@ public class SerializationTests
         var serialized = SerializeToString(c);
         Assert.That(serialized.Contains(JournalStatus.Final, JournalStatus.Comparison), Is.True);
 
-        var calendar = UnserializeCalendar(serialized);
+        var calendar = DeserializeCalendar(serialized);
         var status = calendar.Journals.First().Status;
         Assert.That(string.Equals(JournalStatus.Final, status, JournalStatus.Comparison), Is.True);
     }
@@ -507,8 +507,8 @@ public class SerializationTests
         const string someTz = "Europe/Volgograd";
         var e = new CalendarEvent
         {
-            Start = new CalDateTime(_nowTime, someTz),
-            End = new CalDateTime(_nowTime.AddHours(1), someTz),
+            Start = _nowTime.ToTimeZone(someTz),
+            End = _nowTime.AddHours(1).ToTimeZone(someTz),
             RecurrenceRules = new List<RecurrencePattern> { rrule },
         };
         var c = new Calendar

--- a/Ical.Net/CalendarExtensions.cs
+++ b/Ical.Net/CalendarExtensions.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Globalization;
+using Ical.Net.DataTypes;
 
 namespace Ical.Net;
 
@@ -13,7 +14,7 @@ public static class CalendarExtensions
     /// <summary>
     /// Calculate the week number according to ISO.8601, as required by RFC 5545.
     /// </summary>
-    public static int GetIso8601WeekOfYear(this System.Globalization.Calendar calendar, DateTime time, DayOfWeek firstDayOfWeek)
+    public static int GetIso8601WeekOfYear(this System.Globalization.Calendar calendar, CalDateTime time, DayOfWeek firstDayOfWeek)
     {
         // A week is defined as a
         // seven day period, starting on the day of the week defined to be
@@ -24,7 +25,7 @@ public static class CalendarExtensions
         // We add 3 to make sure the test date is in the 'right' year, because
         // otherwise we might end up with week 53 in a year that only has 52.
         var tTest = GetStartOfWeek(time, firstDayOfWeek).AddDays(3);
-        var res = calendar.GetWeekOfYear(tTest, CalendarWeekRule.FirstFourDayWeek, firstDayOfWeek);
+        var res = calendar.GetWeekOfYear(tTest.Value, CalendarWeekRule.FirstFourDayWeek, firstDayOfWeek);
 
         return res;
     }
@@ -33,7 +34,7 @@ public static class CalendarExtensions
     /// Calculate and return the date that represents the first day of the week the given date is
     /// in, according to the week numbering required by RFC 5545.
     /// </summary>
-    private static DateTime GetStartOfWeek(this DateTime t, DayOfWeek firstDayOfWeek)
+    private static CalDateTime GetStartOfWeek(this CalDateTime t, DayOfWeek firstDayOfWeek)
     {
         var t0 = ((int) firstDayOfWeek) % 7;
         var tn = ((int) t.DayOfWeek) % 7;
@@ -49,7 +50,7 @@ public static class CalendarExtensions
     /// E.g. for `2019-12-31` with first day of the week being Monday, the method will return 2020,
     /// because the week that contains `2019-12-31` is the first week of 2020.
     /// </remarks>
-    public static int GetIso8601YearOfWeek(this System.Globalization.Calendar calendar, DateTime time, DayOfWeek firstDayOfWeek)
+    public static int GetIso8601YearOfWeek(this System.Globalization.Calendar calendar, CalDateTime time, DayOfWeek firstDayOfWeek)
     {
         var year = time.Year;
         if ((time.Month >= 12) && (calendar.GetIso8601WeekOfYear(time, firstDayOfWeek) == 1))
@@ -66,7 +67,7 @@ public static class CalendarExtensions
     public static int GetIso8601WeeksInYear(this System.Globalization.Calendar calendar, int year, DayOfWeek firstDayOfWeek)
     {
         // The last week of the year is the week that contains the 4th-last day of the year (which is the 28th of December in Gregorian Calendar).
-        var testTime = new DateTime(year + 1, 1, 1, 0, 0, 0, DateTimeKind.Unspecified).AddDays(-4);
+        var testTime = new CalDateTime(year + 1, 1, 1, 0, 0, 0, null).AddDays(-4);
         return calendar.GetIso8601WeekOfYear(testTime, firstDayOfWeek);
     }
 }

--- a/Ical.Net/Evaluation/Evaluator.cs
+++ b/Ical.Net/Evaluation/Evaluator.cs
@@ -19,7 +19,7 @@ public abstract class Evaluator : IEvaluator
         Calendar = CultureInfo.CurrentCulture.Calendar;
     }
 
-    protected void IncrementDate(ref DateTime dt, RecurrencePattern pattern, int interval)
+    protected void IncrementDate(ref CalDateTime dt, RecurrencePattern pattern, int interval)
     {
         if (interval == 0)
             return;

--- a/Ical.Net/Evaluation/TodoEvaluator.cs
+++ b/Ical.Net/Evaluation/TodoEvaluator.cs
@@ -73,9 +73,7 @@ public class TodoEvaluator : RecurringEvaluator
         }
         else
         {
-            var dtVal = referenceDateTime.Value;
-            IncrementDate(ref dtVal, recur, -recur.Interval);
-            referenceDateTime = new CalDateTime(DateOnly.FromDateTime(dtVal), TimeOnly.FromDateTime(dtVal));
+            IncrementDate(ref referenceDateTime, recur, -recur.Interval);
         }
     }
 

--- a/Ical.Net/Utility/DateUtil.cs
+++ b/Ical.Net/Utility/DateUtil.cs
@@ -15,7 +15,7 @@ internal static class DateUtil
     public static CalDateTime AsCalDateTime(this DateTime t)
         => new CalDateTime(t);
 
-    public static DateTime AddWeeks(DateTime dt, int interval, DayOfWeek firstDayOfWeek)
+    public static CalDateTime AddWeeks(CalDateTime dt, int interval, DayOfWeek firstDayOfWeek)
     {
         dt = dt.AddDays(interval * 7);
         while (dt.DayOfWeek != firstDayOfWeek)
@@ -26,7 +26,7 @@ internal static class DateUtil
         return dt;
     }
 
-    public static DateTime FirstDayOfWeek(DateTime dt, DayOfWeek firstDayOfWeek, out int offset)
+    public static CalDateTime FirstDayOfWeek(CalDateTime dt, DayOfWeek firstDayOfWeek, out int offset)
     {
         offset = 0;
         while (dt.DayOfWeek != firstDayOfWeek)


### PR DESCRIPTION
Replace `DateTime` with `CalDateTime` in `RecurrencePatternEvaluator` and related code. Key changes:

- Modifying the Until property of `RecurrencePattern` to use `CalDateTime`.
- Updating `ExceptionDates` to directly add `CalDateTime` instances.
- Refactoring methods like `GetIso8601WeekOfYear` to accept `CalDateTime` parameters.
- Adjusting serialization and deserialization processes for `CalDateTime`.
- Adjusting the `RecurrencePatternEvaluator` to work with `CalDateTime`.