### PR TITLE
Evaluation: Raise `EvaluationOutOfRangeException` if year 10k is hit during evaluation

### DIFF
--- a/Ical.Net.Tests/Calendars/Recurrence/RecurrenceTestCases.txt
+++ b/Ical.Net.Tests/Calendars/Recurrence/RecurrenceTestCases.txt
@@ -108,3 +108,51 @@ INSTANCES:20250216T015905,20250216T015906,20250216T020305,20250216T020306,202502
 RRULE:FREQ=YEARLY;BYWEEKNO=1;BYDAY=MO;UNTIL=20241230
 DTSTART:20240101
 INSTANCES:20240101,20241230
+
+# Evaluation without bounds must result in a specific exception
+RRULE:FREQ=YEARLY
+DTSTART:20240101
+EXCEPTION:Ical.Net.Evaluation.EvaluationOutOfRangeException
+EXCEPTION-STEP:Enumeration
+
+# Evaluation until year 9999 must succeed
+RRULE:FREQ=YEARLY;COUNT=2
+DTSTART:99980101
+INSTANCES:99980101,99990101
+
+# Evaluation until year 10000 should fail
+RRULE:FREQ=YEARLY;COUNT=3
+DTSTART:99980101
+EXCEPTION:Ical.Net.Evaluation.EvaluationOutOfRangeException
+EXCEPTION-STEP:Enumeration
+
+# The end stil falls in the year 9999, so it should succeed
+RRULE:FREQ=YEARLY;COUNT=1
+DTSTART:99990101
+DURATION:P364D
+INSTANCES:99990101
+
+# The end exceeds year 9999, so it should fail
+RRULE:FREQ=YEARLY;COUNT=1
+DTSTART:99990101
+DURATION:P365D
+EXCEPTION:Ical.Net.Evaluation.EvaluationOutOfRangeException
+EXCEPTION-STEP:Enumeration
+
+# Due to the size of the interval we'll cause a DateTime overflow.
+RRULE:FREQ=YEARLY;INTERVAL=10000000;COUNT=2
+DTSTART:20240101
+EXCEPTION:Ical.Net.Evaluation.EvaluationOutOfRangeException
+EXCEPTION-STEP:Enumeration
+
+# Due to the size of the interval, this time with freq=WEEKLY we'll cause a DateTime overflow.
+RRULE:FREQ=WEEKLY;INTERVAL=2000000000;COUNT=2
+DTSTART:20240101
+EXCEPTION:Ical.Net.Evaluation.EvaluationOutOfRangeException
+EXCEPTION-STEP:Enumeration
+
+# The 3rd recurrence is on 10000-01-02, which exceeds the limit.
+RRULE:FREQ=YEARLY;BYWEEKNO=-1;BYDAY=SU;COUNT=3
+DTSTART:99971228
+EXCEPTION:Ical.Net.Evaluation.EvaluationOutOfRangeException
+EXCEPTION-STEP:Enumeration

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -3670,6 +3670,14 @@ END:VCALENDAR";
         Assert.That(occurrences, Has.Count.EqualTo(5));
     }
 
+    public enum RecurrenceTestExceptionStep
+    {
+        None,
+        Construction,
+        GetOccurrenceInvocation,
+        Enumeration,
+    }
+
     public class RecurrenceTestCase
     {
         public int LineNumber { get; set; }
@@ -3678,11 +3686,15 @@ END:VCALENDAR";
 
         public CalDateTime? DtStart { get; set; }
 
+        public Duration? Duration { get; internal set; }
+
         public CalDateTime? StartAt { get; set; }
 
         public IReadOnlyList<CalDateTime>? Instances { get; set; }
 
         public string? Exception { get; set; }
+
+        public RecurrenceTestExceptionStep? ExceptionStep { get; set; }
 
         public override string ToString()
             => $"Line {LineNumber}: {DtStart}, {RRule}";
@@ -3732,6 +3744,10 @@ END:VCALENDAR";
                     current.DtStart = new CalDateTime(val, "UTC");
                     break;
 
+                case "DURATION":
+                    current.Duration = Duration.Parse(val);
+                    break;
+
                 case "START-AT":
                     current.StartAt = new CalDateTime(val, "UTC");
                     break;
@@ -3742,6 +3758,11 @@ END:VCALENDAR";
 
                 case "EXCEPTION":
                     current.Exception = val;
+                    current.ExceptionStep ??= RecurrenceTestExceptionStep.Construction;
+                    break;
+
+                case "EXCEPTION-STEP":
+                    current.ExceptionStep = (RecurrenceTestExceptionStep)Enum.Parse(typeof(RecurrenceTestExceptionStep), val);
                     break;
             }
         }
