### PR TITLE
NRT clean-up after all NRT pull requests got merged

### DIFF
--- a/Ical.Net.Tests/EncodingProviderTests.cs
+++ b/Ical.Net.Tests/EncodingProviderTests.cs
@@ -5,6 +5,7 @@
 
 #nullable enable
 using System;
+using System.Runtime.Serialization;
 using Ical.Net.Serialization;
 using NUnit.Framework;
 using EncodingProvider = Ical.Net.Serialization.EncodingProvider;
@@ -33,7 +34,7 @@ public class EncodingProviderTests
         const string encoding = "Invalid-Encoding";
         var data = "Hello"u8.ToArray();
 
-        Assert.That(GetEncodingProvider().Encode(encoding, data), Is.Null);
+        Assert.That(() => GetEncodingProvider().Encode(encoding, data), Throws.TypeOf<SerializationException>());
     }
 
     [Test]
@@ -53,7 +54,7 @@ public class EncodingProviderTests
         const string encoding = "Invalid-Encoding";
         const string data = "Hello";
 
-        Assert.That(GetEncodingProvider().DecodeString(encoding, data), Is.Null);
+        Assert.That(() => GetEncodingProvider().DecodeString(encoding, data), Throws.TypeOf<SerializationException>());
     }
 
     [Test]

--- a/Ical.Net.Tests/PeriodListWrapperTests.cs
+++ b/Ical.Net.Tests/PeriodListWrapperTests.cs
@@ -185,7 +185,7 @@ public class PeriodListWrapperTests
         ]);
 
         var serializer = new CalendarSerializer(cal);
