### PR TITLE
Change `DateTime` method args to `CalDateTime`

### DIFF
--- a/Ical.Net.Benchmarks/ThroughputTests.cs
+++ b/Ical.Net.Benchmarks/ThroughputTests.cs
@@ -6,6 +6,7 @@
 using BenchmarkDotNet.Attributes;
 using System;
 using System.Linq;
+using Ical.Net.DataTypes;
 
 namespace Ical.Net.Benchmarks;
 
@@ -68,8 +69,8 @@ END:VCALENDAR";
 
         var calendar = Calendar.Load(e);
         var calendarEvent = calendar.Events.First();
-        var searchStart = new DateTime(2009, 06, 20);
-        var searchEnd = new DateTime(2011, 06, 23);
+        var searchStart = new CalDateTime(2009, 06, 20);
+        var searchEnd = new CalDateTime(2011, 06, 23);
         var occurrences = calendarEvent.GetOccurrences(searchStart, searchEnd);
     }
 
@@ -130,8 +131,8 @@ END:VCALENDAR";
 
         var calendar = Calendar.Load(e);
         var calendarEvent = calendar.Events.First();
-        var searchStart = new DateTime(2009, 06, 20);
-        var searchEnd = new DateTime(2011, 06, 23);
+        var searchStart = new CalDateTime(2009, 06, 20);
+        var searchEnd = new CalDateTime(2011, 06, 23);
         var occurrences = calendarEvent.GetOccurrences(searchStart, searchEnd);
     }
 }

--- a/Ical.Net.Tests/DocumentationExamples.cs
+++ b/Ical.Net.Tests/DocumentationExamples.cs
@@ -38,8 +38,8 @@ public class DocumentationExamples
 
         // Count the occurrences between July 20, and Aug 5 -- there should be 12:
         // July 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
-        var searchStart = DateTime.Parse("2016-07-20");
-        var searchEnd = DateTime.Parse("2016-08-05");
+        var searchStart = new CalDateTime(2016, 07, 20);
+        var searchEnd = new CalDateTime(2016, 08, 05);
         var occurrences = calendar.GetOccurrences(searchStart, searchEnd).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(12));
     }
@@ -124,8 +124,8 @@ public class DocumentationExamples
         calendar.Events.Add(vEvent);
 
         // We are essentially counting all the days that aren't Sunday in 2016, so there should be 314
-        var searchStart = DateTime.Parse("2015-12-31");
-        var searchEnd = DateTime.Parse("2017-01-01");
+        var searchStart = new CalDateTime(2015, 12, 31);
+        var searchEnd = new CalDateTime(2017, 01, 01);
         var occurrences = calendar.GetOccurrences(searchStart, searchEnd).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(314));
     }

--- a/Ical.Net.Tests/DocumentationExamples.cs
+++ b/Ical.Net.Tests/DocumentationExamples.cs
@@ -63,8 +63,8 @@ public class DocumentationExamples
 
         // Count every other Tuesday between July 1 and Dec 31.
         // The first Tuesday is July 5. There should be 13 in total
-        var searchStart = DateTime.Parse("2010-01-01");
-        var searchEnd = DateTime.Parse("2016-12-31");
+        var searchStart = new CalDateTime(2010, 01, 01);
+        var searchEnd = new CalDateTime(2016, 12, 31);
         var tuesdays = vEvent.GetOccurrences(searchStart, searchEnd).ToList();
 
         Assert.That(tuesdays, Has.Count.EqualTo(13));
@@ -91,8 +91,8 @@ public class DocumentationExamples
         };
         vEvent.RecurrenceRules = new List<RecurrencePattern> { rrule };
 
-        var searchStart = DateTime.Parse("2000-01-01");
-        var searchEnd = DateTime.Parse("2017-01-01");
+        var searchStart = new CalDateTime(2000, 01, 01);
+        var searchEnd = new CalDateTime(2017, 01, 01);
         var usThanksgivings = vEvent.GetOccurrences(searchStart, searchEnd).ToList();
 
         Assert.That(usThanksgivings, Has.Count.EqualTo(17));

--- a/Ical.Net.Tests/GetOccurrenceTests.cs
+++ b/Ical.Net.Tests/GetOccurrenceTests.cs
@@ -32,8 +32,8 @@ internal class GetOccurrenceTests
         calendar.Events.Add(vEvent);
         calendar.Events.Add(vEvent2);
 
-        var searchStart = DateTime.Parse("2015-12-29");
-        var searchEnd = DateTime.Parse("2017-02-10");
+        var searchStart = new CalDateTime(2015, 12, 29);
+        var searchEnd = new CalDateTime(2017, 02, 10);
         var occurrences = calendar.GetOccurrences(searchStart, searchEnd).OrderBy(o => o.Period.StartTime).ToList();
 
         var firstOccurrence = occurrences.First();
@@ -143,7 +143,7 @@ END:VEVENT
 END:VCALENDAR";
 
         var calendar = GetCalendars(ical);
