### PR TITLE
feat: Add evaluation layer to `CalDateTime`

### DIFF
--- a/Ical.Net.Benchmarks/ApplicationWorkflows.cs
+++ b/Ical.Net.Benchmarks/ApplicationWorkflows.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Ical.Net.Evaluation;
 
 namespace Ical.Net.Benchmarks;
 

--- a/Ical.Net.Benchmarks/CalDateTimePerfTests.cs
+++ b/Ical.Net.Benchmarks/CalDateTimePerfTests.cs
@@ -6,6 +6,7 @@
 using BenchmarkDotNet.Attributes;
 using Ical.Net.DataTypes;
 using System;
+using Ical.Net.Evaluation;
 
 namespace Ical.Net.Benchmarks;
 

--- a/Ical.Net.Benchmarks/OccurencePerfTests.cs
+++ b/Ical.Net.Benchmarks/OccurencePerfTests.cs
@@ -9,6 +9,7 @@ using Ical.Net.DataTypes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Ical.Net.Evaluation;
 
 namespace Ical.Net.Benchmarks;
 

--- a/Ical.Net.Tests/CalDateTimeTests.cs
+++ b/Ical.Net.Tests/CalDateTimeTests.cs
@@ -12,6 +12,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using Ical.Net.Evaluation;
 
 namespace Ical.Net.Tests;
 
@@ -55,10 +56,10 @@ public class CalDateTimeTests
     [Test, TestCaseSource(nameof(ToTimeZoneTestCases))]
     public void ToTimeZoneTests(CalendarEvent calendarEvent, string targetTimeZone)
     {
-        var startAsUtc = calendarEvent.Start.AsUtc;
+        var startAsUtc = calendarEvent.Start!.AsUtc();
 
         var convertedStart = calendarEvent.Start.ToTimeZone(targetTimeZone);
-        var convertedAsUtc = convertedStart.AsUtc;
+        var convertedAsUtc = convertedStart.AsUtc();
 
         Assert.That(convertedAsUtc, Is.EqualTo(startAsUtc));
     }
@@ -96,11 +97,11 @@ public class CalDateTimeTests
         var someTime = DateTimeOffset.Parse("2018-05-21T11:35:00-04:00", CultureInfo.InvariantCulture);
 
         var someDt = new CalDateTime(someTime.DateTime, "America/New_York");
-        var firstUtc = someDt.AsUtc;
+        var firstUtc = someDt.AsUtc();
         Assert.That(firstUtc, Is.EqualTo(someTime.UtcDateTime));
 
         someDt = new CalDateTime(someTime.DateTime, "Europe/Berlin");
-        var berlinUtc = someDt.AsUtc;
+        var berlinUtc = someDt.AsUtc();
         Assert.That(berlinUtc, Is.Not.EqualTo(firstUtc));
     }
 
@@ -190,15 +191,15 @@ public class CalDateTimeTests
 
         yield return new TestCaseData(new Func<CalDateTime, CalDateTime>(dt => dt.AddHours(1)))
             .Returns(dateTime.AddHours(1))
-            .SetName($"{nameof(CalDateTime.AddHours)} 1 hour");
+            .SetName($"{nameof(CalDateTimeExtensions.AddHours)} 1 hour");
 
         yield return new TestCaseData(new Func<CalDateTime, CalDateTime>(dt => dt.Add(Duration.FromSeconds(30))))
             .Returns(dateTime.Add(TimeSpan.FromSeconds(30)))
-            .SetName($"{nameof(CalDateTime.Add)} 30 seconds");
+            .SetName($"{nameof(CalDateTimeExtensions.Add)} 30 seconds");
 
         yield return new TestCaseData(new Func<CalDateTime, CalDateTime>(dt => dt.AddMinutes(70)))
             .Returns(dateTime.AddMinutes(70))
-            .SetName($"{nameof(CalDateTime.AddMinutes)} 70 minutes");
+            .SetName($"{nameof(CalDateTimeExtensions.AddMinutes)} 70 minutes");
     }
 
     [Test, TestCaseSource(nameof(EqualityTestCases))]
@@ -259,27 +260,27 @@ public class CalDateTimeTests
 
         yield return new TestCaseData(new Func<CalDateTime, CalDateTime>(dt => dt.Add(-Duration.FromDays(1))))
             .Returns((dateTime.AddDays(-1), false))