@@ -3775,21 +3796,45 @@ END:VCALENDAR";
 
         // Start at midnight, UTC time
         evt.Start = testCase.DtStart!;
+        evt.Duration = testCase.Duration;
 
-        if (testCase.Exception != null)
+        Type LoadType(string name) =>
+            Type.GetType(name) ?? typeof(Calendar).Assembly.GetType(name) ?? throw new Exception();
+
+        var exceptionType = (testCase.Exception == null) ? null : LoadType(testCase.Exception);
+        IConstraint throwsConstraint = (exceptionType == null) ? Throws.InstanceOf(typeof(Exception)) : Throws.InstanceOf(exceptionType);
+
+        RecurrencePattern GetPattern() => new RecurrencePattern(testCase.RRule!);
+
+        if (testCase.ExceptionStep == RecurrenceTestExceptionStep.Construction)
         {
-            var exceptionType = Type.GetType(testCase.Exception)!;
-            Assert.Throws(exceptionType, () => new RecurrencePattern(testCase.RRule!));
+            Assert.That(() => GetPattern(), throwsConstraint);
             return;
         }
 
-        evt.RecurrenceRules.Add(new RecurrencePattern(testCase.RRule!));
+        evt.RecurrenceRules.Add(GetPattern());
 
-        var occurrences = evt.GetOccurrences(testCase.StartAt ?? new CalDateTime(DateTime.MinValue)).TakeUntil(new CalDateTime(DateTime.MaxValue))
-            .ToList();
+        IEnumerable<Occurrence> GetOccurrences() => evt.GetOccurrences(testCase.StartAt ?? null);
+
+        if (testCase.ExceptionStep == RecurrenceTestExceptionStep.GetOccurrenceInvocation)
+        {
+            Assert.That(() => GetOccurrences(), throwsConstraint);
+            return;
+        }
+
+        var occurrencesEnumerator = GetOccurrences();
+
+        List<Occurrence> EnumerateOccurrences() => occurrencesEnumerator.ToList();
+
+        if (testCase.ExceptionStep == RecurrenceTestExceptionStep.Enumeration)
+        {
+            Assert.That(() => EnumerateOccurrences(), throwsConstraint);
+            return;
+        }
+
+        var occurrences = EnumerateOccurrences();
 
         var startDates = occurrences.Select(x => x.Period.StartTime).ToList();
-
         Assert.That(startDates, Is.EqualTo(testCase.Instances));
     }
 

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -3085,6 +3085,48 @@ public class RecurrenceTests
         });
     }
 
