### PR TITLE
Evaluation: Avoid dependency on local culture settings.

### DIFF
--- a/Ical.Net/Evaluation/Evaluator.cs
+++ b/Ical.Net/Evaluation/Evaluator.cs
@@ -6,7 +6,6 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using Ical.Net.DataTypes;
 using Ical.Net.Utility;
 
@@ -14,11 +13,6 @@ namespace Ical.Net.Evaluation;
 
 public abstract class Evaluator : IEvaluator
 {
-    protected Evaluator()
-    {
-        Calendar = CultureInfo.CurrentCulture.Calendar;
-    }
-
     protected void IncrementDate(ref CalDateTime dt, RecurrencePattern pattern, int interval)
     {
         if (interval == 0)
@@ -53,8 +47,6 @@ public abstract class Evaluator : IEvaluator
                 throw new Exception("FrequencyType.NONE cannot be evaluated. Please specify a FrequencyType before evaluating the recurrence.");
         }
     }
-
-    public System.Globalization.Calendar Calendar { get; private set; }
 
     public abstract IEnumerable<Period> Evaluate(CalDateTime referenceDate, CalDateTime? periodStart, CalDateTime? periodEnd, EvaluationOptions options);
 }

--- a/Ical.Net/Evaluation/IEvaluator.cs
+++ b/Ical.Net/Evaluation/IEvaluator.cs
@@ -13,11 +13,6 @@ namespace Ical.Net.Evaluation;
 public interface IEvaluator
 {
     /// <summary>
-    /// The system calendar that governs the evaluation rules.
-    /// </summary>
-    System.Globalization.Calendar Calendar { get; }
-
-    /// <summary>
     /// Evaluates this item to determine the dates and times for which it occurs/recurs.
     /// This method only evaluates items which occur/recur between <paramref name="periodStart"/>
     /// and <paramref name="periodEnd"/>; therefore, if you require a list of items which

--- a/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
@@ -13,6 +13,13 @@ namespace Ical.Net.Evaluation;
 
 public class RecurrencePatternEvaluator : Evaluator
 {
+    /// <summary>
+    /// The system calendar to be used to calculate details like the week of the year, days in a month, etc.
+    /// We only support the gregorian calendar at this time. We take it from the InvariantCulture to avoid
+    /// any side effects from the local system's configuration.
+    /// </summary>
+    private static System.Globalization.Calendar Calendar { get; } = System.Globalization.CultureInfo.InvariantCulture.Calendar;
+
     protected RecurrencePattern Pattern { get; set; }
 
     public RecurrencePatternEvaluator(RecurrencePattern pattern)


### PR DESCRIPTION
The use of `CultureInfo.CurrentCulture.Calendar` is one of the remaining dependencies on the local system settings, which is fixed with this PR.