-            .SetName($"{nameof(CalDateTime.Add)} -1 day TimeSpan");
+            .SetName($"{nameof(CalDateTimeExtensions.Add)} -1 day TimeSpan");
 
         yield return new TestCaseData(new Func<CalDateTime, CalDateTime>(dt => dt.AddYears(1)))
             .Returns((dateTime.AddYears(1), false))
-            .SetName($"{nameof(CalDateTime.AddYears)} 1 year");
+            .SetName($"{nameof(CalDateTimeExtensions.AddYears)} 1 year");
 
         yield return new TestCaseData(new Func<CalDateTime, CalDateTime>(dt => dt.AddMonths(2)))
             .Returns((dateTime.AddMonths(2), false))
-            .SetName($"{nameof(CalDateTime.AddMonths)} 2 months");
+            .SetName($"{nameof(CalDateTimeExtensions.AddMonths)} 2 months");
 
         yield return new TestCaseData(new Func<CalDateTime, CalDateTime>(dt => dt.AddDays(7)))
             .Returns((dateTime.AddDays(7), false))
-            .SetName($"{nameof(CalDateTime.AddDays)} 7 days");
+            .SetName($"{nameof(CalDateTimeExtensions.AddDays)} 7 days");
 
         yield return new TestCaseData(new Func<CalDateTime, CalDateTime>(dt => dt.Add(Duration.FromDays(1))))
             .Returns((dateTime.Add(TimeSpan.FromDays(1)), false))
-            .SetName($"{nameof(CalDateTime.Add)} 1 day TimeSpan");
+            .SetName($"{nameof(CalDateTimeExtensions.Add)} 1 day TimeSpan");
 
         yield return new TestCaseData(new Func<CalDateTime, CalDateTime>(dt => dt.Add(Duration.Zero)))
             .Returns((dateTime.Add(TimeSpan.Zero), false))
-            .SetName($"{nameof(CalDateTime.Add)} TimeSpan.Zero");
+            .SetName($"{nameof(CalDateTimeExtensions.Add)} TimeSpan.Zero");
     }
 
     [Test]

--- a/Ical.Net.Tests/PeriodListWrapperTests.cs
+++ b/Ical.Net.Tests/PeriodListWrapperTests.cs
@@ -7,6 +7,7 @@
 using System.Linq;
 using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
+using Ical.Net.Evaluation;
 using Ical.Net.Serialization;
 using NUnit.Framework;
 

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -4115,8 +4115,6 @@ END:VCALENDAR";
     [Test]
     public void AmbiguousLocalTime_WithShortDurationOfRecurrence()
     {
-        CalDateTimeExtensions.CleanupCache();
-
         // Short recurrence falls into an ambiguous local time
         // for the end time of the second occurrence because
         // of DST transition on 2025-10-25 03:00

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -4111,4 +4111,37 @@ END:VCALENDAR";
             Assert.That(() => serializer.CheckRange("a", (int?) 0, 1, 2, false), Throws.TypeOf<ArgumentOutOfRangeException>());
         });
     }
+
+    [Test]
+    public void AmbiguousLocalTime_WithShortDurationOfRecurrence()
+    {
+        // Short recurrence falls into an ambiguous local time
+        // for the end time of the second occurrence because
+        // of DST transition on 2025-10-25 03:00
+        // See also: https://github.com/ical-org/ical.net/issues/737
+        var ics = """
+                  BEGIN:VCALENDAR
+                  BEGIN:VEVENT
+                  DTSTART;TZID=Europe/Vienna:20201024T023000
+                  DURATION:PT45M
+                  RRULE:FREQ=DAILY;UNTIL=20201025T013000Z
+                  END:VEVENT
+                  END:VCALENDAR
+                  """;
+        var cal = Calendar.Load(ics)!;
+        var occ = cal.GetOccurrences().ToList();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(occ.Count, Is.EqualTo(2));
+
+            Assert.That(occ[0].Period.StartTime, Is.EqualTo(new CalDateTime(2020, 10, 24, 2, 30, 0, "Europe/Vienna")));
+            Assert.That(occ[0].Period.EndTime, Is.EqualTo(new CalDateTime(2020, 10, 24, 3, 15, 0, "Europe/Vienna")));
+            Assert.That(occ[0].Period.EffectiveDuration, Is.EqualTo(new Duration(0, 0, 0, 45, 0)));
+
+            Assert.That(occ[1].Period.StartTime, Is.EqualTo(new CalDateTime(2020, 10, 25, 2, 30, 0, "Europe/Vienna")));
+            Assert.That(occ[1].Period.EndTime, Is.EqualTo(new CalDateTime(2020, 10, 25, 2, 15, 0, "Europe/Vienna")));
+            Assert.That(occ[1].Period.EffectiveDuration, Is.EqualTo(new Duration(0, 0, 0, 45, 0)));
+        });
+    }
 }

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -3986,7 +3986,7 @@ END:VCALENDAR";
         var cal = Calendar.Load(icalText)!;
         var evt = cal.Events.First();
         var ev = new EventEvaluator(evt);