+    [Test]
+
+    // RRULE and RDATE both exceed y10k when converted to UTC, which is done when
+    // ordering the occurrences.
+    [TestCase("""
+            BEGIN:VCALENDAR
+            BEGIN:VEVENT
+            DTSTART;TZID=America/New_York:99991231T220000
+            RRULE:FREQ=DAILY;BYHOUR=22,23;COUNT=2
+            RDATE;TZID=America/Chicago:99991231T221000
+            END:VEVENT
+            END:VCALENDAR
+            """)]
+
+    // y10k exceeded due to the event duration
+    [TestCase("""
+            BEGIN:VCALENDAR
+            BEGIN:VEVENT
+            DTSTART;TZID=America/New_York:99991230T220000
+            DURATION:PT24H
+            RRULE:FREQ=DAILY;BYHOUR=22,23;COUNT=2
+            END:VEVENT
+            END:VCALENDAR
+            """)]
+
+    // Events are merged in different places than individual RRULES of a single event
+    [TestCase("""
+            BEGIN:VCALENDAR
+            BEGIN:VEVENT
+            DTSTART;TZID=America/New_York:99991231T220000
+            END:VEVENT
+            BEGIN:VEVENT
+            DTSTART;TZID=America/Chicago:99991231T221000
+            END:VEVENT
+            END:VCALENDAR
+            """)]
+    public void Recurrence_WithOutOfBoundsUtc_ShouldFailWithCorrectException(string ical)
+    {
+        var cal = Calendar.Load(ical)!;
+        Assert.That(() => cal.GetOccurrences().ToList(), Throws.InstanceOf<EvaluationOutOfRangeException>());
+    }
+
     [Test, Category("Recurrence")]
     public void ExDateShouldFilterOutAllPeriods()
     {

--- a/Ical.Net/Calendar.cs
+++ b/Ical.Net/Calendar.cs
@@ -246,6 +246,9 @@ public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, I
             // Remove duplicates and take advantage of being ordered to avoid full enumeration.
             .OrderedDistinct()
 
+            // Convert overflow exceptions to expected ones.
+            .HandleEvaluationExceptions()
+
             // Remove the occurrence if it has been replaced by a different one.
             .Where(r =>
                 (r.Source.RecurrenceId != null) ||

--- a/Ical.Net/Evaluation/EvaluationOutOfRangeException.cs
+++ b/Ical.Net/Evaluation/EvaluationOutOfRangeException.cs
@@ -1,0 +1,14 @@
+﻿//
+// Copyright ical.net project maintainers and contributors.
+// Licensed under the MIT license.
+//
+
+#nullable enable
+namespace Ical.Net.Evaluation;
+
+/// <summary>
+/// Represents an exception that will be raised during calendar evaluation if the
+/// maximum supported date is exceeded.
+/// </summary>
+public class EvaluationOutOfRangeException(string message) : EvaluationException(message)
+{ }

--- a/Ical.Net/Evaluation/Evaluator.cs
+++ b/Ical.Net/Evaluation/Evaluator.cs
@@ -17,33 +17,41 @@ public abstract class Evaluator : IEvaluator
         if (interval == 0)
             return;
 
-        var old = dt;
-        switch (pattern.Frequency)
+        try
         {
-            case FrequencyType.Secondly:
-                dt = old.AddSeconds(interval);
-                break;
-            case FrequencyType.Minutely:
-                dt = old.AddMinutes(interval);
-                break;
-            case FrequencyType.Hourly:
-                dt = old.AddHours(interval);
-                break;
-            case FrequencyType.Daily:
-                dt = old.AddDays(interval);
-                break;
-            case FrequencyType.Weekly:
-                dt = DateUtil.AddWeeks(old, interval, pattern.FirstDayOfWeek);
-                break;
-            case FrequencyType.Monthly:
-                dt = old.AddDays(-old.Day + 1).AddMonths(interval);
-                break;
-            case FrequencyType.Yearly:
-                dt = old.AddDays(-old.DayOfYear + 1).AddYears(interval);
-                break;
-            // FIXME: use a more specific exception.
-            default:
-                throw new Exception("FrequencyType.NONE cannot be evaluated. Please specify a FrequencyType before evaluating the recurrence.");
+            var old = dt;
+            switch (pattern.Frequency)
+            {
+                case FrequencyType.Secondly:
+                    dt = old.AddSeconds(interval);
+                    break;
+                case FrequencyType.Minutely:
+                    dt = old.AddMinutes(interval);
+                    break;
+                case FrequencyType.Hourly:
+                    dt = old.AddHours(interval);
+                    break;
+                case FrequencyType.Daily:
+                    dt = old.AddDays(interval);
+                    break;
+                case FrequencyType.Weekly:
+                    dt = DateUtil.AddWeeks(old, interval, pattern.FirstDayOfWeek);
+                    break;
+                case FrequencyType.Monthly:
+                    dt = old.AddDays(-old.Day + 1).AddMonths(interval);
+                    break;
+                case FrequencyType.Yearly:
+                    dt = old.AddDays(-old.DayOfYear + 1).AddYears(interval);
+                    break;
+                // FIXME: use a more specific exception.
+                default:
+                    throw new Exception("FrequencyType.NONE cannot be evaluated. Please specify a FrequencyType before evaluating the recurrence.");
+            }
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            // intentionally don't include the outer exception
+            throw new EvaluationOutOfRangeException("Evaluation was aborted because an event's start time exceeded the maxium supported date/time value.");
         }
     }
 

--- a/Ical.Net/Evaluation/Evaluator.cs
+++ b/Ical.Net/Evaluation/Evaluator.cs
@@ -51,7 +51,7 @@ public abstract class Evaluator : IEvaluator
         catch (ArgumentOutOfRangeException)
         {
             // intentionally don't include the outer exception
-            throw new EvaluationOutOfRangeException("Evaluation was aborted because an event's start time exceeded the maxium supported date/time value.");
+            throw new EvaluationOutOfRangeException("Evaluation aborted: The maximum supported date-time was exceeded while enumerating a recurrence rule. This commonly happens when trying to enumerate an unbounded RRULE to its end. Consider applying the .TakeWhile() operator.");
         }
     }
 

