### PR TITLE
Enable NRT for `Collections` and `Proxies` namespace

### DIFF
--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -108,7 +108,7 @@ public class RecurrenceTests
             """;
 
         var cal = Calendar.Load(calendarIcalStr);
-        var tzid = cal.Events.Single().Start?.TzId;
+        var tzid = cal.Events.Single().Start!.TzId;
 
         var periodSerializer = new PeriodSerializer();
         var periods = expectedPeriods
@@ -2337,7 +2337,7 @@ public class RecurrenceTests
     public void Bug2912657()
     {
         var iCal = Calendar.Load(IcsFiles.Bug2912657);
-        var localTzid = iCal.Events.First().Start?.TzId;
+        var localTzid = iCal.Events.First().Start!.TzId;
 
         // Daily recurrence
         EventOccurrenceTest(
@@ -2602,7 +2602,7 @@ public class RecurrenceTests
         for (var index = 0; index < expectedPeriods.Length; index++)
         {
             var p = expectedPeriods[index];
-            var newStart = p.StartTime.ToTimeZone(start?.TzId);
+            var newStart = p.StartTime.ToTimeZone(start!.TzId);
             expectedPeriods[index] = Period.Create(newStart, end: newStart.Add(p.Duration!.Value));
         }
 

--- a/Ical.Net/CalendarComponents/Alarm.cs
+++ b/Ical.Net/CalendarComponents/Alarm.cs
@@ -17,13 +17,13 @@ namespace Ical.Net.CalendarComponents;
 /// </summary>
 public class Alarm : CalendarComponent
 {
-    public virtual string Action
+    public virtual string? Action
     {
         get => Properties.Get<string>(AlarmAction.Key);
         set => Properties.Set(AlarmAction.Key, value);
     }
 
-    public virtual Attachment Attachment
+    public virtual Attachment? Attachment
     {
         get => Properties.Get<Attachment>("ATTACH");
         set => Properties.Set("ATTACH", value);
@@ -35,13 +35,13 @@ public class Alarm : CalendarComponent
         set => Properties.Set("ATTENDEE", value);
     }
 
-    public virtual string Description
+    public virtual string? Description
     {
         get => Properties.Get<string>("DESCRIPTION");
         set => Properties.Set("DESCRIPTION", value);
     }
 
-    public virtual Duration Duration
+    public virtual Duration? Duration
     {
         get => Properties.Get<Duration>("DURATION");
         set => Properties.Set("DURATION", value);
@@ -53,7 +53,7 @@ public class Alarm : CalendarComponent
         set => Properties.Set("REPEAT", value);
     }
 
-    public virtual string Summary
+    public virtual string? Summary
     {
         get => Properties.Get<string>("SUMMARY");
         set => Properties.Set("SUMMARY", value);
@@ -182,7 +182,9 @@ public class Alarm : CalendarComponent
 
             for (var j = 0; j < Repeat; j++)
             {
-                alarmTime = alarmTime?.Add(Duration);
+                if (Duration != null)
+                    alarmTime = alarmTime?.Add(Duration.Value);
+
                 if (alarmTime != null)
                 {
                     occurrences.Add(new AlarmOccurrence(this, alarmTime.Copy(), ao.Component));

--- a/Ical.Net/CalendarComponents/CalendarEvent.cs
+++ b/Ical.Net/CalendarComponents/CalendarEvent.cs
@@ -56,7 +56,7 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
     /// </summary>
     public virtual CalDateTime? DtEnd
     {
-        get => Properties.Get<CalDateTime?>("DTEND");
+        get => Properties.Get<CalDateTime>("DTEND");
         set
         {
             if (Duration is not null) throw new InvalidOperationException("DTEND property cannot be set when DURATION property is not null.");
@@ -82,6 +82,7 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
     /// </remarks>
     public virtual Duration? Duration
     {
+        // Duration is a struct, so we need to use Nullable<Duration> to allow null values
         get => Properties.Get<Duration?>("DURATION");
         set
         {
@@ -181,7 +182,7 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
     /// </summary>
     public virtual GeographicLocation? GeographicLocation
     {
-        get => Properties.Get<GeographicLocation?>("GEO");
+        get => Properties.Get<GeographicLocation>("GEO");
         set => SetProperty("GEO", value);
     }
 
@@ -190,7 +191,7 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
     /// </summary>
     public virtual string? Location
     {
-        get => Properties.Get<string?>("LOCATION");
+        get => Properties.Get<string>("LOCATION");
         set => SetProperty("LOCATION", value);
     }
 
@@ -212,7 +213,7 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
     /// </summary>
     public virtual string? Status
     {
-        get => Properties.Get<string?>("STATUS");
+        get => Properties.Get<string>("STATUS");
         set => SetProperty("STATUS", value);
     }
 
@@ -225,7 +226,7 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
     /// </summary>
     public virtual string? Transparency
     {
-        get => Properties.Get<string?>(TransparencyType.Key);
+        get => Properties.Get<string>(TransparencyType.Key);
         set => SetProperty(TransparencyType.Key, value);
     }
 
@@ -340,20 +341,5 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer, IComparable<Ca
     }
 
     /// <inheritdoc/>
-    public int CompareTo(CalendarEvent? other)
-    {
-        if (other is null)
-        {
-            return 1;
-        }
-        if (DtStart is null)
-        {
-            return other.DtStart is null ? 0 : -1;
-        }
-        if (other.DtStart is null)
-        {
-            return 1;
-        }
-        return DtStart.CompareTo(other.DtStart);
-    }
+    public int CompareTo(CalendarEvent? other) => DtStart?.CompareTo(other?.DtStart) ?? -1;
 }

--- a/Ical.Net/CalendarComponents/FreeBusy.cs
+++ b/Ical.Net/CalendarComponents/FreeBusy.cs
@@ -130,25 +130,25 @@ public class FreeBusy : UniqueComponent, IMergeable
         set => Properties.Set("FREEBUSY", value);
     }
 
-    public virtual CalDateTime DtStart
+    public virtual CalDateTime? DtStart
     {
         get => Properties.Get<CalDateTime>("DTSTART");
         set => Properties.Set("DTSTART", value);
     }
 
-    public virtual CalDateTime DtEnd
+    public virtual CalDateTime? DtEnd
     {
         get => Properties.Get<CalDateTime>("DTEND");
         set => Properties.Set("DTEND", value);
     }
 
-    public virtual CalDateTime Start
+    public virtual CalDateTime? Start
     {
         get => Properties.Get<CalDateTime>("DTSTART");
         set => Properties.Set("DTSTART", value);
     }
 
-    public virtual CalDateTime End
+    public virtual CalDateTime? End
     {
         get => Properties.Get<CalDateTime>("DTEND");
         set => Properties.Set("DTEND", value);

--- a/Ical.Net/CalendarComponents/Journal.cs
+++ b/Ical.Net/CalendarComponents/Journal.cs
@@ -14,7 +14,7 @@ namespace Ical.Net.CalendarComponents;
 /// </summary>
 public class Journal : RecurringComponent
 {
-    public string Status
+    public string? Status
     {
         get => Properties.Get<string>(JournalStatus.Key);
         set => Properties.Set(JournalStatus.Key, value);

--- a/Ical.Net/CalendarComponents/Todo.cs
+++ b/Ical.Net/CalendarComponents/Todo.cs
@@ -91,7 +91,7 @@ public class Todo : RecurringComponent, IAlarmContainer
     /// <summary>
     /// The status of the item.
     /// </summary>
-    public virtual string Status
+    public virtual string? Status
     {
         get => Properties.Get<string>(TodoStatus.Key);
         set
@@ -171,7 +171,7 @@ public class Todo : RecurringComponent, IAlarmContainer
 
     protected override void OnDeserializing(StreamingContext context)
     {
-        //ToDo: a necessary evil, for now
+        //A necessary evil, for now
         base.OnDeserializing(context);
     }
 }

--- a/Ical.Net/CalendarComponents/VTimeZone.cs
+++ b/Ical.Net/CalendarComponents/VTimeZone.cs
@@ -287,7 +287,6 @@ public class VTimeZone : CalendarComponent
         Name = Components.Timezone;
     }
 
-
     public VTimeZone(string tzId) : this()
     {
         if (string.IsNullOrWhiteSpace(tzId))
@@ -301,7 +300,7 @@ public class VTimeZone : CalendarComponent
 
     private DateTimeZone _nodaZone = DateTimeZone.Utc; // must initialize
     private string? _tzId;
-    public virtual string TzId
+    public virtual string? TzId
     {
         get
         {
@@ -322,6 +321,7 @@ public class VTimeZone : CalendarComponent
             {
                 _tzId = null;
                 Properties.Remove("TZID");
+                return;
             }
 
             _nodaZone = DateUtil.GetZone(value);
@@ -384,7 +384,7 @@ public class VTimeZone : CalendarComponent
         unchecked
         {
             var hashCode = Name?.GetHashCode() ?? 0;
-            hashCode = (hashCode * 397) ^ (TzId.GetHashCode());
+            hashCode = (hashCode * 397) ^ (TzId?.GetHashCode() ?? 0);
             hashCode = (hashCode * 397) ^ (Url?.GetHashCode() ?? 0);
             return hashCode;
         }

--- a/Ical.Net/CalendarParameter.cs
+++ b/Ical.Net/CalendarParameter.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 //
 
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -15,7 +16,7 @@ namespace Ical.Net;
 [DebuggerDisplay("{Name}={string.Join(\",\", Values)}")]
 public class CalendarParameter : CalendarObject, IValueObject<string>
 {
-    private HashSet<string> _values;
+    private HashSet<string> _values = new();
 
     public CalendarParameter()
     {
@@ -27,7 +28,7 @@ public class CalendarParameter : CalendarObject, IValueObject<string>
         Initialize();
     }
 
-    public CalendarParameter(string name, string value) : base(name)
+    public CalendarParameter(string name, string? value) : base(name)
     {
         Initialize();
         AddValue(value);
@@ -72,7 +73,7 @@ public class CalendarParameter : CalendarObject, IValueObject<string>
 
     public virtual bool ContainsValue(string value) => _values.Contains(value);
 
-    public virtual int ValueCount => _values?.Count ?? 0;
+    public virtual int ValueCount => _values.Count;
 
     public virtual void SetValue(string value)
     {
@@ -87,25 +88,29 @@ public class CalendarParameter : CalendarObject, IValueObject<string>
         _values.UnionWith(values.Where(IsValidValue));
     }
 
-    private bool IsValidValue(string value) => !string.IsNullOrWhiteSpace(value);
+    private static bool IsValidValue(string? value) => !string.IsNullOrWhiteSpace(value);
 
-    public virtual void AddValue(string value)
+    public virtual void AddValue(string? value)
     {
         if (!IsValidValue(value))
         {
             return;
         }
-        _values.Add(value);
+        _values.Add(value!);
     }
 
-    public virtual void RemoveValue(string value)
-    {
-        _values.Remove(value);
-    }
+    public virtual void RemoveValue(string value) => _values.Remove(value);
 
-    public virtual string Value
+    public virtual string? Value
     {
-        get => Values?.FirstOrDefault();
-        set => SetValue(value);
+        get => Values.FirstOrDefault();
+        set
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value), "Value cannot be null.");
+            }
+            SetValue(value);
+        }
     }
 }

--- a/Ical.Net/CalendarProperty.cs
+++ b/Ical.Net/CalendarProperty.cs
@@ -62,9 +62,7 @@ public class CalendarProperty : CalendarObject, ICalendarProperty
     /// Adds a parameter to the iCalendar object.
     /// </summary>
     public virtual void AddParameter(CalendarParameter p)
-    {
-        Parameters.Add(p);
-    }
+        => Parameters.Add(p);
 
     /// <inheritdoc/>
     public override void CopyFrom(ICopyable obj)

--- a/Ical.Net/Collections/GroupedList.cs
+++ b/Ical.Net/Collections/GroupedList.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 //
 
+#nullable enable
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -15,93 +16,84 @@ namespace Ical.Net.Collections;
 /// </summary>
 public class GroupedList<TGroup, TItem> :
     IGroupedList<TGroup, TItem>
+    where TGroup : notnull
     where TItem : class, IGroupedObject<TGroup>
 {
-    private readonly List<IMultiLinkedList<TItem>> _lists = new List<IMultiLinkedList<TItem>>();
-    private readonly Dictionary<TGroup, IMultiLinkedList<TItem>> _dictionary = new Dictionary<TGroup, IMultiLinkedList<TItem>>();
+    private readonly List<IMultiLinkedList<TItem>> _lists = new();
+    private readonly Dictionary<TGroup, IMultiLinkedList<TItem>> _dictionary = new();
 
-    private IMultiLinkedList<TItem> EnsureList(TGroup group)
+    private IMultiLinkedList<TItem>? EnsureList(TGroup group)
     {
-        if (group == null)
+        if (_dictionary.TryGetValue(group, out var existingList))
         {
-            return null;
-        }
-
-        if (_dictionary.ContainsKey(group))
-        {
-            return _dictionary[group];
+            return existingList;
         }
 
         var list = new MultiLinkedList<TItem>();
         _dictionary[group] = list;
-
         _lists.Add(list);
         return list;
     }
 
-    private IMultiLinkedList<TItem> ListForIndex(int index, out int relativeIndex)
+    private IMultiLinkedList<TItem>? ListForIndex(int index, out int relativeIndex)
     {
         var list = _lists.FirstOrDefault(l => l.StartIndex <= index && l.ExclusiveEnd > index);
         if (list != null)
         {
             relativeIndex = index - list.StartIndex;
-            return list;
+            return list!;
         }
+
         relativeIndex = -1;
         return null;
     }
 
-    public event EventHandler<ObjectEventArgs<TItem, int>> ItemAdded;
+    public event EventHandler<ObjectEventArgs<TItem, int>>? ItemAdded;
 
     protected void OnItemAdded(TItem obj, int index)
-    {
-        ItemAdded?.Invoke(this, new ObjectEventArgs<TItem, int>(obj, index));
-    }
+        => ItemAdded?.Invoke(this, new ObjectEventArgs<TItem, int>(obj, index));
 
-    public virtual void Add(TItem item)
+    public virtual void Add(TItem? item)
     {
         if (item == null)
         {
             return;
         }
 
-        // Add a new list if necessary
         var group = item.Group;
         var list = EnsureList(group);
+        if (list == null)
+        {
+            return;
+        }
+
         var index = list.Count;
         list.Add(item);
         OnItemAdded(item, list.StartIndex + index);
     }
 
-    public virtual int IndexOf(TItem item)
+    public virtual int IndexOf(TItem? obj)
     {
-        var group = item.Group;
-        if (!_dictionary.ContainsKey(group))
+        if (obj == null)
+        {
+            return -1;
+        }
+        var group = obj.Group;
+        if (!_dictionary.TryGetValue(group, out var list))
         {
             return -1;
         }
 
-        // Get the list associated with this object's group
-        var list = _dictionary[group];
-
-        // Find the object within the list.
-        var index = list.IndexOf(item);
-
-        // Return the index within the overall KeyedList
-        if (index >= 0)
-            return list.StartIndex + index;
-        return -1;
+        var index = list.IndexOf(obj);
+        return index >= 0 ? list.StartIndex + index : -1;
     }
 
     public virtual void Clear(TGroup group)
     {
-        if (!_dictionary.ContainsKey(group))
+        if (_dictionary.TryGetValue(group, out var list))
         {
-            return;
+            list.Clear();
         }
-
-        // Clear the list (note that this also clears the list in the _Lists object).
-        _dictionary[group].Clear();
     }
 
     public virtual void Clear()
@@ -110,73 +102,77 @@ public class GroupedList<TGroup, TItem> :
         _lists.Clear();
     }
 
-    public virtual bool ContainsKey(TGroup group) => _dictionary.ContainsKey(@group);
+    public virtual bool ContainsKey(TGroup group) => _dictionary.ContainsKey(group);
 
     public virtual int Count => _lists.Sum(list => list.Count);
 
-    public virtual int CountOf(TGroup group) => _dictionary.ContainsKey(group)
-        ? _dictionary[group].Count
-        : 0;
+    public virtual int CountOf(TGroup group) =>
+        _dictionary.TryGetValue(group, out var list) ? list.Count : 0;
 
     public virtual IEnumerable<TItem> Values() => _dictionary.Values.SelectMany(i => i);
 
-    public virtual IEnumerable<TItem> AllOf(TGroup group) => _dictionary.ContainsKey(@group)
-        ? (IEnumerable<TItem>) _dictionary[@group]
-        : new TItem[0];
+    public virtual IEnumerable<TItem> AllOf(TGroup group) =>
+        _dictionary.TryGetValue(group, out var list) ? list : Array.Empty<TItem>();
 
-    public virtual bool Remove(TItem obj)
+    public virtual bool Remove(TItem? item)
     {
-        var group = obj.Group;
-        if (!_dictionary.ContainsKey(group))
+        if (item == null)
         {
             return false;
         }
 
-        var items = _dictionary[group];
-        var index = items.IndexOf(obj);
+        var group = item.Group;
 
+        if (!_dictionary.TryGetValue(group, out var list))
+        {
+            return false;
+        }
+
+        var index = list.IndexOf(item);
         if (index < 0)
         {
             return false;
         }
 
-        items.RemoveAt(index);
+        list.RemoveAt(index);
         return true;
     }
 
     public virtual bool Remove(TGroup group)
     {
-        if (!_dictionary.ContainsKey(group))
+        if (!_dictionary.TryGetValue(group, out var list))
         {
             return false;
         }
 
-        var list = _dictionary[group];
         for (var i = list.Count - 1; i >= 0; i--)
         {
             list.RemoveAt(i);
         }
+
         return true;
     }
 
-    public virtual bool Contains(TItem item)
+    public virtual bool Contains(TItem? item)
     {
+        if (item == null)
+        {
+            return false;
+        }
+
         var group = item.Group;
-        return _dictionary.ContainsKey(group) && _dictionary[group].Contains(item);
+        return _dictionary.TryGetValue(group, out var list) && list.Contains(item);
     }
 
-    public virtual void CopyTo(TItem[] array, int arrayIndex)
-    {
-        _dictionary.SelectMany(kvp => kvp.Value).ToArray().CopyTo(array, arrayIndex);
-    }
+    public virtual void CopyTo(TItem?[] array, int arrayIndex)
+        => _dictionary.SelectMany(kvp => kvp.Value).ToArray().CopyTo(array, arrayIndex);
 
     public virtual bool IsReadOnly => false;
 
-    public virtual void Insert(int index, TItem item)
+    public virtual void Insert(int index, TItem? item)
     {
-        int relativeIndex;
-        var list = ListForIndex(index, out relativeIndex);
-        if (list == null)
+        var list = ListForIndex(index, out var relativeIndex);
+        if (list == null || item == null)
         {
             return;
         }
@@ -187,42 +183,51 @@ public class GroupedList<TGroup, TItem> :
 
     public virtual void RemoveAt(int index)
     {
-        int relativeIndex;
-        var list = ListForIndex(index, out relativeIndex);
+        var list = ListForIndex(index, out var relativeIndex);
         if (list == null)
         {
             return;
         }
-        var item = list[relativeIndex];
+
         list.RemoveAt(relativeIndex);
     }
 
-    public virtual TItem this[int index]
+    /// <summary>
+    /// The indexer for the IList interface. This is the virtual, primary implementation of the indexer.
+    /// </summary>
+    /// <param name="index"></param>
+    /// <returns>
+    /// Returns the item at the specified index, or null if the index is invalid.
+    /// </returns>
+    public virtual TItem? this[int index]
     {
         get
         {
-            int relativeIndex;
-            var list = ListForIndex(index, out relativeIndex);
+            var list = ListForIndex(index, out var relativeIndex);
             return list?[relativeIndex];
         }
         set
         {
-            int relativeIndex;
-            var list = ListForIndex(index, out relativeIndex);
-            if (list == null)
-            {
-                return;
-            }
-
-            // Remove the item at that index and replace it
-            var item = list[relativeIndex];
-            list.RemoveAt(relativeIndex);
-            list.Insert(relativeIndex, value);
-            OnItemAdded(item, index);
+            var list = ListForIndex(index, out var relativeIndex);
+            if (list == null || value == null) return;
+            list[relativeIndex] = value;
+            OnItemAdded(value, index);
         }
+    }
+
+    /// <summary>
+    /// This is an explicit non-nullable implementation of the indexer for the IList interface.
+    /// </summary>
+    /// <param name="index"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    TItem IList<TItem>.this[int index]
+    {
+        get => this[index] ?? throw new ArgumentOutOfRangeException(nameof(index));
+        set => this[index] = value;
     }
 
     public IEnumerator<TItem> GetEnumerator() => new GroupedListEnumerator<TItem>(_lists);
 
-    IEnumerator IEnumerable.GetEnumerator() => new GroupedListEnumerator<TItem>(_lists);
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/Ical.Net/Collections/GroupedListEnumerator.cs
+++ b/Ical.Net/Collections/GroupedListEnumerator.cs
@@ -3,23 +3,25 @@
 // Licensed under the MIT license.
 //
 
+#nullable enable
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
 namespace Ical.Net.Collections;
 
 public class GroupedListEnumerator<TType> :
-    IEnumerator<TType>
+   IEnumerator<TType> where TType : class
 {
-    private readonly IList<IMultiLinkedList<TType>> _lists;
-    private IEnumerator<IMultiLinkedList<TType>> _listsEnumerator;
-    private IEnumerator<TType> _listEnumerator;
+    private readonly IList<IMultiLinkedList<TType>>? _lists;
+    private IEnumerator<IMultiLinkedList<TType>>? _listsEnumerator;
+    private IEnumerator<TType>? _listEnumerator;
 
     public GroupedListEnumerator(IList<IMultiLinkedList<TType>> lists) => _lists = lists;
 
     public virtual TType Current
-        => _listEnumerator == null
-            ? default(TType)
+        => _listEnumerator == null || _listEnumerator.Current == null
+            ? throw new InvalidOperationException("Current is null.")
             : _listEnumerator.Current;
 
     public virtual void Dispose()
@@ -38,15 +40,15 @@ public class GroupedListEnumerator<TType> :
     }
 
     object IEnumerator.Current
-        => _listEnumerator == null
-            ? default(TType)
+        => _listEnumerator == null || _listEnumerator.Current == null
+            ? throw new InvalidOperationException("Current is null.")
             : _listEnumerator.Current;
 
     private bool MoveNextList()
     {
         if (_listsEnumerator == null)
         {
-            _listsEnumerator = _lists.GetEnumerator();
+            _listsEnumerator = _lists?.GetEnumerator();
         }
 
         if (_listsEnumerator == null)
@@ -60,10 +62,6 @@ public class GroupedListEnumerator<TType> :
         }
 
         DisposeListEnumerator();
-        if (_listsEnumerator.Current == null)
-        {
-            return false;
-        }
 
         _listEnumerator = _listsEnumerator.Current.GetEnumerator();
         return true;

--- a/Ical.Net/Collections/GroupedValueList.cs
+++ b/Ical.Net/Collections/GroupedValueList.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 //
 
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,6 +14,7 @@ namespace Ical.Net.Collections;
 
 public class GroupedValueList<TGroup, TInterface, TItem, TValueType> :
     GroupedList<TGroup, TInterface>
+    where TGroup : notnull
     where TInterface : class, IGroupedObject<TGroup>, IValueObject<TValueType>
     where TItem : new()
 {
@@ -38,7 +40,7 @@ public class GroupedValueList<TGroup, TInterface, TItem, TValueType> :
         }
     }
 
-    public virtual TType Get<TType>(TGroup group)
+    public virtual TType? Get<TType>(TGroup group)
     {
         var firstItem = AllOf(group).FirstOrDefault();
         if (firstItem?.Values != null)
@@ -51,5 +53,5 @@ public class GroupedValueList<TGroup, TInterface, TItem, TValueType> :
         return default(TType);
     }
 
-    public virtual IList<TType> GetMany<TType>(TGroup group) => new GroupedValueListProxy<TGroup, TInterface, TItem, TValueType, TType>(this, group);
+    public virtual IList<TType> GetMany<TType>(TGroup group) where TType : class => new GroupedValueListProxy<TGroup, TInterface, TItem, TValueType, TType>(this, group);
 }

--- a/Ical.Net/Collections/IGroupedCollection.cs
+++ b/Ical.Net/Collections/IGroupedCollection.cs
@@ -3,12 +3,13 @@
 // Licensed under the MIT license.
 //
 
+#nullable enable
 using System;
 using System.Collections.Generic;
 
 namespace Ical.Net.Collections;
 
-public interface IGroupedCollection<TGroup, TItem> :
+public interface IGroupedCollection<in TGroup, TItem> :
     ICollection<TItem>
     where TItem : class, IGroupedObject<TGroup>
 {

--- a/Ical.Net/Collections/IGroupedList.cs
+++ b/Ical.Net/Collections/IGroupedList.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 //
 
+#nullable enable
 using System.Collections.Generic;
 
 namespace Ical.Net.Collections;
@@ -10,6 +11,7 @@ namespace Ical.Net.Collections;
 public interface IGroupedList<TGroup, TItem> :
     IGroupedCollection<TGroup, TItem>,
     IList<TItem>
+    where TGroup : notnull
     where TItem : class, IGroupedObject<TGroup>
 {
     /// <summary>
@@ -22,5 +24,5 @@ public interface IGroupedList<TGroup, TItem> :
     /// <summary>
     /// Gets the object at the specified index.
     /// </summary>
-    new TItem this[int index] { get; }
+    new TItem? this[int index] { get; }
 }

--- a/Ical.Net/Collections/IGroupedObject.cs
+++ b/Ical.Net/Collections/IGroupedObject.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 //
 
+#nullable enable
 namespace Ical.Net.Collections;
 
 public interface IGroupedObject<TGroup>

--- a/Ical.Net/Collections/IMultiLinkedList.cs
+++ b/Ical.Net/Collections/IMultiLinkedList.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 //
 
+#nullable enable
 using System.Collections.Generic;
 
 namespace Ical.Net.Collections;

--- a/Ical.Net/Collections/Interfaces/IValueObject.cs
+++ b/Ical.Net/Collections/Interfaces/IValueObject.cs
@@ -3,13 +3,14 @@
 // Licensed under the MIT license.
 //
 
+#nullable enable
 using System.Collections.Generic;
 
 namespace Ical.Net.Collections.Interfaces;
 
 public interface IValueObject<T>
 {
-    IEnumerable<T> Values { get; }
+    IEnumerable<T>? Values { get; }
 
     bool ContainsValue(T value);
     void SetValue(T value);

--- a/Ical.Net/Collections/MultiLinkedList.cs
+++ b/Ical.Net/Collections/MultiLinkedList.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 //
 
+#nullable enable
 using System.Collections.Generic;
 
 namespace Ical.Net.Collections;
@@ -11,18 +12,9 @@ public class MultiLinkedList<TType> :
     List<TType>,
     IMultiLinkedList<TType>
 {
-    private IMultiLinkedList<TType> _previous;
-    private IMultiLinkedList<TType> _next;
+    private IMultiLinkedList<TType>? _previous;
 
-    public virtual void SetPrevious(IMultiLinkedList<TType> previous)
-    {
-        _previous = previous;
-    }
-
-    public virtual void SetNext(IMultiLinkedList<TType> next)
-    {
-        _next = next;
-    }
+    public virtual void SetPrevious(IMultiLinkedList<TType> previous) => _previous = previous;
 
     public virtual int StartIndex => _previous?.ExclusiveEnd ?? 0;
 

--- a/Ical.Net/Collections/ObjectEventArgs.cs
+++ b/Ical.Net/Collections/ObjectEventArgs.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 //
 
+#nullable enable
 using System;
 
 namespace Ical.Net.Collections;

--- a/Ical.Net/Collections/Proxies/GroupedCollectionProxy.cs
+++ b/Ical.Net/Collections/Proxies/GroupedCollectionProxy.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 //
 
+#nullable enable
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -20,31 +21,24 @@ public class GroupedCollectionProxy<TGroup, TOriginal, TNew> :
 {
     private readonly Func<TNew, bool> _predicate;
 
-    public GroupedCollectionProxy(IGroupedCollection<TGroup, TOriginal> realObject, Func<TNew, bool> predicate = null)
+    public GroupedCollectionProxy(IGroupedCollection<TGroup, TOriginal> realObject, Func<TNew, bool>? predicate = null)
     {
         _predicate = predicate ?? (o => true);
-        SetProxiedObject(realObject);
+        RealObject = realObject;
     }
 
-    public virtual event EventHandler<ObjectEventArgs<TNew, int>> ItemAdded;
-    public virtual event EventHandler<ObjectEventArgs<TNew, int>> ItemRemoved;
+    public event EventHandler<ObjectEventArgs<TNew, int>>? ItemAdded;
+    public event EventHandler<ObjectEventArgs<TNew, int>>? ItemRemoved;
 
     protected void OnItemAdded(TNew item, int index)
-    {
-        ItemAdded?.Invoke(this, new ObjectEventArgs<TNew, int>(item, index));
-    }
+        => ItemAdded?.Invoke(this, new ObjectEventArgs<TNew, int>(item, index));
 
     protected void OnItemRemoved(TNew item, int index)
-    {
-        ItemRemoved?.Invoke(this, new ObjectEventArgs<TNew, int>(item, index));
-    }
+        => ItemRemoved?.Invoke(this, new ObjectEventArgs<TNew, int>(item, index));
 
     public virtual bool Remove(TGroup group) => RealObject.Remove(group);
 
-    public virtual void Clear(TGroup group)
-    {
-        RealObject.Clear(group);
-    }
+    public virtual void Clear(TGroup group) => RealObject.Clear(group);
 
     public virtual bool ContainsKey(TGroup group) => RealObject.ContainsKey(group);
 
@@ -55,10 +49,7 @@ public class GroupedCollectionProxy<TGroup, TOriginal, TNew> :
         .OfType<TNew>()
         .Where(_predicate);
 
-    public virtual void Add(TNew item)
-    {
-        RealObject.Add(item);
-    }
+    public virtual void Add(TNew item) => RealObject.Add(item);
 
     public virtual void Clear()
     {
@@ -105,7 +96,5 @@ public class GroupedCollectionProxy<TGroup, TOriginal, TNew> :
     public IGroupedCollection<TGroup, TOriginal> RealObject { get; private set; }
 
     public virtual void SetProxiedObject(IGroupedCollection<TGroup, TOriginal> realObject)
-    {
-        RealObject = realObject;
-    }
+        => RealObject = realObject;
 }

--- a/Ical.Net/DataTypes/CalendarDataType.cs
+++ b/Ical.Net/DataTypes/CalendarDataType.cs
@@ -94,10 +94,8 @@ public abstract class CalendarDataType : ICalendarDataType
         return null;
     }
 
-    public virtual void SetValueType(string? type)
-    {
-        _proxy.Set("VALUE", type?.ToUpper());
-    }
+    public virtual void SetValueType(string type) =>
+        _proxy.Set("VALUE", type.ToUpper());
 
     public virtual ICalendarObject? AssociatedObject
     {

--- a/Ical.Net/Evaluation/TodoEvaluator.cs
+++ b/Ical.Net/Evaluation/TodoEvaluator.cs
@@ -20,6 +20,10 @@ public class TodoEvaluator : RecurringEvaluator
 
     internal IEnumerable<Period> EvaluateToPreviousOccurrence(CalDateTime completedDate, CalDateTime currDt, EvaluationOptions? options)
     {
+        // Cannot evaluate a todos that have no start date
+        if (Todo.Start == null)
+            return [];
+
         var beginningDate = completedDate.Copy();
 
         foreach (var rrule in Todo.RecurrenceRules)
@@ -69,7 +73,8 @@ public class TodoEvaluator : RecurringEvaluator
 
         if (recur.Count.HasValue)
         {
-            referenceDateTime = Todo.Start.Copy();
+            // Caller ensures that Start is not null
+            referenceDateTime = Todo.Start!.Copy();
         }
         else
         {

--- a/Ical.Net/Proxies/CalendarObjectListProxy.cs
+++ b/Ical.Net/Proxies/CalendarObjectListProxy.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license.
 //
 
+#nullable enable
+using System;
 using System.Linq;
 using Ical.Net.Collections;
 using Ical.Net.Collections.Proxies;
@@ -14,5 +16,20 @@ public class CalendarObjectListProxy<TType> : GroupedCollectionProxy<string, ICa
 {
     public CalendarObjectListProxy(IGroupedCollection<string, ICalendarObject> list) : base(list) { }
 
-    public virtual TType this[int index] => this.Skip(index).FirstOrDefault();
+    /// <summary>
+    /// The indexer for the <see cref="ICalendarObjectList{T}"/> interface. This is the virtual, primary implementation of the indexer.
+    /// </summary>
+    /// <param name="index"></param>
+    /// <returns>
+    /// Returns the item at the specified index, or null if the index is invalid.
+    /// </returns>
+    public virtual TType? this[int index] => this.Skip(index).FirstOrDefault();
+
+    /// <summary>
+    /// This is an explicit non-nullable implementation of the indexer for the <see cref="ICalendarObjectList{T}"/> interface.
+    /// </summary>
+    /// <param name="index"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    TType ICalendarObjectList<TType>.this[int index] => this[index] ?? throw new ArgumentOutOfRangeException(nameof(index));
 }

--- a/Ical.Net/Proxies/IUniqueComponentList.cs
+++ b/Ical.Net/Proxies/IUniqueComponentList.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 //
 
+#nullable enable
 using System.Collections.Generic;
 using Ical.Net.CalendarComponents;
 

--- a/Ical.Net/Proxies/ParameterCollectionProxy.cs
+++ b/Ical.Net/Proxies/ParameterCollectionProxy.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 //
 
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,11 +15,11 @@ namespace Ical.Net.Proxies;
 public class ParameterCollectionProxy : GroupedCollectionProxy<string, CalendarParameter, CalendarParameter>, IParameterCollection
 {
     protected GroupedValueList<string, CalendarParameter, CalendarParameter, string> Parameters
-        => RealObject as GroupedValueList<string, CalendarParameter, CalendarParameter, string>;
+        => (GroupedValueList<string, CalendarParameter, CalendarParameter, string>) RealObject;
 
     public ParameterCollectionProxy(IGroupedList<string, CalendarParameter> realObject) : base(realObject) { }
 
-    public virtual void SetParent(ICalendarObject parent)
+    public virtual void SetParent(ICalendarObject? parent)
     {
         foreach (var parameter in this)
         {
@@ -27,11 +28,9 @@ public class ParameterCollectionProxy : GroupedCollectionProxy<string, CalendarP
     }
 
     public virtual void Add(string name, string value)
-    {
-        RealObject.Add(new CalendarParameter(name, value));
-    }
+        => RealObject.Add(new CalendarParameter(name, value));
 
-    public virtual string Get(string name)
+    public virtual string? Get(string name)
     {
         var parameter = RealObject.FirstOrDefault(o => string.Equals(o.Name, name, StringComparison.Ordinal));
 
@@ -74,9 +73,29 @@ public class ParameterCollectionProxy : GroupedCollectionProxy<string, CalendarP
 
     public virtual void RemoveAt(int index) { }
 
-    public virtual CalendarParameter this[int index]
+    /// <summary>
+    /// The indexer for the IList interface. This is the virtual, primary implementation of the indexer.
+    /// </summary>
+    /// <param name="index"></param>
+    /// <returns>
+    /// Returns the item at the specified index, or null if the index is invalid.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">For a <see langword="null"/> value.</exception>
+    public virtual CalendarParameter? this[int index]
     {
-        get { return Parameters[index]; }
-        set { }
+        get => Parameters[index];
+        set => Parameters[index] = (value ?? throw new ArgumentNullException(nameof(value)));
+    }
+
+    /// <summary>
+    /// This is an explicit non-nullable implementation of the indexer for the IList interface.
+    /// </summary>
+    /// <param name="index"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    CalendarParameter IList<CalendarParameter>.this[int index]
+    {
+        get => this[index] ?? throw new ArgumentOutOfRangeException(nameof(index));
+        set => this[index] = value;
     }
 }

--- a/Ical.Net/Proxies/UniqueComponentListProxy.cs
+++ b/Ical.Net/Proxies/UniqueComponentListProxy.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 //
 
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -23,7 +24,7 @@ public class UniqueComponentListProxy<TComponentType> :
         _lookup = new Dictionary<string, TComponentType>();
     }
 
-    private TComponentType Search(string uid)
+    private TComponentType? Search(string uid)
     {
         if (_lookup.TryGetValue(uid, out var componentType))
         {
@@ -34,14 +35,21 @@ public class UniqueComponentListProxy<TComponentType> :
 
         if (item == null)
         {
-            return default(TComponentType);
+            return null;
         }
 
         _lookup[uid] = item;
         return item;
     }
 
-    public virtual TComponentType this[string uid]
+    /// <summary>
+    /// The indexer for the <see cref="IUniqueComponentList{T}"/> interface. This is the virtual, primary implementation of the indexer.
+    /// </summary>
+    /// <param name="uid"></param>
+    /// <returns>
+    /// Returns the item at the specified index, or null if the index is invalid.
+    /// </returns>
+    public virtual TComponentType? this[string uid]
     {
         get => Search(uid);
         set
@@ -58,6 +66,28 @@ public class UniqueComponentListProxy<TComponentType> :
             {
                 Add(value);
             }
+        }
+    }
+
+    /// <summary>
+    /// This is an explicit non-nullable implementation of the indexer for the <see cref="IUniqueComponentList{T}"/> interface.
+    /// </summary>
+    /// <param name="uid"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    TComponentType IUniqueComponentList<TComponentType>.this[string uid]
+    {
+        get => Search(uid) ?? throw new ArgumentOutOfRangeException(nameof(uid), "The specified UID does not exist.");
+        set
+        {
+            var item = Search(uid);
+
+            if (item != null)
+            {
+                Remove(item);
+            }
+
+            Add(value);
         }
     }
 

--- a/Ical.Net/VTimeZoneInfo.cs
+++ b/Ical.Net/VTimeZoneInfo.cs
@@ -47,7 +47,8 @@ public class VTimeZoneInfo : CalendarComponent, IRecurrable
 
     public override bool Equals(object? obj)
     {
-        if (obj is VTimeZoneInfo tzi)
+        var tzi = obj as VTimeZoneInfo;
+        if (tzi != null)
         {
             return Equals(TimeZoneName, tzi.TimeZoneName) &&
                    Equals(OffsetFrom, tzi.OffsetFrom) &&
@@ -99,7 +100,7 @@ public class VTimeZoneInfo : CalendarComponent, IRecurrable
             TimeZoneNames.Add(value ?? string.Empty);
         }
     }
-    
+
     public virtual UtcOffset? OffsetFrom
     {
         get => Properties.Get<UtcOffset>("TZOFFSETFROM");
@@ -111,7 +112,7 @@ public class VTimeZoneInfo : CalendarComponent, IRecurrable
         get => Properties.Get<UtcOffset>("TZOFFSETTO");
         set => Properties.Set("TZOFFSETTO", value);
     }
-    
+
     public virtual IList<string> TimeZoneNames
     {
         get => Properties.GetMany<string>("TZNAME");


### PR DESCRIPTION
Including necessary NRT updates to
* CalendarComponents
   * Alarm
   * CalendardEvent
   * FreeBusy
   * Journal
   * Todo
   * VTimeZone
   * Interfaces.IValueObject
   * Proxies.GroupedCollectionProxy
   * Proxies.GroupedValueListProxy
* DataTypes.CalendarDataType
* Evaluation.TodoEvaluator
* Proxies
   * CalendarObjectListProxy
   * IUniqueComponentList
   * UniqueComponentListProxy
   * ParameterCollectionProxy
* CalendarParameter
* CalendarProperty
* VTimeZoneInfo
* some unit tests

The transition to NRT in this pull request required significant effort, particularly due to challenges with the `Collections` namespace and the handling of `Proxies`. These areas demanded careful adjustments to ensure compatibility, also given the low unit test coverage.

@minichma Due to vacation I'll merge the PR, so that I can move on with NRT over the next days. Reviews and necessary corrections could then be done after the NRT transition is completed. 