-        var occurrences = ev.Evaluate(evt.DtStart!, evt.DtStart!.ToTimeZone(tzId), null).TakeWhileBefore(evt.DtStart.AddMinutes(61).ToTimeZone(tzId));
+        var occurrences = ev.Evaluate(evt.DtStart!, evt.DtStart!.ToTimeZone(tzId), null).TakeWhileBefore(evt.DtStart!.AddMinutes(61).ToTimeZone(tzId));
         var occurrencesStartTimes = occurrences.Select(x => x.StartTime).Take(2).ToList();
 
         var expectedStartTimes = new[]
@@ -4115,6 +4115,8 @@ END:VCALENDAR";
     [Test]
     public void AmbiguousLocalTime_WithShortDurationOfRecurrence()
     {
+        CalDateTimeExtensions.CleanupCache();
+
         // Short recurrence falls into an ambiguous local time
         // for the end time of the second occurrence because
         // of DST transition on 2025-10-25 03:00
@@ -4130,11 +4132,11 @@ END:VCALENDAR";
                   """;
         var cal = Calendar.Load(ics)!;
         var occ = cal.GetOccurrences().ToList();
-
+        
         Assert.Multiple(() =>
         {
             Assert.That(occ.Count, Is.EqualTo(2));
-
+            
             Assert.That(occ[0].Period.StartTime, Is.EqualTo(new CalDateTime(2020, 10, 24, 2, 30, 0, "Europe/Vienna")));
             Assert.That(occ[0].Period.EndTime, Is.EqualTo(new CalDateTime(2020, 10, 24, 3, 15, 0, "Europe/Vienna")));
             Assert.That(occ[0].Period.EffectiveDuration, Is.EqualTo(new Duration(0, 0, 0, 45, 0)));

--- a/Ical.Net.Tests/RecurrenceWithRDateTests.cs
+++ b/Ical.Net.Tests/RecurrenceWithRDateTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using Ical.Net.CalendarComponents;
 using Ical.Net.Collections;
 using Ical.Net.DataTypes;
+using Ical.Net.Evaluation;
 using Ical.Net.Serialization;
 using Ical.Net.Utility;
 using NUnit.Framework;

--- a/Ical.Net.Tests/SerializationTests.cs
+++ b/Ical.Net.Tests/SerializationTests.cs
@@ -12,6 +12,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
+using Ical.Net.Evaluation;
 using Ical.Net.Serialization;
 using Ical.Net.Serialization.DataTypes;
 using Ical.Net.Utility;

--- a/Ical.Net/CalendarComponents/VTimeZone.cs
+++ b/Ical.Net/CalendarComponents/VTimeZone.cs
@@ -11,6 +11,7 @@ using NodaTime.TimeZones;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Ical.Net.Evaluation;
 
 namespace Ical.Net.CalendarComponents;
 

--- a/Ical.Net/CalendarExtensions.cs
+++ b/Ical.Net/CalendarExtensions.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Globalization;
 using Ical.Net.DataTypes;
+using Ical.Net.Evaluation;
 
 namespace Ical.Net;
 

--- a/Ical.Net/DataTypes/Duration.cs
+++ b/Ical.Net/DataTypes/Duration.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.IO;
+using Ical.Net.Evaluation;
 using Ical.Net.Serialization.DataTypes;
 
 namespace Ical.Net.DataTypes;

--- a/Ical.Net/DataTypes/Period.cs
+++ b/Ical.Net/DataTypes/Period.cs
@@ -4,6 +4,7 @@
 //
 
 using System;
+using Ical.Net.Evaluation;
 using Ical.Net.Serialization.DataTypes;
 
 namespace Ical.Net.DataTypes;
@@ -78,7 +79,7 @@ public class Period : EncodableDataType, IComparable<Period>
                 $"Start time ({start}) and end time ({end}) must both have a time or both be date-only.");
 
         // Although the timezones are the same, the start and end times may be in different DST offsets.
-        if (end != null && end.AsUtc < start.AsUtc)
+        if (end != null && end.AsUtc() < start.AsUtc())
             throw new ArgumentException($"End time ({end}) as UTC must be greater than start time ({start}) as UTC.", nameof(end));
 
         _startTime = start;
@@ -261,7 +262,7 @@ public class Period : EncodableDataType, IComparable<Period>
             return 1;
         }
 
-        if (StartTime.AsUtc.Equals(other.StartTime.AsUtc))
+        if (StartTime.AsUtc().Equals(other.StartTime.AsUtc()))
         {
             return 0;
         }

--- a/Ical.Net/DataTypes/Period.cs
+++ b/Ical.Net/DataTypes/Period.cs
@@ -77,8 +77,9 @@ public class Period : EncodableDataType, IComparable<Period>
             throw new ArgumentException(
                 $"Start time ({start}) and end time ({end}) must both have a time or both be date-only.");
 
-        if (end != null && end.LessThan(start))
-            throw new ArgumentException($"End time ({end}) must be greater than start time ({start}).", nameof(end));
+        // Although the timezones are the same, the start and end times may be in different DST offsets.
+        if (end != null && end.AsUtc < start.AsUtc)
+            throw new ArgumentException($"End time ({end}) as UTC must be greater than start time ({start}) as UTC.", nameof(end));
 
         _startTime = start;
         _endTime = end;

--- a/Ical.Net/DataTypes/Trigger.cs
+++ b/Ical.Net/DataTypes/Trigger.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.IO;
+using Ical.Net.Evaluation;
 using Ical.Net.Serialization.DataTypes;
 
 namespace Ical.Net.DataTypes;

--- a/Ical.Net/Evaluation/CalDateTimeExtensions.cs
+++ b/Ical.Net/Evaluation/CalDateTimeExtensions.cs
@@ -1,0 +1,287 @@
+﻿//
+// Copyright ical.net project maintainers and contributors.
+// Licensed under the MIT license.
+//
+
+using System;
+using System.Collections.Concurrent;
+using System.Globalization;
+using Ical.Net.DataTypes;
+using Ical.Net.Utility;
+using NodaTime;
+
+namespace Ical.Net.Evaluation;
+
+/// <summary>
+/// This class belongs to the evaluation layer of the library.
+/// It provides extension methods for the <see cref="CalDateTime"/> class.
+/// </summary>
+public static class CalDateTimeExtensions
+{
+    /// <summary>
+    /// This struct is used as a key for the cache.
+    /// It holds a weak reference to the <see cref="CalDateTime"/> object.
+    /// </summary>
+    private struct WeakCalDateTimeKey : IEquatable<WeakCalDateTimeKey>
+    {
+        private readonly WeakReference<CalDateTime> _weakRef;
+        private readonly int _hashCode;
+
+        public WeakCalDateTimeKey(CalDateTime calDateTime)
+        {
+            _weakRef = new WeakReference<CalDateTime>(calDateTime);
+            _hashCode = calDateTime.GetHashCode();
+        }
+
+        public bool TryGetTarget(out CalDateTime? target) => _weakRef.TryGetTarget(out target);
+
+        public bool Equals(WeakCalDateTimeKey other)
+        {
+            if (!_weakRef.TryGetTarget(out var thisTarget) || !other._weakRef.TryGetTarget(out var otherTarget))
+                return false;
+
+            return ReferenceEquals(thisTarget, otherTarget) || thisTarget.Equals(otherTarget);
+        }
+
+        public override bool Equals(object? obj) => obj is WeakCalDateTimeKey other && Equals(other);
+
+        public override int GetHashCode() => _hashCode;
+    }
+
+    /// <summary>
+    /// The cache for storing resolved <see cref="ZonedDateTime"/> objects for <see cref="CalDateTime"/> objects.
+    /// This is a thread-safe dictionary that uses weak references to avoid memory leaks.
+    /// </summary>
+    private static readonly ConcurrentDictionary<WeakCalDateTimeKey, ZonedDateTime> _cache = new();
+
+    /// <summary>
+    /// Stores a <see cref="ZonedDateTime"/> in the cache for the given <see cref="CalDateTime"/>.
+    /// </summary>
+    private static void AddToCache(CalDateTime calDateTime, ZonedDateTime zonedDateTime)
+    {
+        var key = new WeakCalDateTimeKey(calDateTime);
+        _cache[key] = zonedDateTime;
+    }
+
+    /// <summary>
+    /// Resolves a <see cref="CalDateTime"/> to a <see cref="ZonedDateTime"/>,
+    /// using the cache if possible.
+    /// </summary>
+    public static ZonedDateTime? ResolveZonedDateTime(CalDateTime calDateTime)
+    {
+        var key = new WeakCalDateTimeKey(calDateTime);
+
+        // Try to get from cache
+        if (_cache.TryGetValue(key, out var zoned))
+            return zoned;
+
+        // Compute and cache
+        ZonedDateTime? result = null;
+        if (calDateTime.IsUtc)
+        {
+            result = LocalDateTime.FromDateTime(calDateTime.Value).InZoneStrictly(DateTimeZone.Utc);
+        }
+        else if (!calDateTime.IsFloating)
+        {
+            var zone = DateUtil.GetZone(calDateTime.TzId!);
+            result = DateUtil.ToZonedDateTimeLeniently(calDateTime.Value, zone.Id);
+        }
+
+        if (result.HasValue)
+            _cache[key] = result.Value;
+
+        return result;
+    }
+
+    /// <summary>
+    /// Removes dead entries from the cache.
+    /// </summary>
+    public static void CleanupCache()
+    {
+        foreach (var key in _cache.Keys)
+        {
+            if (!key.TryGetTarget(out _))
+                _cache.TryRemove(key, out _);
+        }
+    }
+
+    /// <summary>
+    /// Converts the date/time to UTC (Coordinated Universal Time)
+    /// If <see cref="CalDateTime.IsFloating"/>==<see langword="true"/>
+    /// it means that the <see cref="CalDateTime.Value"/> is considered as local time for every timezone:
+    /// The returned <see cref="CalDateTime.Value"/> is unchanged, but with <see cref="DateTimeKind.Utc"/>.
+    /// </summary>
+    public static DateTime AsUtc(this CalDateTime calDateTime)
+        => DateTime.SpecifyKind(ToTimeZone(calDateTime, CalDateTime.UtcTzId).Value, DateTimeKind.Utc);
+
+    /// <summary>
+    /// Converts the <see cref="CalDateTime.Value"/> to a date/time
+    /// within the specified <see paramref="otherTzId"/> timezone.
+    /// <para/>
+    /// If <see cref="CalDateTime.IsFloating"/>==<see langword="true"/>
+    /// it means that the <see cref="CalDateTime.Value"/> is considered as local time for every timezone:
+    /// The returned <see cref="CalDateTime.Value"/> is unchanged and the <see paramref="otherTzId"/> is set as <see cref="TzId"/>.
+    /// </summary>
+    /// <param name="calDateTime">The CalDateTime instance.</param>
+    /// <param name="otherTzId">The target time zone ID, or null for floating.</param>
+    /// <returns>A new CalDateTime in the specified time zone.</returns>
+    public static CalDateTime ToTimeZone(this CalDateTime calDateTime, string? otherTzId)
+    {
+        if (otherTzId is null)
+            return new CalDateTime(calDateTime.Value, null, calDateTime.HasTime);
+
+        var zoned = ResolveZonedDateTime(calDateTime);
+
+        ZonedDateTime converted;
+        if (calDateTime.IsFloating)
+        {
+            // Make sure, we properly fix the time if it doesn't exist in the target tz.
+            converted = DateUtil.ToZonedDateTimeLeniently(calDateTime.Value, otherTzId);
+        }
+        else
+        {
+            converted = otherTzId != calDateTime.TzId
+                ? zoned!.Value.WithZone(DateUtil.GetZone(otherTzId))
+                : zoned!.Value;
+        }
+        var convCalDt = new CalDateTime(converted.ToDateTimeUnspecified(), otherTzId, calDateTime.HasTime);
+        AddToCache(convCalDt, converted);
+        return convCalDt;
+    }
+
+    /// <summary>
+    /// Add the specified <see cref="DataTypes.Duration"/> to this instance/>.
+    /// </summary>
+    /// <remarks>
+    /// In correspondence to RFC5545, the weeks and day fields of a duration are considered nominal durations while the time fields are considered exact values.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when attempting to add a time span to a date-only instance, 
+    /// and the time span is not a multiple of full days.
+    /// </exception>
+    public static CalDateTime Add(this CalDateTime calDateTime, DataTypes.Duration d)
+    {
+        if (!calDateTime.HasTime && d.HasTime)
+        {
+            throw new InvalidOperationException($"This instance represents a 'date-only' value '{calDateTime.ToString()}'. Only multiples of full days can be added to a 'date-only' instance, not '{d}'");
+        }
+
+        // RFC 5545 3.3.6:
+        // If the property permits, multiple "duration" values are specified by a COMMA-separated
+        // list of values.The format is based on the[ISO.8601.2004] complete representation basic
+        // format with designators for the duration of time.The format can represent nominal
+        // durations(weeks and days) and accurate durations(hours, minutes, and seconds).
+        // Note that unlike[ISO.8601.2004], this value type doesn't support the "Y" and "M"
+        // designators to specify durations in terms of years and months.
+        //
+        // The duration of a week or a day depends on its position in the calendar. In the case
+        // of discontinuities in the time scale, such as the change from standard time to daylight
+        // time and back, the computation of the exact duration requires the subtraction or
+        // addition of the change of duration of the discontinuity.Leap seconds MUST NOT be
+        // considered when computing an exact duration.When computing an exact duration, the
+        // greatest order time components MUST be added first, that is, the number of days MUST be
+        // added first, followed by the number of hours, number of minutes, and number of seconds.
+
+        (TimeSpan? nominalPart, TimeSpan? exactPart) dt;
+        if (calDateTime.TzId is null)
+            dt = (d.ToTimeSpanUnspecified(), null);
+        else
+            dt = (d.HasDate ? d.DateAsTimeSpan : null, d.HasTime ? d.TimeAsTimeSpan : null);
+
+        var newDateTime = calDateTime;
+        if (dt.nominalPart is not null)
+            newDateTime = new CalDateTime(newDateTime.Value.Add(dt.nominalPart.Value), calDateTime.TzId, calDateTime.HasTime);
+
+        if (dt.exactPart is not null)
+            newDateTime = new CalDateTime(AsUtc(newDateTime).Add(dt.exactPart.Value), CalDateTime.UtcTzId, calDateTime.HasTime);
+
+        if (calDateTime.TzId is not null)
+            // Convert to the original timezone even if already set to ensure we're not in a non-existing time.
+            newDateTime = ToTimeZone(newDateTime, calDateTime.TzId);
+
+        return newDateTime;
+    }
+
+    public static string ToString(this CalDateTime calDateTime, string? format, IFormatProvider? formatProvider)
+    {
+        formatProvider ??= CultureInfo.InvariantCulture;
+        var dateTimeOffset =
+            ResolveZonedDateTime(calDateTime)?.ToDateTimeOffset()
+            ?? DateUtil.ToZonedDateTimeLeniently(calDateTime.Value, calDateTime.TzId ?? string.Empty).ToDateTimeOffset();
+
+        // Use the .NET format options to format the DateTimeOffset
+        var tzIdString = calDateTime.TzId is not null ? $" {calDateTime.TzId}" : string.Empty;
+
+        return calDateTime.HasTime
+            ? $"{dateTimeOffset.ToString(format, formatProvider)}{tzIdString}"
+            : $"{DateOnly.FromDateTime(dateTimeOffset.Date).ToString(format ?? "d", formatProvider)}{tzIdString}";
+    }
+
+    internal static CalDateTime Copy(this CalDateTime calDateTime)
+    {
+        var copy = new CalDateTime(calDateTime.Date, calDateTime.Time, calDateTime.TzId);
+
+        if (calDateTime.IsFloating)
+            return copy;
+
+        AddToCache(copy, AsZonedDateTime(calDateTime));
+        return copy;
+    }
+
+    /// <summary>
+    /// Returns the NodaTime ZonedDateTime for the given CalDateTime.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Undefined for floating date/time.</exception>
+    internal static ZonedDateTime AsZonedDateTime(this CalDateTime calDateTime) => ResolveZonedDateTime(calDateTime) ?? throw new InvalidOperationException("Timezone not found.");
+
+    /// <summary>Returns a new <see cref="TimeSpan" /> from subtracting the specified <see cref="CalDateTime"/> from to the value of this instance.</summary>
+    public static TimeSpan SubtractExact(this CalDateTime dt, CalDateTime other) => dt.AsUtc() - other.AsUtc();
+
+    /// <summary>
+    /// Returns a new <see cref="DataTypes.Duration"/> from subtracting the specified <see cref="CalDateTime"/> from to the value of this instance.
+    /// </summary>
+    /// <exception cref="InvalidOperationException"></exception>
+    public static DataTypes.Duration Subtract(this CalDateTime dt, CalDateTime other)
+    {
+        if (dt.TzId is not null)
+            return SubtractExact(dt, other).ToDurationExact();
+
+        if (dt.HasTime != other.HasTime)
+            throw new InvalidOperationException($"Trying to calculate the difference between dates of different types. An instance of type DATE cannot be subtracted from a DATE-TIME and vice versa: {dt.ToString()} - {other.ToString()}");
+
+        return (dt.Value - other.Value).ToDuration();
+    }
+
+    /// <inheritdoc cref="DateTime.AddYears"/>
+    public static CalDateTime AddYears(this CalDateTime dt, int years)
+        => new(dt.Date.AddYears(years), dt.Time, dt.TzId);
+
+    /// <inheritdoc cref="DateTime.AddMonths"/>
+    public static CalDateTime AddMonths(this CalDateTime dt, int months)
+        => new(dt.Date.AddMonths(months), dt.Time, dt.TzId);
+
+    /// <inheritdoc cref="DateTime.AddDays"/>
+    public static CalDateTime AddDays(this CalDateTime dt, int days)
+        => new(dt.Date.AddDays(days), dt.Time, dt.TzId);
+
+    /// <inheritdoc cref="DateTime.AddHours"/>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when attempting to add a time span to a date-only instance, 
+    /// and the time span is not a multiple of full days.
+    /// </exception>
+    public static CalDateTime AddHours(this CalDateTime calDateTime, int hours) => Add(calDateTime, DataTypes.Duration.FromHours(hours));
+
+    /// <inheritdoc cref="DateTime.AddMinutes"/>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when attempting to add a time span to a date-only instance, 
+    /// and the time span is not a multiple of full days.
+    /// </exception>
+    public static CalDateTime AddMinutes(this CalDateTime calDateTime, int minutes) => Add(calDateTime, DataTypes.Duration.FromMinutes(minutes));
+
+    /// <inheritdoc cref="DateTime.AddSeconds"/>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when attempting to add a time span to a date-only instance, 
+    /// and the time span is not a multiple of full days.
+    /// </exception>
+    public static CalDateTime AddSeconds(this CalDateTime calDateTime, int seconds) => Add(calDateTime,DataTypes.Duration.FromSeconds(seconds));
+}

--- a/Ical.Net/Utility/DateUtil.cs
+++ b/Ical.Net/Utility/DateUtil.cs
@@ -5,6 +5,7 @@
 
 using System;
 using Ical.Net.DataTypes;
+using Ical.Net.Evaluation;
 using NodaTime;
 
 namespace Ical.Net.Utility;
@@ -80,7 +81,7 @@ internal static class DateUtil
         // Thus, TZID=America/New_York:20070311T023000 indicates March 11,
         // 2007 at 3:30 A.M. EDT (UTC-04:00), one hour after 1:30 A.M. EST
         // (UTC-05:00).
-        var lenientZonedDateTime = localDt.InZoneLeniently(zone).WithZone(zone);
+        var lenientZonedDateTime = localDt.InZoneLeniently(zone);
 
         return lenientZonedDateTime;
     }


### PR DESCRIPTION
Add evaluation layer to `CalDateTime` (WIP!)

* Introduced `CalDateTimeExtensions` for extension methods on `CalDateTime`
* Moved `CalDateTime` arithmetic and conversion methods to `CalDateTimeExtensions`
* Adjusted related classes with new references

Note: 
* `CalDateTimeExtensions.ToTimeZone` links the input `CalDateTime` with its `ZonedDateTime` representation, using a cache with weak references to `CalDateTime`. The cache is implemented with `ConditionalWeakTable<CalDateTime, ZonedDateTime>`.
* This way, once a `CalDateTime` is resolved to a `ZonedDateTime`, the `ZonedDateTime` will be used for further conversions.

Why cache `ZonedDateTime`?
* If a `CalDateTime` is instantiated from a lenient timezone conversion, this leniently determined value must not be converted again. 
* Lenient conversions resolve non-existing or ambiguous times caused by DST transitions.

Resolves #737
Resolves #677