--- a/Ical.Net/Evaluation/EventEvaluator.cs
+++ b/Ical.Net/Evaluation/EventEvaluator.cs
@@ -102,7 +102,7 @@ public class EventEvaluator : RecurringEvaluator
         catch (ArgumentOutOfRangeException)
         {
             // intentionally don't include the outer exception
-            throw new EvaluationOutOfRangeException("Evaluation was aborted because an event's end time is out of range. This commonly happens if an event has an unbounded RRULE or a very long duration. Consider applying the .TakeWhile() operator on the returned sequence.");
+            throw new EvaluationOutOfRangeException("Evaluation aborted: Calculating the end time of the event occurrence resulted in an out-of-range value. This commonly happens when trying to enumerate an unbounded RRULE to its end. Consider applying the .TakeWhile() operator.");
         }
     }
 }

--- a/Ical.Net/Evaluation/EventEvaluator.cs
+++ b/Ical.Net/Evaluation/EventEvaluator.cs
@@ -54,47 +54,55 @@ public class EventEvaluator : RecurringEvaluator
     /// <returns>Returns the <paramref name="period"/> with <see cref="Period.EndTime"/> and exact <see cref="Period.Duration"/> set.</returns>
     private Period WithEndTime(Period period)
     {
-        /*
-           We use a time span to calculate the end time of the event.
-           It evaluates the event's definition of DtStart and either DtEnd or Duration.
-           
-           The time span is used, because the period end time gets the same timezone as the event end time.
-           This ensures that the end time is correct, even for DST transitions.
-
-           The exact duration is calculated from the zoned end time and the zoned start time,
-           and it may differ from the time span added to the period start time.
-         */
-        var tsToAdd = CalendarEvent.EffectiveDuration;
-
-        CalDateTime endTime;
-        if (tsToAdd.IsZero)
+        try
         {
-            // For a zero-duration event, the end time is the same as the start time.
-            endTime = period.StartTime;
-        }
-        else
-        {
-            // Calculate the end time of the event as a DateTime
-            var endDt = period.StartTime.Add(tsToAdd);
-            if ((CalendarEvent.End is { } end) && (end.TzId != period.StartTime.TzId) && (end.TzId is { } tzid))
+            /*
+               We use a time span to calculate the end time of the event.
+               It evaluates the event's definition of DtStart and either DtEnd or Duration.
+
+               The time span is used, because the period end time gets the same timezone as the event end time.
+               This ensures that the end time is correct, even for DST transitions.
+
+               The exact duration is calculated from the zoned end time and the zoned start time,
+               and it may differ from the time span added to the period start time.
+             */
+            var tsToAdd = CalendarEvent.EffectiveDuration;
+
+            CalDateTime endTime;
+            if (tsToAdd.IsZero)
             {
-                // Ensure the end time has the same timezone as the event end time.
-                endDt = endDt.ToTimeZone(tzid);
+                // For a zero-duration event, the end time is the same as the start time.
+                endTime = period.StartTime;
+            }
+            else
+            {
+                // Calculate the end time of the event as a DateTime
+                var endDt = period.StartTime.Add(tsToAdd);
+                if ((CalendarEvent.End is { } end) && (end.TzId != period.StartTime.TzId) && (end.TzId is { } tzid))
+                {
+                    // Ensure the end time has the same timezone as the event end time.
+                    endDt = endDt.ToTimeZone(tzid);
+                }
+
+                endTime = endDt;
             }
 
-            endTime = endDt;
+            // Return the Period object with the calculated end time.
+            // Only EndTime is relevant for further processing,
+            // so we have to set it.
+            // If the period duration is not null here, it is an RDATE period
+            // and has priority over the calculated end time.
+
+            return new Period(
+                start: period.StartTime,
+                end: period.Duration == null
+                    ? endTime
+                    : period.EffectiveEndTime);
         }
-
-        // Return the Period object with the calculated end time.
-        // Only EndTime is relevant for further processing,
-        // so we have to set it.
-        // If the period duration is not null here, it is an RDATE period
-        // and has priority over the calculated end time.
-
-        return new Period(
-            start: period.StartTime,
-            end: period.Duration == null
-                ? endTime
-                : period.EffectiveEndTime);
+        catch (ArgumentOutOfRangeException)
+        {
+            // intentionally don't include the outer exception
+            throw new EvaluationOutOfRangeException("Evaluation was aborted because an event's end time is out of range. This commonly happens if an event has an unbounded RRULE or a very long duration. Consider applying the .TakeWhile() operator on the returned sequence.");
+        }
     }
 }