-        var date = new DateTime(2016, 10, 11);
+        var date = new CalDateTime(2016, 10, 11);
         var occurrences = calendar.GetOccurrences(date, date.AddDays(1)).ToList();
 
         //We really want to make sure this doesn't explode
@@ -207,7 +207,7 @@ END:VCALENDAR";
             """;
 
         var collection = Calendar.Load(ical);
-        var startCheck = new DateTime(2016, 11, 11);
+        var startCheck = new CalDateTime(2016, 11, 11);
         var occurrences = collection.GetOccurrences<CalendarEvent>(startCheck, startCheck.AddMonths(1)).ToList();
 
         CalDateTime[] expectedStartDates = [
@@ -261,7 +261,7 @@ END:VCALENDAR";
             """;
 
         var collection = Calendar.Load(ical);
-        var startCheck = new DateTime(2023, 10, 1);
+        var startCheck = new CalDateTime(2023, 10, 1);
         var occurrences = collection.GetOccurrences<CalendarEvent>(startCheck, startCheck.AddMonths(1))
             .ToList();
 

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -1232,8 +1232,8 @@ public class RecurrenceTests
         var rpe1 = new RecurrencePatternEvaluator(new RecurrencePattern("FREQ=YEARLY;WKST=MO;BYDAY=MO;BYWEEKNO=1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53"));
         var rpe2 = new RecurrencePatternEvaluator(new RecurrencePattern("FREQ=YEARLY;WKST=MO;BYDAY=MO;BYWEEKNO=53,51,49,47,45,43,41,39,37,35,33,31,29,27,25,23,21,19,17,15,13,11,9,7,5,3,1"));
 
-        var recurringPeriods1 = rpe1.Evaluate(new CalDateTime(start), start, end, default).ToList();
-        var recurringPeriods2 = rpe2.Evaluate(new CalDateTime(start), start, end, default).ToList();
+        var recurringPeriods1 = rpe1.Evaluate(new CalDateTime(start), start, end, null).ToList();
+        var recurringPeriods2 = rpe2.Evaluate(new CalDateTime(start), start, end, null).ToList();
 
         Assert.That(recurringPeriods2, Has.Count.EqualTo(recurringPeriods1.Count));
     }
@@ -3800,31 +3800,34 @@ END:VCALENDAR";
 
     [Test]
     // Reproducer from https://github.com/ical-org/ical.net/issues/629
+    // Note: The original reproducer used DateTime.Parse(yyyy-MM-dd) to create a CalDateTime
+    // which resolves to DateTime, with a Time part of 00:00:00.0000000.
+    // It's important to always or never use the Time part in this unit test
     public void ShouldCreateARecurringYearlyEvent()
     {
         var springAdminEvent = new CalendarEvent
         {
-            Start = new CalDateTime(DateTime.Parse("2024-04-15")),
-            End = new CalDateTime(DateTime.Parse("2024-04-15")),
+            Start = new CalDateTime(2024, 04, 15),
+            End = new CalDateTime(2024, 04, 15),
             RecurrenceRules = new List<RecurrencePattern> { new RecurrencePattern(FrequencyType.Yearly, 1) },
         };
 
         var calendar = new Calendar();
         calendar.Events.Add(springAdminEvent);
-        var searchStart = DateTime.Parse("2024-04-15");
-        var searchEnd = DateTime.Parse("2050-5-31");
+        var searchStart = new CalDateTime(2024, 04, 15);
+        var searchEnd = new CalDateTime(2050, 05, 31);
         var occurrences = calendar.GetOccurrences(searchStart, searchEnd);
         Assert.That(occurrences.Count, Is.EqualTo(27));
 
-        springAdminEvent.Start = new CalDateTime(DateTime.Parse("2024-04-16"));
-        springAdminEvent.End = new CalDateTime(DateTime.Parse("2024-04-16"));
+        springAdminEvent.Start = new CalDateTime(2024, 04, 16);
+        springAdminEvent.End = new CalDateTime(2024, 04, 16);
         springAdminEvent.RecurrenceRules = new List<RecurrencePattern> { new RecurrencePattern(FrequencyType.Yearly, 1) };
 
-        searchStart = DateTime.Parse("2024-04-16");
-        searchEnd = DateTime.Parse("2050-5-31");
+        searchStart = new CalDateTime(2024, 04, 16);
+        searchEnd = new CalDateTime(2050, 05, 31);
         occurrences = calendar.GetOccurrences(searchStart, searchEnd);
 
-        //occurences is 26 here, omitting 4/16/2024
+        // occurrences are 26 here, omitting 4/16/2024
         Assert.That(occurrences.Count, Is.EqualTo(27));
     }
 

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -2672,7 +2672,7 @@ public class RecurrenceTests
 
         evt.RecurrenceRules.Add(pattern);
 
