### PR TITLE
feat: Serialize multiple categories and resources to one line

### DIFF
--- a/Ical.Net.Tests/SymmetricSerializationTests.cs
+++ b/Ical.Net.Tests/SymmetricSerializationTests.cs
@@ -238,17 +238,19 @@ public class SymmetricSerializationTests
         yield return new TestCaseData("\\\\uncPath\\to\\resource.txt", new Uri("\\\\uncPath\\to\\resource.txt")).SetName("UNC path URL");
     }
 
-    [Test]
-    public void CategoriesTest()
+    [TestCase("Foo", "Bar", "Baz")]
+    [TestCase("Hello", "World", null)]
+    public void CategoriesTest(string cat1, string cat2, string cat3)
     {
         var vEvent = GetSimpleEvent();
-        vEvent.Categories = new List<string> { "Foo", "Bar", "Baz" };
+        vEvent.Categories = [cat1, cat2, cat3];
         var c = new Calendar();
         c.Events.Add(vEvent);
 
         var serialized = SerializeToString(c);
         var categoriesCount = Regex.Matches(serialized, "CATEGORIES").Count;
         Assert.That(categoriesCount, Is.EqualTo(1));
+        Assert.That(serialized, Does.Contain($"CATEGORIES:{string.Join(",", vEvent.Categories)}"));
 
         var deserialized = UnserializeCalendar(serialized);
         Assert.That(deserialized, Is.EqualTo(c));

--- a/Ical.Net.Tests/SymmetricSerializationTests.cs
+++ b/Ical.Net.Tests/SymmetricSerializationTests.cs
@@ -255,4 +255,22 @@ public class SymmetricSerializationTests
         var deserialized = UnserializeCalendar(serialized);
         Assert.That(deserialized, Is.EqualTo(c));
     }
+
+    [TestCase("Foo", "Bar", "Baz")]
+    [TestCase("Hello", "World", null)]
+    public void ResourceTest(string cat1, string cat2, string cat3)
+    {
+        var vEvent = GetSimpleEvent();
+        vEvent.Resources = [cat1, cat2, cat3];
+        var c = new Calendar();
+        c.Events.Add(vEvent);
+
+        var serialized = SerializeToString(c);
+        var categoriesCount = Regex.Matches(serialized, "RESOURCES").Count;
+        Assert.That(categoriesCount, Is.EqualTo(1));
+        Assert.That(serialized, Does.Contain($"RESOURCES:{string.Join(",", vEvent.Categories)}"));
+
+        var deserialized = UnserializeCalendar(serialized);
+        Assert.That(deserialized, Is.EqualTo(c));
+    }
 }

--- a/Ical.Net.Tests/SymmetricSerializationTests.cs
+++ b/Ical.Net.Tests/SymmetricSerializationTests.cs
@@ -238,7 +238,7 @@ public class SymmetricSerializationTests
         yield return new TestCaseData("\\\\uncPath\\to\\resource.txt", new Uri("\\\\uncPath\\to\\resource.txt")).SetName("UNC path URL");
     }
 
-    [Test, Ignore("TODO: Fix CATEGORIES multiple serializations")]
+    [Test]
     public void CategoriesTest()
     {
         var vEvent = GetSimpleEvent();

--- a/Ical.Net/Serialization/PropertySerializer.cs
+++ b/Ical.Net/Serialization/PropertySerializer.cs
@@ -39,7 +39,7 @@ public class PropertySerializer : SerializerBase
         // TODO: Exhaust this list with all properties which can be displayed in one line.
         var stringBuilder = prop.Name switch
         {
-            "CATEGORIES" => ToOneLine(prop, sf),
+            "CATEGORIES" or "RESOURCES" => ToOneLine(prop, sf),
             _ => ToMultipleLines(prop, sf),
         };
 

--- a/Ical.Net/Serialization/PropertySerializer.cs
+++ b/Ical.Net/Serialization/PropertySerializer.cs
@@ -36,15 +36,35 @@ public class PropertySerializer : SerializerBase
         // the property and parameter values
         var sf = GetService<ISerializerFactory>();
 
+        // TODO: Exhaust this list with all properties which can be displayed in one line.
+        var stringBuilder = prop.Name switch
+        {
+            "CATEGORIES" => ToOneLine(prop, sf),
+            _ => ToMultipleLines(prop, sf),
+        };
+
+        // Pop the object off the serialization context.
+        SerializationContext.Pop();
+        return stringBuilder.ToString();
+    }
+
+    private StringBuilder ToOneLine(ICalendarProperty prop, ISerializerFactory sf)
+    {
+        var result = new StringBuilder();
+        SerializeValue(result, prop, prop.Values.Where(e => e is not null), sf);
+
+        return result;
+    }
+
+    private StringBuilder ToMultipleLines(ICalendarProperty prop, ISerializerFactory sf)
+    {
         var result = new StringBuilder();
         foreach (var v in prop.Values.Where(value => value != null))
         {
             SerializeValue(result, prop, v!, sf);
         }
 
-        // Pop the object off the serialization context.
-        SerializationContext.Pop();
-        return result.ToString();
+        return result;
     }
 
     private void SerializeValue(StringBuilder result, ICalendarProperty prop, object value, ISerializerFactory sf)


### PR DESCRIPTION
It's allowed to have `CATEGORIES` property multiple times in an event but it's not that pretty and some other programs will have trouble reading such events. So it's more a feature than a bug (#156).
Here is a quick fix to display multiple categories in one line.