### PR TITLE
Update codecov/codecov-action to v5

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,9 +44,9 @@ jobs:
         name: coverage-report
         path: ./Ical.Net.Tests/coverage.*.xml  # store all coverage reports
     - name: Upload coverage to Codecov  
-      uses: codecov/codecov-action@v4  
+      uses: codecov/codecov-action@v5  
       with:  
         # files: automatically finds all in ./Ical.Net.Tests/
         name: coverage
-        token: ${{ secrets.CODECOV_TOKEN }}
+        # ical-org does not require an upload token for its public repositories
         fail_ci_if_error: false

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -48,5 +48,6 @@ jobs:
       with:  
         # files: automatically finds all in ./Ical.Net.Tests/
         name: coverage
-        # ical-org does not require an upload token for its public repositories
+        token: ${{ secrets.CODECOV_TOKEN }}
+        # ical-org global settings do not require an upload token from forks
         fail_ci_if_error: false


### PR DESCRIPTION
Change global setting at codecov.io to not require an upload token for ical-org public repositories

Response form Codecov support:

> Yes, this behavior was reported in [#1671](https://github.com/codecov/codecov-action/issues/1671) and [#1782](https://github.com/codecov/codecov-action/issues/1782). It turns out that codecov-action@v5 had a regression where tokenless uploads failed, even if they were enabled. In one case, the issue was a trailing newline in the CODECOV_TOKEN secret, and in others, it was a bug fixed in v5.0.6. If you're still running into this, make sure you're using at least version v5.4.0 and that your token (if set) is clean.