-        var occurrences = evt.GetOccurrences(new DateTime(2018, 1, 1), DateTime.MaxValue).ToList();
+        var occurrences = evt.GetOccurrences(new CalDateTime(2018, 1, 1), new CalDateTime(DateTime.MaxValue, false)).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(10), "There should be 10 occurrences of this event.");
     }
 
@@ -2741,7 +2741,7 @@ public class RecurrenceTests
 
         evt.RecurrenceRules.Add(pattern);
 
-        var occurrences = evt.GetOccurrences(new DateTime(2011, 1, 1), new DateTime(2012, 1, 1)).ToList();
+        var occurrences = evt.GetOccurrences(new CalDateTime(2011, 1, 1), new CalDateTime(2012, 1, 1)).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(10), "There should be 10 occurrences of this event, one for each month except February and December.");
     }
 
@@ -2782,7 +2782,7 @@ public class RecurrenceTests
         //Testing on both the first day and the next, results used to be different
         for (var i = 0; i <= 1; i++)
         {
-            var checkTime = DateTime.Parse("2019-01-04T08:00Z").ToUniversalTime();
+            var checkTime = new CalDateTime(2019, 01, 04, 08, 00, 00, CalDateTime.UtcTzId);
             checkTime = checkTime.AddDays(i);
             //Valid asking for the exact moment
             var occurrences = vEvent.GetOccurrences(checkTime, checkTime).ToList();
@@ -2811,7 +2811,7 @@ public class RecurrenceTests
             End = new CalDateTime(DateTime.Parse("2020-01-11T00:00")),
         };
 
-        var occurrences = vEvent.GetOccurrences(DateTime.Parse("2020-01-10T00:00"), DateTime.Parse("2020-01-11T00:00"));
+        var occurrences = vEvent.GetOccurrences(new CalDateTime(2020,01, 10, 0, 0, 0), new CalDateTime(2020, 01, 11, 00, 00, 00));
         Assert.That(occurrences.Count, Is.EqualTo(0));
     }
 
@@ -3023,7 +3023,7 @@ public class RecurrenceTests
 
         Assert.That(() =>
         {
-            _ = evt.GetOccurrences(DateTime.Today.AddDays(1), DateTime.Today.AddDays(2));
+            _ = evt.GetOccurrences(CalDateTime.Today.AddDays(1), CalDateTime.Today.AddDays(2));
         }, Throws.Exception, "An exception should be thrown when evaluating a recurrence with no specified FREQUENCY");
     }
 
@@ -3403,7 +3403,7 @@ END:VCALENDAR";
         //Testing on both the first day and the next, results used to be different
         for (var i = 0; i <= 1; i++)
         {
-            var checkTime = DateTime.Parse("2019-06-07 00:00:00");
+            var checkTime = new CalDateTime(2019, 06, 07, 00, 00, 00);
             checkTime = checkTime.AddDays(i);
 
             //Valid if asking for a range starting at the same moment
@@ -3428,19 +3428,19 @@ END:VCALENDAR";
         vEvent.RecurrenceRules.Add(rrule);
 
         // Exactly on start time
-        var testingTime = new DateTime(2019, 6, 7, 9, 0, 0);
+        var testingTime = new CalDateTime(2019, 6, 7, 9, 0, 0);
 
         var occurrences = vEvent.GetOccurrences(testingTime, testingTime).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(1));
 
         // One second before end time
-        testingTime = new DateTime(2019, 6, 7, 16, 59, 59);
+        testingTime = new CalDateTime(2019, 6, 7, 16, 59, 59);
 
         occurrences = vEvent.GetOccurrences(testingTime, testingTime).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(1));
 
         // Exactly on end time
-        testingTime = new DateTime(2019, 6, 7, 17, 0, 0);
+        testingTime = new CalDateTime(2019, 6, 7, 17, 0, 0);
 
         occurrences = vEvent.GetOccurrences(testingTime, testingTime).ToList();
         Assert.That(occurrences.Count, Is.EqualTo(0));
@@ -3778,7 +3778,7 @@ END:VCALENDAR";
         evt.Summary = "Event summary";
 
         // Start at midnight, UTC time
-        evt.Start = testCase.DtStart;
+        evt.Start = testCase.DtStart!;
 
         if (testCase.Exception != null)
         {
@@ -3789,7 +3789,7 @@ END:VCALENDAR";
 
         evt.RecurrenceRules.Add(new RecurrencePattern(testCase.RRule!));
 
-        var occurrences = evt.GetOccurrences(testCase.StartAt?.Value ?? DateTime.MinValue, DateTime.MaxValue)
+        var occurrences = evt.GetOccurrences(testCase.StartAt ?? new CalDateTime(DateTime.MinValue), new CalDateTime(DateTime.MaxValue))
             .OrderBy(x => x)
             .ToList();
 

--- a/Ical.Net.Tests/RecurrenceTests_From_Issues.cs
+++ b/Ical.Net.Tests/RecurrenceTests_From_Issues.cs
@@ -302,8 +302,8 @@ public class RecurrenceTests_From_Issues
             }
         });
 
