### PR TITLE
Remove unnessary null checks

### DIFF
--- a/Ical.Net/Collections/GroupedListEnumerator.cs
+++ b/Ical.Net/Collections/GroupedListEnumerator.cs
@@ -19,8 +19,8 @@ public class GroupedListEnumerator<TType> :
     public GroupedListEnumerator(IList<IMultiLinkedList<TType>> lists) => _lists = lists;
 
     public virtual TType Current
-        => _listEnumerator == null || _listEnumerator.Current == null
-            ? throw new InvalidOperationException("Current is null.")
+        => _listEnumerator == null
+            ? throw new InvalidOperationException("List enumerator is null.")
             : _listEnumerator.Current;
 
     public virtual void Dispose()
@@ -39,8 +39,8 @@ public class GroupedListEnumerator<TType> :
     }
 
     object IEnumerator.Current
-        => _listEnumerator == null || _listEnumerator.Current == null
-            ? throw new InvalidOperationException("Current is null.")
+        => _listEnumerator == null
+            ? throw new InvalidOperationException("List enumerator is null.")
             : _listEnumerator.Current;
 
     private bool MoveNextList()

--- a/Ical.Net/Collections/Proxies/GroupedValueListProxy.cs
+++ b/Ical.Net/Collections/Proxies/GroupedValueListProxy.cs
@@ -94,9 +94,7 @@ public class GroupedValueListProxy<TGroup, TInterface, TItem, TOriginalValue, TN
 
     public virtual void Clear()
     {
-        var items = Items.Where(o => o.Values != null);
-
-        foreach (var original in items)
+        foreach (var original in Items)
         {
             // Clear all values from each matching object
             original.SetValue(default(TOriginalValue)!);
@@ -108,7 +106,6 @@ public class GroupedValueListProxy<TGroup, TInterface, TItem, TOriginalValue, TN
     public virtual void CopyTo(TNewValue[] array, int arrayIndex)
     {
         Items
-            .Where(o => o.Values != null)
             .SelectMany(o => o.Values!)
             .ToArray()
             .CopyTo(array, arrayIndex);
@@ -153,7 +150,7 @@ public class GroupedValueListProxy<TGroup, TInterface, TItem, TOriginalValue, TN
         var value = (TOriginalValue) (object) item;
         IterateValues((o, i, count) =>
         {
-            if (o.Values != null && o.Values.Contains(value))
+            if (o.Values.Contains(value))
             {
                 var list = o.Values.ToList();
                 index = i + list.IndexOf(value);

--- a/Ical.Net/Evaluation/RecurringEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurringEvaluator.cs
@@ -29,7 +29,7 @@ public class RecurringEvaluator : Evaluator
     /// <param name="options"></param>
     protected IEnumerable<Period> EvaluateRRule(CalDateTime referenceDate, CalDateTime? periodStart, EvaluationOptions? options)
     {
-        if (Recurrable.RecurrenceRules == null || !Recurrable.RecurrenceRules.Any())
+        if (!Recurrable.RecurrenceRules.Any())
             return [];
 
         var periodsQueries = Recurrable.RecurrenceRules.Select(rule =>
@@ -66,7 +66,7 @@ public class RecurringEvaluator : Evaluator
     /// <param name="options"></param>
     protected IEnumerable<Period> EvaluateExRule(CalDateTime referenceDate, CalDateTime? periodStart, EvaluationOptions? options)
     {
-        if (Recurrable.ExceptionRules == null || !Recurrable.ExceptionRules.Any())
+        if (!Recurrable.ExceptionRules.Any())
             return [];
 
         var exRuleEvaluatorQueries = Recurrable.ExceptionRules.Select(exRule =>
@@ -105,10 +105,9 @@ public class RecurringEvaluator : Evaluator
         // Only add referenceDate if there are no RecurrenceRules defined. This is in line
         // with RFC 5545 which requires DTSTART to match any RRULE. If it doesn't, the behaviour
         // is undefined. It seems to be good practice not to return the referenceDate in this case.
-        if ((Recurrable.RecurrenceRules == null) || !Recurrable.RecurrenceRules.Any())
-            rruleOccurrences = [new Period(referenceDate)];
-        else
-            rruleOccurrences = EvaluateRRule(referenceDate, periodStart, options);
+        rruleOccurrences = !Recurrable.RecurrenceRules.Any()
+            ? [new Period(referenceDate)]
+            : EvaluateRRule(referenceDate, periodStart, options);
 
         var rdateOccurrences = EvaluateRDate(referenceDate, periodStart);
 

--- a/Ical.Net/Serialization/ComponentSerializer.cs
+++ b/Ical.Net/Serialization/ComponentSerializer.cs
@@ -25,7 +25,7 @@ public class ComponentSerializer : SerializerBase
 
     public override string? SerializeToString(object? obj)
     {
-        if (obj is not ICalendarComponent c || SerializationContext == null)
+        if (obj is not ICalendarComponent c)
         {
             return null;
         }

--- a/Ical.Net/Serialization/DataMapSerializer.cs
+++ b/Ical.Net/Serialization/DataMapSerializer.cs
@@ -19,10 +19,6 @@ public class DataMapSerializer : SerializerBase
     {
         var sf = GetService<ISerializerFactory>();
         var mapper = GetService<DataTypeMapper>();
-        if (sf == null || mapper == null || SerializationContext == null)
-        {
-            return null;
-        }
 
         var obj = SerializationContext.Peek();
 

--- a/Ical.Net/Serialization/DataTypes/AttachmentSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/AttachmentSerializer.cs
@@ -61,10 +61,7 @@ public class AttachmentSerializer : EncodableDataTypeSerializer
 
             // Get the currently-used encoding off the encoding stack.
             var encodingStack = GetService<EncodingStack>();
-            if (encodingStack != null)
-            {
-                a.ValueEncoding = encodingStack.Current;
-            }
+            a.ValueEncoding = encodingStack.Current;
 
             // Get the format of the attachment
             var valueType = a.GetValueType();

--- a/Ical.Net/Serialization/DataTypes/PeriodListSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/PeriodListSerializer.cs
@@ -22,7 +22,7 @@ public class PeriodListSerializer : EncodableDataTypeSerializer
     public override string? SerializeToString(object? obj)
     {
         var factory = GetService<ISerializerFactory>();
-        if (obj is not PeriodList periodList || factory == null || SerializationContext == null)
+        if (obj is not PeriodList periodList)
         {
             return null;
         }
@@ -69,12 +69,9 @@ public class PeriodListSerializer : EncodableDataTypeSerializer
         var value = tr.ReadToEnd();
 
         // Create the day specifier and associate it with a calendar object
-        var rdt = CreateAndAssociate() as PeriodList;
+        if (CreateAndAssociate() is not PeriodList rdt) return null;
+
         var factory = GetService<ISerializerFactory>();
-        if (rdt == null || factory == null || SerializationContext == null)
-        {
-            return null;
-        }
 
         // Decode the value, if necessary
         value = Decode(rdt, value);

--- a/Ical.Net/Serialization/DataTypes/PeriodSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/PeriodSerializer.cs
@@ -22,7 +22,7 @@ public class PeriodSerializer : EncodableDataTypeSerializer
     {
         var factory = GetService<ISerializerFactory>();
 
-        if (obj is not Period p || factory == null)
+        if (obj is not Period p)
         {
             return null;
         }
@@ -78,12 +78,8 @@ public class PeriodSerializer : EncodableDataTypeSerializer
     {
         var value = tr.ReadToEnd();
 
-        var p = CreateAndAssociate() as Period;
+        if (CreateAndAssociate() is not Period p) return null;
         var factory = GetService<ISerializerFactory>();
-        if (p == null || factory == null)
-        {
-            return null;
-        }
 
         var dtSerializer = factory.Build(typeof(CalDateTime), SerializationContext) as IStringSerializer;
         var durationSerializer = factory.Build(typeof(Duration), SerializationContext) as IStringSerializer;

--- a/Ical.Net/Serialization/DataTypes/RecurrencePatternSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/RecurrencePatternSerializer.cs
@@ -105,7 +105,7 @@ public class RecurrencePatternSerializer : EncodableDataTypeSerializer
     public override string? SerializeToString(object? obj)
     {
         var factory = GetService<ISerializerFactory>();
-        if (obj is not RecurrencePattern recur || factory == null || SerializationContext == null)
+        if (obj is not RecurrencePattern recur)
         {
             return null;
         }

--- a/Ical.Net/Serialization/DataTypes/RequestStatusSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/RequestStatusSerializer.cs
@@ -21,11 +21,6 @@ public class RequestStatusSerializer : StringSerializer
 
     public override string? SerializeToString(object? obj)
     {
-        if (SerializationContext == null)
-        {
-            return null;
-        }
-
         try
         {
             if (obj is not RequestStatus rs)
@@ -73,7 +68,7 @@ public class RequestStatusSerializer : StringSerializer
 
     public override object? Deserialize(TextReader? tr)
     {
-        if (tr == null || SerializationContext == null) return null;
+        if (tr == null) return null;
         
         var value = tr.ReadToEnd();
 
@@ -92,10 +87,6 @@ public class RequestStatusSerializer : StringSerializer
         try
         {
             var factory = GetService<ISerializerFactory>();
-            if (factory == null)
-            {
-                return null;
-            }
 
             var match = NarrowRequestMatch.Match(value);
             if (!match.Success)

--- a/Ical.Net/Serialization/DataTypes/TriggerSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/TriggerSerializer.cs
@@ -31,10 +31,6 @@ public class TriggerSerializer : StringSerializer
             try
             {
                 var factory = GetService<ISerializerFactory>();
-                if (factory == null)
-                {
-                    return null;
-                }
 
                 var valueType = t.GetValueType() ?? typeof(Duration);
                 if (!(factory.Build(valueType, SerializationContext) is IStringSerializer serializer))
@@ -88,10 +84,6 @@ public class TriggerSerializer : StringSerializer
             }
 
             var factory = GetService<ISerializerFactory>();
-            if (factory == null)
-            {
-                return null;
-            }
 
             var valueType = t.GetValueType() ?? typeof(Duration);
             var serializer = factory.Build(valueType, SerializationContext) as IStringSerializer;

--- a/Ical.Net/Serialization/SerializationUtil.cs
+++ b/Ical.Net/Serialization/SerializationUtil.cs
@@ -35,11 +35,6 @@ internal class SerializationUtil
     private static readonly ConcurrentDictionary<Type, List<MethodInfo>> _onDeserializingMethods = new ConcurrentDictionary<Type, List<MethodInfo>>();
     private static List<MethodInfo> GetDeserializingMethods(Type targetType)
     {
-        if (targetType == null)
-        {
-            return new List<MethodInfo>();
-        }
-
         if (_onDeserializingMethods.ContainsKey(targetType))
         {
             return _onDeserializingMethods[targetType];


### PR DESCRIPTION
Remove null checks having "Expression is always true or false according to NRT annotations" from Code Inspector.
Again, increasing coverage.