--- a/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
@@ -163,9 +163,6 @@ public class RecurrencePatternEvaluator : Evaluator
         var dateCount = 0;
         while (true)
         {
-            if (dateCount >= pattern.Count)
-                break;
-
             if (searchEndDate < GetIntervalLowerLimit(intervalRefTime, pattern))
                 break;
 
@@ -180,13 +177,13 @@ public class RecurrencePatternEvaluator : Evaluator
                 // For example, FREQ=YEARLY;BYWEEKNO=1 could return dates
                 // from the previous year.
 
-                if (dateCount >= pattern.Count)
-                    break;
-
                 // UNTIL is applied outside of this method, after TZ conversion has been applied.
 
                 yield return candidate;
                 dateCount++;
+
+                if (dateCount >= pattern.Count)
+                    yield break;
             }
 
             if (noCandidateIncrementCount > options?.MaxUnmatchedIncrementsLimit)

--- a/Ical.Net/Evaluation/RecurrenceUtil.cs
+++ b/Ical.Net/Evaluation/RecurrenceUtil.cs
@@ -102,9 +102,9 @@ internal static class RecurrenceUtil
             // There shouldn't be other causes for this type of exceptions, as most validations of the pattern
             // itself are already done earlier, before doing the actual enumeration.
             // Intentionally don't include the outer exception as this most likely is not a technical but a usage error.
-            .Catch<T, ArgumentOutOfRangeException>(_ => throw new EvaluationOutOfRangeException("The maximum supported date/time value has been exceeded while evaluating occurrences. This is likely to happen in case of unbounded RRULEs. Consider applying .TakeWhile() on the returned sequence."))
+            .Catch<T, ArgumentOutOfRangeException>(_ => throw new EvaluationOutOfRangeException("An out-of-range value was encountered while evaluating occurrences. This commonly happens when trying to enumerate an unbounded RRULE to its end. Consider applying the .TakeWhile() operator."))
 
             // System.OverflowException is raised by NodaTime when exceeding the maximum supported date/time
             // value of one tick before 10000-01-01.
-            .Catch<T, OverflowException>(_ => throw new EvaluationOutOfRangeException("The maximum supported date/time value has been exceeded while evaluating occurrences. This is likely to happen in case of unbounded RRULEs. Consider applying .TakeWhile() on the returned sequence."));
+            .Catch<T, OverflowException>(_ => throw new EvaluationOutOfRangeException("An overflow was encountered while evaluating the calendar occurrences. This commonly happens when trying to enumerate an unbounded RRULE to its end. Consider applying the .TakeWhile() operator."));
 }

--- a/Ical.Net/Evaluation/RecurringEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurringEvaluator.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 //
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Ical.Net.CalendarComponents;
@@ -119,7 +120,10 @@ public class RecurringEvaluator : Evaluator
             .OrderedMerge(rdateOccurrences)
             .OrderedDistinct()
             .OrderedExclude(exRuleExclusions)
-            .OrderedExclude(exDateExclusions, Comparer<Period>.Create(CompareExDateOverlap));
+            .OrderedExclude(exDateExclusions, Comparer<Period>.Create(CompareExDateOverlap))
+
+            // Convert overflow exceptions to expected ones.
+            .HandleEvaluationExceptions();
 
         return periods;
     }