-        var start = new DateTime(2024, 12, 9, 8, 5, 0, DateTimeKind.Utc);
-        var end = new DateTime(2024, 12, 10, 7, 59, 59, DateTimeKind.Utc);
+        var start = new CalDateTime(2024, 12, 9, 8, 5, 0, CalDateTime.UtcTzId);
+        var end = new CalDateTime(2024, 12, 10, 7, 59, 59, CalDateTime.UtcTzId);
         var occurrence = calendar.GetOccurrences(start, end);
 
         Assert.That(occurrence.Count, Is.EqualTo(1));

--- a/Ical.Net.Tests/RecurrenceTests_From_Issues.cs
+++ b/Ical.Net.Tests/RecurrenceTests_From_Issues.cs
@@ -359,7 +359,7 @@ public class RecurrenceTests_From_Issues
             RecurrenceRules = new List<RecurrencePattern> { rule }
         };
 
-        var occurrences = calendarEvent.GetOccurrences(startDate, endDate);
+        var occurrences = calendarEvent.GetOccurrences(new CalDateTime(startDate), new CalDateTime(endDate));
         var occurrencesDates = occurrences.Select(o => new CalDateTime(o.Period.StartTime.Date)).ToList();
 
         // Sort both collections to ensure they are in the same order
@@ -501,8 +501,7 @@ public class RecurrenceTests_From_Issues
         var calendar = new Calendar();
         calendar.Events.Add(vEvent);
 