-        var serialized = serializer.SerializeToString();
+        var serialized = serializer.SerializeToString()!;
         // Assign the deserialized event
         cal = Calendar.Load(serialized)!;
         evt = cal.Events[0];

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -3940,7 +3940,7 @@ END:VCALENDAR";
     [TestCase(1, TestMaxIncrementCountWithoutGaps, false)]
     public void TestMaxIncrementCount(int? limit, string ical, bool expectException)
     {
-        var cal = Calendar.Load(ical);
+        var cal = Calendar.Load(ical)!;
 
         var options = new EvaluationOptions
         {

--- a/Ical.Net.Tests/RecurrenceWithExDateTests.cs
+++ b/Ical.Net.Tests/RecurrenceWithExDateTests.cs
@@ -102,7 +102,7 @@ public class RecurrenceWithExDateTests
         var serializer = new CalendarSerializer();
         ics = serializer.SerializeToString(cal);
         // serialize and deserialize to ensure the exclusion dates de/serialized
-        cal = Calendar.Load(new CalendarSerializer(cal).SerializeToString())!;
+        cal = Calendar.Load(new CalendarSerializer(cal).SerializeToString()!)!;
 
         // Start date: 2024-10-19 at 18:00 (GMT Standard Time)
         // Recurrence: Every hour, 4 occurrences
@@ -150,7 +150,7 @@ public class RecurrenceWithExDateTests
         var serializer = new CalendarSerializer();
         ics = serializer.SerializeToString(cal);
         // serialize and deserialize to ensure the exclusion dates de/serialized
-        cal = Calendar.Load(new CalendarSerializer(cal).SerializeToString())!;
+        cal = Calendar.Load(new CalendarSerializer(cal).SerializeToString()!)!;
 
         // Occurrences:
         // 2023-10-25 09:00 (UTC Offset: +0200)

--- a/Ical.Net.Tests/RecurrenceWithExDateTests.cs
+++ b/Ical.Net.Tests/RecurrenceWithExDateTests.cs
@@ -55,7 +55,7 @@ public class RecurrenceWithExDateTests
 
         // Act
         var serializer = new CalendarSerializer();
-        var ics = serializer.SerializeToString(calendar);
+        var ics = serializer.SerializeToString(calendar)!;
 
         var deserializedCalendar = Calendar.Load(ics)!;
         var occurrences = deserializedCalendar.GetOccurrences<CalendarEvent>().ToList();
@@ -206,7 +206,7 @@ public class RecurrenceWithExDateTests
 
         var cal = Calendar.Load(ics)!;
         // serialize and deserialize to ensure the exclusion dates de/serialized
-        cal = Calendar.Load(new CalendarSerializer(cal).SerializeToString())!;
+        cal = Calendar.Load(new CalendarSerializer(cal).SerializeToString()!)!;
         var occurrences = cal.GetOccurrences<CalendarEvent>().ToList();
 
         // Occurrences:

--- a/Ical.Net/Calendar.cs
+++ b/Ical.Net/Calendar.cs
@@ -227,7 +227,7 @@ public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, I
         // These are the UID/RECURRENCE-ID combinations that replace other occurrences.
         var recurrenceIdsAndUids = this.Children.OfType<IRecurrable>()
             .Where(r => r.RecurrenceId != null)
-            .Select(r => new { (r as IUniqueComponent).Uid, Dt = r.RecurrenceId!.Value })
+            .Select(r => new { (r as IUniqueComponent)?.Uid, Dt = r.RecurrenceId!.Value })
             .Where(r => r.Uid != null)
             .ToDictionary(x => x);
 
@@ -297,7 +297,7 @@ public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, I
         ProductId = c.ProductId;
         Scale = c.Scale;
 
-        foreach (var p in c.Properties.Where(p => p.Name != null && !Properties.ContainsKey(p.Name)))
+        foreach (var p in c.Properties.Where(p => !Properties.ContainsKey(p.Name)))
         {
             Properties.Add(p);
         }

--- a/Ical.Net/Calendar.cs
+++ b/Ical.Net/Calendar.cs
@@ -121,7 +121,7 @@ public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, I
     {
         unchecked
         {
-            var hashCode = Name?.GetHashCode() ?? 0;
+            var hashCode = Name.GetHashCode();
             hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(UniqueComponents);
             hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(Events);
             hashCode = (hashCode * 397) ^ CollectionHelpers.GetHashCode(Todos);
@@ -289,8 +289,6 @@ public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, I
         {
             return;
         }
-
-        Name ??= c.Name;
 
         Method = c.Method;
         Version = c.Version;

--- a/Ical.Net/CalendarCollection.cs
+++ b/Ical.Net/CalendarCollection.cs
@@ -74,7 +74,7 @@ public class CalendarCollection : List<Calendar>
         return this.Aggregate<Calendar, FreeBusy?>(null, (current, iCal) =>
         {
             var freeBusy = iCal.GetFreeBusy(freeBusyRequest);
-            return current is null ? freeBusy : CombineFreeBusy(current, freeBusy);
+            return current is null || freeBusy is null ? freeBusy : CombineFreeBusy(current, freeBusy);
         });
     }
 
@@ -83,7 +83,7 @@ public class CalendarCollection : List<Calendar>
         return this.Aggregate<Calendar, FreeBusy?>(null, (current, iCal) =>
         {
             var freeBusy = iCal.GetFreeBusy(organizer, contacts, fromInclusive, toExclusive);
-            return current is null ? freeBusy : CombineFreeBusy(current, freeBusy);
+            return current is null || freeBusy is null ? freeBusy : CombineFreeBusy(current, freeBusy);
         });
     }
 

--- a/Ical.Net/CalendarComponents/Alarm.cs
+++ b/Ical.Net/CalendarComponents/Alarm.cs
@@ -172,7 +172,7 @@ public class Alarm : CalendarComponent
         for (var i = 0; i < len; i++)
         {
             var ao = occurrences[i];
-            if (ao?.DateTime == null || ao.Component == null)
+            if (ao.DateTime == null || ao.Component == null)
             {
                 continue;
             }

--- a/Ical.Net/CalendarComponents/Todo.cs
+++ b/Ical.Net/CalendarComponents/Todo.cs
@@ -85,7 +85,7 @@ public class Todo : RecurringComponent, IAlarmContainer
     public virtual IList<string> Resources
     {
         get => Properties.GetMany<string>("RESOURCES");
-        set => Properties.Set("RESOURCES", value ?? new List<string>());
+        set => Properties.Set("RESOURCES", value);
     }
 
     /// <summary>

--- a/Ical.Net/CalendarComponents/VTimeZone.cs
+++ b/Ical.Net/CalendarComponents/VTimeZone.cs
@@ -383,7 +383,7 @@ public class VTimeZone : CalendarComponent
     {
         unchecked
         {
-            var hashCode = Name?.GetHashCode() ?? 0;
+            var hashCode = Name.GetHashCode();
             hashCode = (hashCode * 397) ^ (TzId?.GetHashCode() ?? 0);
             hashCode = (hashCode * 397) ^ (Url?.GetHashCode() ?? 0);
             return hashCode;

--- a/Ical.Net/Collections/Proxies/GroupedValueListProxy.cs
+++ b/Ical.Net/Collections/Proxies/GroupedValueListProxy.cs
@@ -64,7 +64,7 @@ public class GroupedValueListProxy<TGroup, TInterface, TItem, TOriginalValue, TN
         foreach (var obj in _realObject)
         {
             // Get the number of items of the target value i this object
-            var count = obj.Values?.OfType<TNewValue>().Count() ?? 0;
+            var count = obj.Values.OfType<TNewValue>().Count();
 
             // Perform some action on this item
             if (!action(obj, i, count))

--- a/Ical.Net/DataTypes/Attachment.cs
+++ b/Ical.Net/DataTypes/Attachment.cs
@@ -113,8 +113,8 @@ public class Attachment : EncodableDataType
         unchecked
         {
             var hashCode = Uri?.GetHashCode() ?? 0;
-            hashCode = (hashCode * 397) ^ (CollectionHelpers.GetHashCode(Data));
-            hashCode = (hashCode * 397) ^ (ValueEncoding?.GetHashCode() ?? 0);
+            hashCode = (hashCode * 397) ^ (Data != null ? CollectionHelpers.GetHashCode(Data) : 0);
+            hashCode = (hashCode * 397) ^ (ValueEncoding.GetHashCode());
             return hashCode;
         }
     }

--- a/Ical.Net/DataTypes/Occurrence.cs
+++ b/Ical.Net/DataTypes/Occurrence.cs
@@ -41,7 +41,7 @@ public class Occurrence : IComparable<Occurrence>
     {
         unchecked
         {
-            return ((Period?.GetHashCode() ?? 0) * 397) ^ (Source?.GetHashCode() ?? 0);
+            return ((Period.GetHashCode()) * 397) ^ (Source.GetHashCode());
         }
     }
 

--- a/Ical.Net/DataTypes/PeriodList.cs
+++ b/Ical.Net/DataTypes/PeriodList.cs
@@ -125,7 +125,7 @@ internal class PeriodList : EncodableDataType, IList<Period>
     }
 
     /// <inheritdoc/>
-    public void RemoveAt(int index) => Periods?.RemoveAt(index);
+    public void RemoveAt(int index) => Periods.RemoveAt(index);
 
     /// <summary>
     /// Adds a <see cref="Period"/> to the list if it does not already exist.<br/>
@@ -159,7 +159,7 @@ internal class PeriodList : EncodableDataType, IList<Period>
     public bool Contains(Period item) => Periods.Contains(item);
 
     /// <inheritdoc/>
-    public void CopyTo(Period[] array, int arrayIndex) => Periods?.CopyTo(array, arrayIndex);
+    public void CopyTo(Period[] array, int arrayIndex) => Periods.CopyTo(array, arrayIndex);
 
     /// <inheritdoc/>
     public IEnumerator<Period> GetEnumerator() => Periods.GetEnumerator();

--- a/Ical.Net/DataTypes/Trigger.cs
+++ b/Ical.Net/DataTypes/Trigger.cs
@@ -119,7 +119,7 @@ public class Trigger : EncodableDataType
         {
             var hashCode = _mDateTime?.GetHashCode() ?? 0;
             hashCode = (hashCode * 397) ^ _mDuration.GetHashCode();
-            hashCode = (hashCode * 397) ^ _mRelated?.GetHashCode() ?? 0;
+            hashCode = (hashCode * 397) ^ _mRelated.GetHashCode();
             return hashCode;
         }
     }

--- a/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
@@ -100,10 +100,10 @@ public class RecurrencePatternEvaluator : Evaluator
 
         // Pre-order those BY values that don't allow for negative values. Those with negative values can only
         // be ordered once the individual position is known.
-        if (r.BySecond?.Count > 0) r.BySecond = r.BySecond.OrderBy(x => x).ToList();
-        if (r.ByMinute?.Count > 0) r.ByMinute = r.ByMinute.OrderBy(x => x).ToList();
-        if (r.ByHour?.Count > 0) r.ByHour = r.ByHour.OrderBy(x => x).ToList();
-        if (r.ByMonth?.Count > 0) r.ByMonth = r.ByMonth.OrderBy(x => x).ToList();
+        if (r.BySecond.Count > 0) r.BySecond = r.BySecond.OrderBy(x => x).ToList();
+        if (r.ByMinute.Count > 0) r.ByMinute = r.ByMinute.OrderBy(x => x).ToList();
+        if (r.ByHour.Count > 0) r.ByHour = r.ByHour.OrderBy(x => x).ToList();
+        if (r.ByMonth.Count > 0) r.ByMonth = r.ByMonth.OrderBy(x => x).ToList();
 
         return r;
     }

--- a/Ical.Net/Serialization/ComponentSerializer.cs
+++ b/Ical.Net/Serialization/ComponentSerializer.cs
@@ -45,7 +45,7 @@ public class ComponentSerializer : SerializerBase
         foreach (var p in properties)
         {
             // Get a serializer for each property.
-            var serializer = sf?.Build(p.GetType(), SerializationContext) as IStringSerializer;
+            var serializer = sf.Build(p.GetType(), SerializationContext) as IStringSerializer;
             var val = serializer?.SerializeToString(p);
             if (val != null) sb.Append(val);
         }

--- a/Ical.Net/Serialization/DataTypes/DataTypeSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/DataTypeSerializer.cs
@@ -23,7 +23,7 @@ public abstract class DataTypeSerializer : SerializerBase
             return null;
         }
 
-        if (SerializationContext?.Peek() is ICalendarObject associatedObject)
+        if (SerializationContext.Peek() is ICalendarObject associatedObject)
         {
             dt.AssociatedObject = associatedObject;
         }

--- a/Ical.Net/Serialization/DataTypes/DateTimeSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/DateTimeSerializer.cs
@@ -68,7 +68,7 @@ public class DateTimeSerializer : SerializerBase, IParameterProvider
         var value = tr.ReadToEnd();
 
         // CalDateTime is defined as the Target type
-        var parent = SerializationContext?.Peek();
+        var parent = SerializationContext.Peek();
 
         // The associated object is an ICalendarObject of type CalendarProperty
         // that contains any timezone ("TZID" property) deserialized in a prior step

--- a/Ical.Net/Serialization/DataTypes/EncodableDataTypeSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/EncodableDataTypeSerializer.cs
@@ -28,9 +28,8 @@ public abstract class EncodableDataTypeSerializer : DataTypeSerializer
 
         // Return the value in the current encoding
         var encodingStack = GetService<EncodingStack>();
-        return encodingStack?.Current == null
-            ? value
-            : Encode(dt, encodingStack.Current.GetBytes(value));
+
+        return Encode(dt, encodingStack.Current.GetBytes(value));
     }
 
     protected string? Encode(IEncodableDataType dt, byte[]? data)