--- a/Ical.Net/IGetOccurrences.cs
+++ b/Ical.Net/IGetOccurrences.cs
@@ -12,25 +12,38 @@ namespace Ical.Net;
 
 public interface IGetOccurrences
 {
-    /// <summary>
-    /// Returns all occurrences of this component that overlap with the date range provided.
-    /// All components that start at or after or end after <paramref name="startTime"/> will be returned.
-    /// </summary>
-    /// <param name="startTime">The starting date range</param>
-    /// <param name="options"></param>
+    /// <summary>  
+    /// Returns an IEnumerable that generates and returns all occurrences at or after <paramref name="startTime"/>.
+    /// If <paramref name="startTime"/> isn't provided, all occurrences will be generated.
+    /// </summary>  
+    /// <param name="startTime">The starting date range</param>  
+    /// <param name="options">Evaluation options to be applied. If null, default options will be applied.</param>  
     /// <returns>An IEnumerable that calculates and returns Periods representing the occurrences of this object in ascending order.</returns>
+    /// <remarks>  
+    /// The returned enumerable will evaluate as it is enumerated and can therefore also represent an indefinite sequence.
+    /// The sequence is ordered.
+    /// If enumeration hits year 10,000, an <see cref="EvaluationOutOfRangeException"/> is raised.
+    /// This particularly can happen with recurrence rules (rrules) that neither have a count nor an until date specified.
+    /// It is advisable to limit indefinite sequences by applying LINQ methods like <c>.TakeWhile()</c>.
+    /// </remarks>  
     IEnumerable<Occurrence> GetOccurrences(CalDateTime? startTime = null, EvaluationOptions? options = null);
 }
 
 public interface IGetOccurrencesTyped : IGetOccurrences
 {
-    /// <summary>
-    /// Returns all occurrences of components of type T that start within the date range provided.
-    /// All components occurring at or after <paramref name="startTime"/>
-    /// will be returned.
-    /// </summary>
-    /// <param name="startTime">The starting date range. If set to null, occurrences are returned from the beginning.</param>
-    /// <param name="options"></param>
+    /// <summary>  
+    /// Returns an IEnumerable that generates and returns all occurrences at or after <paramref name="startTime"/>.
+    /// If <paramref name="startTime"/> isn't provided, all occurrences will be generated.
+    /// </summary>  
+    /// <param name="startTime">The starting date range</param>  
+    /// <param name="options">Evaluation options to be applied. If null, default options will be applied.</param>  
     /// <returns>An IEnumerable that calculates and returns Periods representing the occurrences of this object in ascending order.</returns>
+    /// <remarks>  
+    /// The returned enumerable will evaluate as it is enumerated and can therefore also represent an indefinite sequence.
+    /// The sequence is ordered.
+    /// If enumeration hits year 10,000, an <see cref="EvaluationOutOfRangeException"/> is raised.
+    /// This particularly can happen with recurrence rules (rrules) that neither have a count nor an until date specified.
+    /// It is advisable to limit indefinite sequences by applying LINQ methods like <c>.TakeWhile()</c>.
+    /// </remarks>  
     IEnumerable<Occurrence> GetOccurrences<T>(CalDateTime? startTime = null, EvaluationOptions? options = null) where T : IRecurringComponent;
 }

--- a/Ical.Net/Utility/CollectionHelpers.cs
+++ b/Ical.Net/Utility/CollectionHelpers.cs
@@ -267,4 +267,27 @@ internal static class CollectionHelpers
             first = false;
         }
     }
+
+    /// <summary>
+    /// While iterating the source sequence, catch exceptions of the specified type and call the handler.
+    /// </summary>
+    public static IEnumerable<T> Catch<T, TException>(this IEnumerable<T> source, Action<TException> handler)
+        where TException : Exception
+    {
+        using var enumerator = source.GetEnumerator();
+        while (true)
+        {
+            try
+            {
+                if (!enumerator.MoveNext())
+                    break;
+            } catch (TException ex)
+            {
+                handler(ex);
+                break;
+            }
+
+            yield return enumerator.Current;
+        }
+    }
 }


### PR DESCRIPTION
If recurrence evaluation produced an unrepresentable date/time, it used to throw an unspecific `ArgumentOutOfRangeException` or `OverflowException`. With this PR we throw a more specific `EvaluationoutOfRangeException`.

As an overflow could happen virtually anywhere throughout the evaluation code, the overflow handling is implemented in a quite coarse manner. I.e. all `ArgumentOutOfRangeException`s (raised by `DateOnly` et al) as well as `OverflowException`s (raised by NodaTime) are caught in central places. They could theoretically also be caused for different reasons, but, as patterns are validated upfront, it should be quite safe to assume they are caused due to y10k overflows.

Addresses #784