-        var occurrences = vEvent.GetOccurrences(DateTime.Parse("2017-06-01T00:00"), DateTime.Parse("2017-06-30T23:59")).ToList();
-
+        var occurrences = vEvent.GetOccurrences(new CalDateTime(2017, 06, 01, 00, 00, 00), new CalDateTime(2017, 06, 30, 23, 59, 0)).ToList();
         var excludedDays = new List<DayOfWeek> { DayOfWeek.Sunday, DayOfWeek.Saturday, DayOfWeek.Tuesday, DayOfWeek.Thursday };
 
         Assert.Multiple(() =>

--- a/Ical.Net/Calendar.cs
+++ b/Ical.Net/Calendar.cs
@@ -218,14 +218,6 @@ public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, I
     public virtual IEnumerable<Occurrence> GetOccurrences(CalDateTime startTime = null, CalDateTime endTime = null, EvaluationOptions options = default)
         => GetOccurrences<IRecurringComponent>(startTime, endTime, options);
 
-    /// <inheritdoc cref="GetOccurrences(CalDateTime, CalDateTime)"/>
-    public virtual IEnumerable<Occurrence> GetOccurrences(DateTime? startTime, DateTime? endTime, EvaluationOptions options = default)
-        => GetOccurrences<IRecurringComponent>(startTime?.AsCalDateTime(), endTime?.AsCalDateTime(), options);
-
-    /// <inheritdoc cref="GetOccurrences(CalDateTime, CalDateTime)"/>
-    public virtual IEnumerable<Occurrence> GetOccurrences<T>(DateTime? startTime, DateTime? endTime, EvaluationOptions options = default) where T : IRecurringComponent
-        => GetOccurrences<T>(startTime?.AsCalDateTime(), endTime?.AsCalDateTime(), options);
-
     /// <summary>
     /// Returns all occurrences of components of type T that start within the date range provided.
     /// All components occurring between <paramref name="startTime"/> and <paramref name="endTime"/>

--- a/Ical.Net/CalendarCollection.cs
+++ b/Ical.Net/CalendarCollection.cs
@@ -60,13 +60,7 @@ public class CalendarCollection : List<Calendar>
     public IEnumerable<Occurrence> GetOccurrences(CalDateTime startTime = null, CalDateTime endTime = null, EvaluationOptions options = default)
         => GetOccurrences(iCal => iCal.GetOccurrences(startTime, endTime, options));
 
-    public IEnumerable<Occurrence> GetOccurrences(DateTime? startTime, DateTime? endTime, EvaluationOptions options = default)
-        => GetOccurrences(iCal => iCal.GetOccurrences(startTime, endTime, options));
-
     public IEnumerable<Occurrence> GetOccurrences<T>(CalDateTime startTime = null, CalDateTime endTime = null, EvaluationOptions options = default) where T : IRecurringComponent
-        => GetOccurrences(iCal => iCal.GetOccurrences<T>(startTime, endTime, options));
-
-    public IEnumerable<Occurrence> GetOccurrences<T>(DateTime? startTime, DateTime? endTime, EvaluationOptions options = default) where T : IRecurringComponent
         => GetOccurrences(iCal => iCal.GetOccurrences<T>(startTime, endTime, options));
 
     private FreeBusy CombineFreeBusy(FreeBusy main, FreeBusy current)

--- a/Ical.Net/CalendarComponents/Alarm.cs
+++ b/Ical.Net/CalendarComponents/Alarm.cs
@@ -145,7 +145,7 @@ public class Alarm : CalendarComponent
     /// <param name="end"></param>
     /// <param name="options"></param>
     /// <returns>A list of <see cref="AlarmOccurrence"/> objects, each containing a triggered alarm.</returns>
-    public virtual IList<AlarmOccurrence> Poll(CalDateTime start, CalDateTime end, EvaluationOptions? options = null)
+    public virtual IList<AlarmOccurrence> Poll(CalDateTime? start, CalDateTime? end, EvaluationOptions? options = null)
     {
         var results = new List<AlarmOccurrence>();
 

--- a/Ical.Net/CalendarComponents/Alarm.cs
+++ b/Ical.Net/CalendarComponents/Alarm.cs
@@ -74,7 +74,7 @@ public class Alarm : CalendarComponent
     /// Gets a list of alarm occurrences for the given recurring component, <paramref name="rc"/>
     /// that occur between <paramref name="fromDate"/> and <paramref name="toDate"/>.
     /// </summary>
-    public virtual IList<AlarmOccurrence> GetOccurrences(IRecurringComponent rc, CalDateTime? fromDate, CalDateTime? toDate, EvaluationOptions options)
+    public virtual IList<AlarmOccurrence> GetOccurrences(IRecurringComponent rc, CalDateTime? fromDate, CalDateTime? toDate, EvaluationOptions? options)
     {
         if (Trigger == null)
         {
@@ -143,8 +143,9 @@ public class Alarm : CalendarComponent
     /// </summary>
     /// <param name="start">The earliest date/time to poll trigered alarms for.</param>
     /// <param name="end"></param>
+    /// <param name="options"></param>
     /// <returns>A list of <see cref="AlarmOccurrence"/> objects, each containing a triggered alarm.</returns>
-    public virtual IList<AlarmOccurrence> Poll(CalDateTime start, CalDateTime end, EvaluationOptions options = default)
+    public virtual IList<AlarmOccurrence> Poll(CalDateTime start, CalDateTime end, EvaluationOptions? options = null)
     {
         var results = new List<AlarmOccurrence>();
 

--- a/Ical.Net/CalendarComponents/RecurringComponent.cs
+++ b/Ical.Net/CalendarComponents/RecurringComponent.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 //
 
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -79,7 +80,7 @@ public class RecurringComponent : UniqueComponent, IRecurringComponent
         set => Properties.Set("EXDATE", value);
     }
 
-    public virtual ExceptionDates ExceptionDates { get; internal set; }
+    public virtual ExceptionDates ExceptionDates { get; internal set; } = null!;
 
     public virtual IList<RecurrencePattern> ExceptionRules
     {
@@ -105,7 +106,7 @@ public class RecurringComponent : UniqueComponent, IRecurringComponent
         set => Properties.Set("RDATE", value);
     }
 
-    public virtual RecurrenceDates RecurrenceDates { get; internal set; }
+    public virtual RecurrenceDates RecurrenceDates { get; internal set; } = null!;
 
     public virtual IList<RecurrencePattern> RecurrenceRules
     {
@@ -151,9 +152,9 @@ public class RecurringComponent : UniqueComponent, IRecurringComponent
     /// </summary>
     public virtual ICalendarObjectList<Alarm> Alarms => new CalendarObjectListProxy<Alarm>(Children);
 
-    private RecurringEvaluator _evaluator;
+    private RecurringEvaluator? _evaluator;
 
-    public virtual IEvaluator Evaluator => _evaluator;
+    public virtual IEvaluator? Evaluator => _evaluator;
 
     public RecurringComponent()
     {
@@ -169,7 +170,7 @@ public class RecurringComponent : UniqueComponent, IRecurringComponent
 
     private void Initialize()
     {
-        this._evaluator = new RecurringEvaluator(this);
+        _evaluator = new RecurringEvaluator(this);
         ExceptionDates = new ExceptionDates(ExceptionDatesPeriodLists);
         RecurrenceDates = new RecurrenceDates(RecurrenceDatesPeriodLists);
     }
@@ -189,17 +190,13 @@ public class RecurringComponent : UniqueComponent, IRecurringComponent
         Initialize();
     }
 
-    public virtual IEnumerable<Occurrence> GetOccurrences(CalDateTime startTime = null, CalDateTime endTime = null, EvaluationOptions options = default)
+    public virtual IEnumerable<Occurrence> GetOccurrences(CalDateTime? startTime = null, CalDateTime? endTime = null, EvaluationOptions? options = null)
         => RecurrenceUtil.GetOccurrences(this, startTime, endTime, options);
-
-    public virtual IEnumerable<Occurrence> GetOccurrences(DateTime? startTime, DateTime? endTime, EvaluationOptions options = default)
-        => RecurrenceUtil.GetOccurrences(this, startTime?.AsCalDateTime(), endTime?.AsCalDateTime(), options);
 
     public virtual IList<AlarmOccurrence> PollAlarms() => PollAlarms(null, null);
 
-    public virtual IList<AlarmOccurrence> PollAlarms(CalDateTime startTime, CalDateTime endTime)
-        => Alarms?.SelectMany(a => a.Poll(startTime, endTime)).ToList()
-           ?? new List<AlarmOccurrence>();
+    public virtual IList<AlarmOccurrence> PollAlarms(CalDateTime? startTime, CalDateTime? endTime)
+        => Alarms.SelectMany(a => a.Poll(startTime, endTime)).ToList();
 
     protected bool Equals(RecurringComponent other)
     {
@@ -220,7 +217,7 @@ public class RecurringComponent : UniqueComponent, IRecurringComponent
         return result;
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj)) return false;
         if (ReferenceEquals(this, obj)) return true;

--- a/Ical.Net/CalendarComponents/Todo.cs
+++ b/Ical.Net/CalendarComponents/Todo.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Runtime.Serialization;
 using Ical.Net.DataTypes;
 using Ical.Net.Evaluation;
-using Ical.Net.Utility;
 
 namespace Ical.Net.CalendarComponents;
 

--- a/Ical.Net/Evaluation/EventEvaluator.cs
+++ b/Ical.Net/Evaluation/EventEvaluator.cs
@@ -42,7 +42,7 @@ public class EventEvaluator : RecurringEvaluator
     /// <param name="periodEnd">The end date of the range to evaluate.</param>
     /// <param name="options"></param>
     /// <returns></returns>
-    public override IEnumerable<Period> Evaluate(CalDateTime referenceTime, CalDateTime? periodStart, CalDateTime? periodEnd, EvaluationOptions options)
+    public override IEnumerable<Period> Evaluate(CalDateTime referenceTime, CalDateTime? periodStart, CalDateTime? periodEnd, EvaluationOptions? options)
     {
         // Evaluate recurrences normally
         var periods = base.Evaluate(referenceTime, periodStart, periodEnd, options)

--- a/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
@@ -108,7 +108,7 @@ public class RecurrencePatternEvaluator : Evaluator
     /// the start dates returned should all be at 9:00AM, and not 12:19PM.
     /// </summary>
     private IEnumerable<CalDateTime> GetDates(CalDateTime seed, CalDateTime? periodStart, CalDateTime? periodEnd, RecurrencePattern pattern,
-         EvaluationOptions options)
+         EvaluationOptions? options)
     {
         // In the first step, we work with DateTime values, so we need to convert the CalDateTime to DateTime
         var originalDate = seed;
@@ -146,7 +146,7 @@ public class RecurrencePatternEvaluator : Evaluator
         return EnumerateDates(originalDate, seedCopy, periodStartDt, periodEndDt, pattern, options);
     }
 
-    private IEnumerable<CalDateTime> EnumerateDates(CalDateTime originalDate, CalDateTime intervalRefTime, CalDateTime? periodStart, CalDateTime? periodEnd, RecurrencePattern pattern, EvaluationOptions options)
+    private IEnumerable<CalDateTime> EnumerateDates(CalDateTime originalDate, CalDateTime intervalRefTime, CalDateTime? periodStart, CalDateTime? periodEnd, RecurrencePattern pattern, EvaluationOptions? options)
     {
         var expandBehavior = RecurrenceUtil.GetExpandBehaviorList(pattern);
 
@@ -897,7 +897,7 @@ public class RecurrencePatternEvaluator : Evaluator
     /// <param name="periodEnd">End (excl.) of the period occurrences are generated for.</param>
     /// <param name="options"></param>
     /// <returns></returns>
-    public override IEnumerable<Period> Evaluate(CalDateTime referenceDate, CalDateTime? periodStart, CalDateTime? periodEnd, EvaluationOptions options)
+    public override IEnumerable<Period> Evaluate(CalDateTime referenceDate, CalDateTime? periodStart, CalDateTime? periodEnd, EvaluationOptions? options)
     {
         if (Pattern.Frequency != FrequencyType.None && Pattern.Frequency < FrequencyType.Daily && !referenceDate.HasTime)
         {

--- a/Ical.Net/Evaluation/RecurringEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurringEvaluator.cs
@@ -28,8 +28,8 @@ public class RecurringEvaluator : Evaluator
     /// <param name="referenceDate"></param>
     /// <param name="periodStart">The beginning date of the range to evaluate.</param>
     /// <param name="periodEnd">The end date of the range to evaluate.</param>
-    /// <param name="includeReferenceDateInResults"></param>
-    protected IEnumerable<Period> EvaluateRRule(CalDateTime referenceDate, CalDateTime? periodStart, CalDateTime? periodEnd, EvaluationOptions options)
+    /// <param name="options"></param>
+    protected IEnumerable<Period> EvaluateRRule(CalDateTime referenceDate, CalDateTime? periodStart, CalDateTime? periodEnd, EvaluationOptions? options)
     {
         if (Recurrable.RecurrenceRules == null || !Recurrable.RecurrenceRules.Any())
             return [];
@@ -63,7 +63,8 @@ public class RecurringEvaluator : Evaluator
     /// <param name="referenceDate"></param>
     /// <param name="periodStart">The beginning date of the range to evaluate.</param>
     /// <param name="periodEnd">The end date of the range to evaluate.</param>
-    protected IEnumerable<Period> EvaluateExRule(CalDateTime referenceDate, CalDateTime? periodStart, CalDateTime? periodEnd, EvaluationOptions options)
+    /// <param name="options"></param>
+    protected IEnumerable<Period> EvaluateExRule(CalDateTime referenceDate, CalDateTime? periodStart, CalDateTime? periodEnd, EvaluationOptions? options)
     {
         if (Recurrable.ExceptionRules == null || !Recurrable.ExceptionRules.Any())
             return [];
@@ -94,7 +95,7 @@ public class RecurringEvaluator : Evaluator
         return exDates;
     }
 
-    public override IEnumerable<Period> Evaluate(CalDateTime referenceDate, CalDateTime? periodStart, CalDateTime? periodEnd, EvaluationOptions options)
+    public override IEnumerable<Period> Evaluate(CalDateTime referenceDate, CalDateTime? periodStart, CalDateTime? periodEnd, EvaluationOptions? options)
     {
         IEnumerable<Period> rruleOccurrences;
 

--- a/Ical.Net/Evaluation/TimeZoneInfoEvaluator.cs
+++ b/Ical.Net/Evaluation/TimeZoneInfoEvaluator.cs
@@ -21,13 +21,8 @@ public class TimeZoneInfoEvaluator : RecurringEvaluator
 
     public TimeZoneInfoEvaluator(IRecurrable tzi) : base(tzi) { }
 
-    public override IEnumerable<Period> Evaluate(CalDateTime referenceDate, CalDateTime? periodStart, CalDateTime? periodEnd, EvaluationOptions options)
+    public override IEnumerable<Period> Evaluate(CalDateTime referenceDate, CalDateTime? periodStart, CalDateTime? periodEnd, EvaluationOptions? options)
     {
-        // Time zones must include an effective start date/time
-        // and must provide an evaluator.
-        if (TimeZoneInfo == null)
-            return [];
-
         // Always include the reference date in the results
         var periods = base.Evaluate(referenceDate, periodStart, periodEnd, options);
         return periods;

--- a/Ical.Net/Evaluation/TodoEvaluator.cs
+++ b/Ical.Net/Evaluation/TodoEvaluator.cs
@@ -77,7 +77,7 @@ public class TodoEvaluator : RecurringEvaluator
         }
     }
 
-    public override IEnumerable<Period> Evaluate(CalDateTime referenceDate, CalDateTime? periodStart, CalDateTime? periodEnd, EvaluationOptions options)
+    public override IEnumerable<Period> Evaluate(CalDateTime referenceDate, CalDateTime? periodStart, CalDateTime? periodEnd, EvaluationOptions? options)
     {
         // TODO items can only recur if a start date is specified
         if (Todo.Start == null)

--- a/Ical.Net/IGetOccurrences.cs
+++ b/Ical.Net/IGetOccurrences.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT license.
 //
 
-using System;
+#nullable enable
 using System.Collections.Generic;
 using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
@@ -19,10 +19,9 @@ public interface IGetOccurrences
     /// </summary>
     /// <param name="startTime">The starting date range</param>
     /// <param name="endTime">The ending date range</param>
+    /// <param name="options"></param>
     /// <returns>An IEnumerable that calculates and returns Periods representing the occurrences of this object in ascending order.</returns>
-    IEnumerable<Occurrence> GetOccurrences(CalDateTime startTime = null, CalDateTime endTime = null, EvaluationOptions options = default);
-
-    IEnumerable<Occurrence> GetOccurrences(DateTime? startTime, DateTime? endTime, EvaluationOptions options = default);
+    IEnumerable<Occurrence> GetOccurrences(CalDateTime? startTime = null, CalDateTime? endTime = null, EvaluationOptions? options = null);
 }
 
 public interface IGetOccurrencesTyped : IGetOccurrences
@@ -34,8 +33,7 @@ public interface IGetOccurrencesTyped : IGetOccurrences
     /// </summary>
     /// <param name="startTime">The starting date range. If set to null, occurrences are returned from the beginning.</param>
     /// <param name="endTime">The ending date range. If set to null, occurrences are returned until the end.</param>
+    /// <param name="options"></param>
     /// <returns>An IEnumerable that calculates and returns Periods representing the occurrences of this object in ascending order.</returns>
-    IEnumerable<Occurrence> GetOccurrences<T>(CalDateTime startTime = null, CalDateTime endTime = null, EvaluationOptions options = default) where T : IRecurringComponent;
-
-    IEnumerable<Occurrence> GetOccurrences<T>(DateTime? startTime, DateTime? endTime, EvaluationOptions options = default) where T : IRecurringComponent;
+    IEnumerable<Occurrence> GetOccurrences<T>(CalDateTime? startTime = null, CalDateTime? endTime = null, EvaluationOptions? options = null) where T : IRecurringComponent;
 }

--- a/Ical.Net/VTimeZoneInfo.cs
+++ b/Ical.Net/VTimeZoneInfo.cs
@@ -3,19 +3,18 @@
 // Licensed under the MIT license.
 //
 
-using System;
+#nullable enable
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
 using Ical.Net.Evaluation;
-using Ical.Net.Utility;
 
 namespace Ical.Net;
 
 public class VTimeZoneInfo : CalendarComponent, IRecurrable
 {
-    private TimeZoneInfoEvaluator _evaluator;
+    private TimeZoneInfoEvaluator? _evaluator;
 
     public VTimeZoneInfo()
     {
@@ -46,7 +45,7 @@ public class VTimeZoneInfo : CalendarComponent, IRecurrable
         Initialize();
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         var tzi = obj as VTimeZoneInfo;
         if (tzi != null)
@@ -70,7 +69,7 @@ public class VTimeZoneInfo : CalendarComponent, IRecurrable
         }
     }
 
-    public virtual string TzId
+    public virtual string? TzId
     {
         get =>
             !(Parent is VTimeZone tz)
@@ -90,7 +89,7 @@ public class VTimeZoneInfo : CalendarComponent, IRecurrable
     ///     </list>
     /// </example>
     /// </summary>
-    public virtual string TimeZoneName
+    public virtual string? TimeZoneName
     {
         get => TimeZoneNames.Count > 0
             ? TimeZoneNames[0]
@@ -98,7 +97,7 @@ public class VTimeZoneInfo : CalendarComponent, IRecurrable
         set
         {
             TimeZoneNames.Clear();
-            TimeZoneNames.Add(value);
+            TimeZoneNames.Add(value ?? string.Empty);
         }
     }
 
@@ -150,7 +149,7 @@ public class VTimeZoneInfo : CalendarComponent, IRecurrable
         set => Properties.Set("EXDATE", value);
     }
 
-    public virtual ExceptionDates ExceptionDates { get; private set; }
+    public virtual ExceptionDates ExceptionDates { get; private set; } = null!;
 
     public virtual IList<RecurrencePattern> ExceptionRules
     {
@@ -164,7 +163,7 @@ public class VTimeZoneInfo : CalendarComponent, IRecurrable
         set => Properties.Set("RDATE", value);
     }
 
-    public virtual RecurrenceDates RecurrenceDates { get; private set; }
+    public virtual RecurrenceDates RecurrenceDates { get; private set; } = null!;
 
     public virtual IList<RecurrencePattern> RecurrenceRules
     {
@@ -178,11 +177,8 @@ public class VTimeZoneInfo : CalendarComponent, IRecurrable
         set => Properties.Set("RECURRENCE-ID", value);
     }
 
-    public IEvaluator Evaluator => _evaluator;
+    public IEvaluator? Evaluator => _evaluator;
 
-    public virtual IEnumerable<Occurrence> GetOccurrences(CalDateTime startTime = null, CalDateTime endTime = null, EvaluationOptions options = default)
+    public virtual IEnumerable<Occurrence> GetOccurrences(CalDateTime? startTime = null, CalDateTime? endTime = null, EvaluationOptions? options = null)
         => RecurrenceUtil.GetOccurrences(this, startTime, endTime, options);
-
-    public virtual IEnumerable<Occurrence> GetOccurrences(DateTime? startTime, DateTime? endTime, EvaluationOptions options = default)
-        => RecurrenceUtil.GetOccurrences(this, startTime?.AsCalDateTime(), endTime?.AsCalDateTime(), options);
 }


### PR DESCRIPTION
Methods left using `DateTime`:
```
Type: Ical.Net.Calendar, Method: AddTimeZone
Type: Ical.Net.Calendar, Method: AddTimeZone
Type: Ical.Net.Calendar, Method: AddLocalTimeZone
Type: Ical.Net.Utility.DateUtil, Method: AsCalDateTime
Type: Ical.Net.Utility.DateUtil, Method: ToZonedDateTimeLeniently
Type: Ical.Net.Utility.DateUtil, Method: FromTimeZoneToTimeZone
Type: Ical.Net.Utility.DateUtil, Method: FromTimeZoneToTimeZone
Type: Ical.Net.Utility.DateUtil, Method: Truncate
Type: Ical.Net.Utility.DateUtil, Method: WeekOfMonth
Type: Ical.Net.DataTypes.UtcOffset, Method: ToUtc
Type: Ical.Net.DataTypes.UtcOffset, Method: ToLocal
Type: Ical.Net.CalendarComponents.VTimeZone, Method: FromLocalTimeZone
Type: Ical.Net.CalendarComponents.VTimeZone, Method: FromSystemTimeZone
Type: Ical.Net.CalendarComponents.VTimeZone, Method: FromDateTimeZone
```

Closes #703