@@ -44,11 +43,11 @@ public abstract class EncodableDataTypeSerializer : DataTypeSerializer
         {
             // Default to the current encoding
             var encodingStack = GetService<EncodingStack>();
-            return encodingStack?.Current.GetString(data);
+            return encodingStack.Current.GetString(data);
         }
 
         var encodingProvider = GetService<IEncodingProvider>();
-        return encodingProvider?.Encode(dt.Encoding, data);
+        return encodingProvider.Encode(dt.Encoding, data);
     }
 
     protected string? Decode(IEncodableDataType dt, string value)
@@ -66,7 +65,7 @@ public abstract class EncodableDataTypeSerializer : DataTypeSerializer
 
         // Default to the current encoding
         var encodingStack = GetService<EncodingStack>();
-        return encodingStack?.Current.GetString(data);
+        return encodingStack.Current.GetString(data);
     }
 
     protected byte[]? DecodeData(IEncodableDataType dt, string? value)
@@ -80,10 +79,10 @@ public abstract class EncodableDataTypeSerializer : DataTypeSerializer
         {
             // Default to the current encoding
             var encodingStack = GetService<EncodingStack>();
-            return encodingStack?.Current.GetBytes(value);
+            return encodingStack.Current.GetBytes(value);
         }
 
         var encodingProvider = GetService<IEncodingProvider>();
-        return encodingProvider?.DecodeData(dt.Encoding, value);
+        return encodingProvider.DecodeData(dt.Encoding, value);
     }
 }

--- a/Ical.Net/Serialization/DataTypes/EnumSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/EnumSerializer.cs
@@ -30,7 +30,7 @@ public class EnumSerializer : EncodableDataTypeSerializer
     {
         try
         {
-            if (SerializationContext?.Peek() is ICalendarObject calObject)
+            if (SerializationContext.Peek() is ICalendarObject calObject)
             {
                 // Encode the value as needed.
                 var dt = new EncodableDataType
@@ -53,7 +53,7 @@ public class EnumSerializer : EncodableDataTypeSerializer
 
         try
         {
-            if (SerializationContext?.Peek() is ICalendarObject obj)
+            if (SerializationContext.Peek() is ICalendarObject obj)
             {
                 // Decode the value, if necessary!
                 var dt = new EncodableDataType

--- a/Ical.Net/Serialization/DataTypes/IntegerSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/IntegerSerializer.cs
@@ -24,7 +24,7 @@ public class IntegerSerializer : EncodableDataTypeSerializer
         {
             var i = Convert.ToInt32(obj);
 
-            if (SerializationContext?.Peek() is ICalendarObject calObject)
+            if (SerializationContext.Peek() is ICalendarObject calObject)
             {
                 // Encode the value as needed.
                 var dt = new EncodableDataType
@@ -47,7 +47,7 @@ public class IntegerSerializer : EncodableDataTypeSerializer
 
         try
         {
-            if (SerializationContext?.Peek() is ICalendarObject obj)
+            if (SerializationContext.Peek() is ICalendarObject obj)
             {
                 // Decode the value, if necessary!
                 var dt = new EncodableDataType

--- a/Ical.Net/Serialization/DataTypes/PeriodSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/PeriodSerializer.cs
@@ -71,7 +71,7 @@ public class PeriodSerializer : EncodableDataTypeSerializer
         finally
         {
             // Pop the period off the serialization context stack
-            SerializationContext?.Pop();
+            SerializationContext.Pop();
         }
     }
 

--- a/Ical.Net/Serialization/DataTypes/PeriodSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/PeriodSerializer.cs
@@ -29,7 +29,7 @@ public class PeriodSerializer : EncodableDataTypeSerializer
         }
 
         // Push the period onto the serialization context stack
-        SerializationContext?.Push(p);
+        SerializationContext.Push(p);
 
         try
         {

--- a/Ical.Net/Serialization/DataTypes/RequestStatusSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/RequestStatusSerializer.cs
@@ -40,7 +40,7 @@ public class RequestStatusSerializer : StringSerializer
             try
             {
                 var factory = GetService<ISerializerFactory>();
-                var serializer = factory?.Build(typeof(StatusCode), SerializationContext) as IStringSerializer;
+                var serializer = factory.Build(typeof(StatusCode), SerializationContext) as IStringSerializer;
                 if (serializer == null)
                 {
                     return null;
@@ -60,7 +60,7 @@ public class RequestStatusSerializer : StringSerializer
             finally
             {
                 // Pop the object off the serialization stack
-                SerializationContext?.Pop();
+                SerializationContext.Pop();
             }
         }
         catch
@@ -128,7 +128,7 @@ public class RequestStatusSerializer : StringSerializer
         finally
         {
             // Pop the object off the serialization stack
-            SerializationContext?.Pop();
+            SerializationContext.Pop();
         }
         return null;
     }

--- a/Ical.Net/Serialization/DataTypes/StringSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/StringSerializer.cs
@@ -81,7 +81,7 @@ public class StringSerializer : EncodableDataTypeSerializer
             values.AddRange(from object child in enumerable select child.ToString());
         }
 
-        if (SerializationContext?.Peek() is ICalendarObject co)
+        if (SerializationContext.Peek() is ICalendarObject co)
         {
             // Encode the string as needed.
             var dt = new EncodableDataType
@@ -125,18 +125,15 @@ public class StringSerializer : EncodableDataTypeSerializer
 
         // Ensure SerializationContext is not null before accessing Peek()
         var context = SerializationContext;
-        if (context?.Peek() is ICalendarProperty cp)
+        if (context.Peek() is ICalendarProperty cp)
         {
             var dataTypeMapper = GetService<DataTypeMapper>();
-            if (dataTypeMapper != null)
-            {
-                serializeAsList = dataTypeMapper.GetPropertyAllowsMultipleValues(cp);
-            }
+            serializeAsList = dataTypeMapper.GetPropertyAllowsMultipleValues(cp);
         }
 
         var dt = new EncodableDataType
         {
-            AssociatedObject = context?.Peek() as ICalendarObject
+            AssociatedObject = context.Peek() as ICalendarObject
         };
 
         var encodedValues = serializeAsList ? UnescapedCommas.Split(value) : new[] { value };

--- a/Ical.Net/Serialization/DataTypes/TriggerSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/TriggerSerializer.cs
@@ -28,7 +28,7 @@ public class TriggerSerializer : StringSerializer
             }
 
             // Push the trigger onto the serialization stack
-            SerializationContext?.Push(t);
+            SerializationContext.Push(t);
             try
             {
                 var factory = GetService<ISerializerFactory>();
@@ -73,7 +73,7 @@ public class TriggerSerializer : StringSerializer
         }
 
         // Push the trigger onto the serialization stack
-        SerializationContext?.Push(t);
+        SerializationContext.Push(t);
         try
         {
             // Decode the value as needed
@@ -82,7 +82,8 @@ public class TriggerSerializer : StringSerializer
             if (value == null) return null;
 
             // Set the trigger relation
-            if (t.Parameters.ContainsKey("RELATED") && t.Parameters.Get("RELATED").Equals("END"))
+            var relatedParameter = t.Parameters.Get("RELATED");
+            if (relatedParameter is not null && relatedParameter.Equals("END"))
             {
                 t.Related = TriggerRelation.End;
             }

--- a/Ical.Net/Serialization/DataTypes/TriggerSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/TriggerSerializer.cs
@@ -52,7 +52,7 @@ public class TriggerSerializer : StringSerializer
             finally
             {
                 // Pop the trigger off the serialization stack
-                SerializationContext?.Pop();
+                SerializationContext.Pop();
             }
         }
         catch
@@ -114,7 +114,7 @@ public class TriggerSerializer : StringSerializer
         finally
         {
             // Pop the trigger off the serialization stack
-            SerializationContext?.Pop();
+            SerializationContext.Pop();
         }
     }
 }

--- a/Ical.Net/Serialization/DataTypes/UriSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/UriSerializer.cs
@@ -25,7 +25,7 @@ public class UriSerializer : EncodableDataTypeSerializer
             return null;
         }
 
-        if (SerializationContext?.Peek() is ICalendarObject co)
+        if (SerializationContext.Peek() is ICalendarObject co)
         {
             var dt = new EncodableDataType
             {
@@ -45,7 +45,7 @@ public class UriSerializer : EncodableDataTypeSerializer
 
         var value = tr.ReadToEnd();
 
-        if (SerializationContext?.Peek() is ICalendarObject co)
+        if (SerializationContext.Peek() is ICalendarObject co)
         {
             var dt = new EncodableDataType
             {

--- a/Ical.Net/Serialization/GenericListSerializer.cs
+++ b/Ical.Net/Serialization/GenericListSerializer.cs
@@ -32,7 +32,7 @@ public class GenericListSerializer : SerializerBase
     private MethodInfo? _addMethodInfo;
     public override object? Deserialize(TextReader tr)
     {
-        var p = SerializationContext?.Peek() as ICalendarProperty;
+        var p = SerializationContext.Peek() as ICalendarProperty;
         if (p == null)
         {
             return null;

--- a/Ical.Net/Serialization/GenericListSerializer.cs
+++ b/Ical.Net/Serialization/GenericListSerializer.cs
@@ -47,7 +47,7 @@ public class GenericListSerializer : SerializerBase
 
         // Get a serializer for the inner type
         var sf = GetService<ISerializerFactory>();
-        var stringSerializer = sf?.Build(_innerType, SerializationContext) as IStringSerializer;
+        var stringSerializer = sf.Build(_innerType, SerializationContext) as IStringSerializer;
         if (stringSerializer == null)
         {
             return null;

--- a/Ical.Net/Serialization/IEncodingProvider.cs
+++ b/Ical.Net/Serialization/IEncodingProvider.cs
@@ -8,7 +8,7 @@ namespace Ical.Net.Serialization;
 
 internal interface IEncodingProvider
 {
-    string Encode(string encoding, byte[] data);
-    string DecodeString(string encoding, string value);
-    byte[] DecodeData(string encoding, string value);
+    string? Encode(string encoding, byte[] data);
+    string? DecodeString(string encoding, string value);
+    byte[]? DecodeData(string encoding, string value);
 }

--- a/Ical.Net/Serialization/ISerializer.cs
+++ b/Ical.Net/Serialization/ISerializer.cs
@@ -12,7 +12,7 @@ namespace Ical.Net.Serialization;
 
 public interface ISerializer : IServiceProvider
 {
-    SerializationContext? SerializationContext { get; set; }
+    SerializationContext SerializationContext { get; set; }
 
     Type TargetType { get; }
     void Serialize(object obj, Stream stream, Encoding encoding);

--- a/Ical.Net/Serialization/PropertySerializer.cs
+++ b/Ical.Net/Serialization/PropertySerializer.cs
@@ -31,12 +31,11 @@ public class PropertySerializer : SerializerBase
         }
 
         // Push this object on the serialization context.
-        SerializationContext?.Push(prop);
+        SerializationContext.Push(prop);
 
         // Get a serializer factory that we can use to serialize
         // the property and parameter values
         var sf = GetService<ISerializerFactory>();
-        if (sf == null) return null;
 
         var result = new StringBuilder();
         foreach (var v in prop.Values.Where(value => value != null))
@@ -45,7 +44,7 @@ public class PropertySerializer : SerializerBase
         }
 
         // Pop the object off the serialization context.
-        SerializationContext?.Pop();
+        SerializationContext.Pop();
         return result.ToString();
     }
 

--- a/Ical.Net/Serialization/SerializationContext.cs
+++ b/Ical.Net/Serialization/SerializationContext.cs
@@ -83,13 +83,13 @@ public class SerializationContext
         return null;
     }
 
-    public virtual object GetService(Type serviceType) => _mServiceProvider.GetService(serviceType);
+    public virtual object? GetService(Type serviceType) => _mServiceProvider.GetService(serviceType);
 
-    public virtual object GetService(string name) => _mServiceProvider.GetService(name);
+    public virtual object? GetService(string name) => _mServiceProvider.GetService(name);
 
-    public virtual T GetService<T>() => _mServiceProvider.GetService<T>();
+    public virtual T? GetService<T>() => _mServiceProvider.GetService<T>();
 
-    public virtual T GetService<T>(string name) => _mServiceProvider.GetService<T>(name);
+    public virtual T? GetService<T>(string name) => _mServiceProvider.GetService<T>(name);
 
     public virtual void SetService(string name, object obj) => _mServiceProvider.SetService(name, obj);
 

--- a/Ical.Net/Serialization/SerializationContext.cs
+++ b/Ical.Net/Serialization/SerializationContext.cs
@@ -83,13 +83,13 @@ public class SerializationContext
         return null;
     }
 
-    public virtual object? GetService(Type serviceType) => _mServiceProvider.GetService(serviceType);
+    public virtual object GetService(Type serviceType) => _mServiceProvider.GetService(serviceType);
 
-    public virtual object? GetService(string name) => _mServiceProvider.GetService(name);
+    public virtual object GetService(string name) => _mServiceProvider.GetService(name);
 
-    public virtual T? GetService<T>() => _mServiceProvider.GetService<T>();
+    public virtual T GetService<T>() => _mServiceProvider.GetService<T>();
 
-    public virtual T? GetService<T>(string name) => _mServiceProvider.GetService<T>(name);
+    public virtual T GetService<T>(string name) => _mServiceProvider.GetService<T>(name);
 
     public virtual void SetService(string name, object obj) => _mServiceProvider.SetService(name, obj);
 

--- a/Ical.Net/Serialization/SerializerBase.cs
+++ b/Ical.Net/Serialization/SerializerBase.cs
@@ -12,7 +12,7 @@ namespace Ical.Net.Serialization;
 
 public abstract class SerializerBase : IStringSerializer
 {
-    private SerializationContext? _mSerializationContext;
+    private SerializationContext _mSerializationContext;
 
     protected SerializerBase()
     {
@@ -24,7 +24,7 @@ public abstract class SerializerBase : IStringSerializer
         _mSerializationContext = ctx;
     }
 
-    public virtual SerializationContext? SerializationContext // NOSONAR: auto-property
+    public virtual SerializationContext SerializationContext // NOSONAR: auto-property
     {
         get => _mSerializationContext;
         set => _mSerializationContext = value;
@@ -54,7 +54,7 @@ public abstract class SerializerBase : IStringSerializer
         using var sw = new StreamWriter(stream, encoding, defaultBuffer, leaveOpen: true);
 
         // Push the current object onto the serialization stack
-        SerializationContext?.Push(obj);
+        SerializationContext.Push(obj);
 
         // Push the current encoding on the stack
         var encodingStack = GetService<EncodingStack>();
@@ -66,7 +66,7 @@ public abstract class SerializerBase : IStringSerializer
         encodingStack?.Pop();
 
         // Pop the current object off the serialization stack
-        SerializationContext?.Pop();
+        SerializationContext.Pop();
     }
 
     public virtual object? GetService(Type serviceType) => SerializationContext?.GetService(serviceType);
@@ -74,20 +74,20 @@ public abstract class SerializerBase : IStringSerializer
     public virtual object? GetService(string name) => SerializationContext?.GetService(name);
 
     public virtual T? GetService<T>()
-        => SerializationContext != null ? SerializationContext.GetService<T>() : default;
+        => SerializationContext.GetService<T>();
 
     public virtual T? GetService<T>(string name) =>
-        SerializationContext != null ? SerializationContext.GetService<T>(name) : default;
+        SerializationContext.GetService<T>(name);
 
     public void SetService(string name, object obj)
-        => SerializationContext?.SetService(name, obj);
+        => SerializationContext.SetService(name, obj);
 
     public void SetService(object obj)
-        => SerializationContext?.SetService(obj);
+        => SerializationContext.SetService(obj);
 
     public void RemoveService(Type type)
-        => SerializationContext?.RemoveService(type);
+        => SerializationContext.RemoveService(type);
 
     public void RemoveService(string name)
-        => SerializationContext?.RemoveService(name);
+        => SerializationContext.RemoveService(name);
 }

--- a/Ical.Net/Serialization/SerializerBase.cs
+++ b/Ical.Net/Serialization/SerializerBase.cs
@@ -38,9 +38,9 @@ public abstract class SerializerBase : IStringSerializer
     {
         using var sr = new StreamReader(stream, encoding);
         var encodingStack = GetService<EncodingStack>();
-        encodingStack?.Push(encoding);
+        encodingStack.Push(encoding);
         var obj = Deserialize(sr);
-        encodingStack?.Pop();
+        encodingStack.Pop();
         return obj;
     }
 
@@ -58,25 +58,25 @@ public abstract class SerializerBase : IStringSerializer
 
         // Push the current encoding on the stack
         var encodingStack = GetService<EncodingStack>();
-        encodingStack?.Push(encoding);
+        encodingStack.Push(encoding);
 
         sw.Write(SerializeToString(obj));
 
         // Pop the current encoding off the serialization stack
-        encodingStack?.Pop();
+        encodingStack.Pop();
 
         // Pop the current object off the serialization stack
         SerializationContext.Pop();
     }
 
-    public virtual object? GetService(Type serviceType) => SerializationContext?.GetService(serviceType);
+    public virtual object GetService(Type serviceType) => SerializationContext.GetService(serviceType);
 
-    public virtual object? GetService(string name) => SerializationContext?.GetService(name);
+    public virtual object GetService(string name) => SerializationContext.GetService(name);
 
-    public virtual T? GetService<T>()
+    public virtual T GetService<T>()
         => SerializationContext.GetService<T>();
 
-    public virtual T? GetService<T>(string name) =>
+    public virtual T GetService<T>(string name) =>
         SerializationContext.GetService<T>(name);
 
     public void SetService(string name, object obj)

--- a/Ical.Net/ServiceProvider.cs
+++ b/Ical.Net/ServiceProvider.cs
@@ -15,37 +15,25 @@ public class ServiceProvider
     private readonly IDictionary<Type, object> _mTypedServices = new Dictionary<Type, object>();
     private readonly IDictionary<string, object> _mNamedServices = new Dictionary<string, object>();
 
-    public virtual object? GetService(Type serviceType)
+    public virtual object GetService(Type serviceType)
     {
-        _mTypedServices.TryGetValue(serviceType, out var service);
+        if (!_mTypedServices.TryGetValue(serviceType, out var service))
+            throw new ArgumentException($"Service of type {serviceType.FullName} not found.", nameof(serviceType));
+
         return service;
     }
 
-    public virtual object? GetService(string name)
+    public virtual object GetService(string name)
     {
-        _mNamedServices.TryGetValue(name, out var service);
+        if (!_mNamedServices.TryGetValue(name, out var service))
+            throw new ArgumentException($"Service with name {name} not found.", nameof(name));
+
         return service;
     }
 
-    public virtual T? GetService<T>()
-    {
-        var service = GetService(typeof(T));
-        if (service is T svc)
-        {
-            return svc;
-        }
-        return default(T);
-    }
+    public virtual T GetService<T>() => (T) GetService(typeof(T));
 
-    public virtual T? GetService<T>(string name)
-    {
-        var service = GetService(name);
-        if (service is T svc)
-        {
-            return svc;
-        }
-        return default(T);
-    }
+    public virtual T GetService<T>(string name) => (T) GetService(name);
 
     public virtual void SetService(string name, object obj)
     {


### PR DESCRIPTION
* `ISerializer.SerializationContext`is not nullable
* `SerializerBase.SerializationContext`: Ensure it is initialized and non-null by design
* `ServiceProvider.GetService(...)` returns a non-null instance or throws an exception if the service is unavailable.
* `EncodingProvider.DecoderDelegate` throws for invalid encoding argument
* `EncoderDelegate GetEncoderFor` throws for invalid encoding argument
* `SimpleDeserializer`: Ensure that `ParseContentLine(context, contentLineString).Vaue` is a string 
* Remove unneccessary conditional access qualifier according to nullable reference types' annotations
* Other small fixes in ical.net
* Small fixes n ical.net.tests
* NRT warninga left are with target `nestandard2.0`

Unit tests untouched except for those with `nullable enable`