### PR TITLE
Update publish.yml for manual version tagging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,23 +1,49 @@
 ﻿name: Publish
 # This job builds and publishes the package to NuGet.
 # It depends on the included tests job to complete successfully.
-# The version number is determined by the latest 'v*' tag for the main branch.
+# The version number is determined by the tag provided when manually triggering the workflow.
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      version_tag:
+        description: 'Enter an existing version tag to publish (e.g., "v5.1.0" or "v5.2.0-pre.1")'
+        required: true
+        type: string
 
 jobs:
   tests:
     runs-on: ubuntu-22.04
-    # ubuntu-latest = ubuntu-24.04 does not include mono (2025-08-01)
-
+    # ubuntu-latest = ubuntu-24.04 does not include mono needed for tests (2025-08-01)
+    outputs:
+      VERSION: ${{ steps.set_version.outputs.VERSION }}
     steps:
     - name: Checkout main
       uses: actions/checkout@v4
       with:
         fetch-depth: 0  # Fetch all history for all tags and branches
         ref: main
+
+    - name: Verify tag exists
+      run: |
+        if ! git rev-parse "${{ inputs.version_tag }}" >/dev/null 2>&1; then
+          echo "::error::Tag '${{ inputs.version_tag }}' does not exist."
+          echo "Available tags:"
+          git tag -l
+          exit 1
+        fi
+    - name: Set VERSION output
+      id: set_version
+      run: |
+         Version="${{ inputs.version_tag }}"
+         # Strip 'v' prefix for VERSION variable
+         Version="${Version#v}"
+         echo "VERSION=$Version" >> $GITHUB_ENV
+         echo "VERSION=$Version" >> $GITHUB_OUTPUT
+         echo "Version: $Version"
+
     - name: Set Git config for line endings
       run: git config --global core.autocrlf true
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
@@ -25,24 +51,21 @@ jobs:
           8.0.x
           6.0.x
           3.1.x
-    - name: Get version tag
-      # The latest tag for the selected branch.
-      # Get it and strip off any leading 'v' from the version tag
-      run: | 
-         Version=$(git tag --list 'v*' --sort=-v:refname | head -n 1 | sed 's/^v//')
-         echo "VERSION=$Version" >> $GITHUB_ENV
-         echo "Version: $Version"
+
     - name: Reset branch to specified tag
-      run: git reset --hard v${{ env.VERSION }}
+      run: git reset --hard ${{ inputs.version_tag }}
+
     - name: Restore dependencies
       run: dotnet restore
+
     - name: Build
       run: dotnet build --no-restore --configuration Release -p:nowarn=1591
+
     - name: Test
       run: dotnet test --no-build --configuration Release --verbosity quiet
 
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: tests
 
     steps:
@@ -51,39 +74,53 @@ jobs:
       with:
         fetch-depth: 0  # Fetch all history for all tags and branches
         ref: main
+
     - name: Set Git config for line endings
       run: git config --global core.autocrlf true
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
-          8.0.x    
-    - name: Get version tag
-        # The latest tag for the selected branch.
-        # Get it and strip off any leading 'v' from the version tag
-      run: | 
-           # The version variable will be e.g. like "5.1.0-pre.1" (pre-release) or "5.1.0" (release)
-           Version=$(git tag --list 'v*' --sort=-v:refname | head -n 1 | sed 's/^v//')
-           echo "VERSION=$Version" >> $GITHUB_ENV
-           echo "Version: $Version"
+          8.0.x
+
+    - name: Use verified version
+      run: |
+        # Reuse the version from tests job
+        echo "Using version: ${{ needs.tests.outputs.VERSION }}"
+        echo "VERSION=${{ needs.tests.outputs.VERSION }}" >> $GITHUB_ENV
+
     - name: Set version variables
       run: |
-           FileVersion=${VERSION%%-*}
-           AssemblyVersion=${VERSION%%.*}.0.0
-           echo "FILE_VERSION=$FileVersion" >> $GITHUB_ENV
-           echo "ASSEMBLY_VERSION=$AssemblyVersion" >> $GITHUB_ENV
-           echo "File Version: $FileVersion"
-           echo "Assembly Version: $AssemblyVersion"
+        FileVersion=${VERSION%%-*}
+        AssemblyVersion=${VERSION%%.*}.0.0
+        echo "FILE_VERSION=$FileVersion" >> $GITHUB_ENV
+        echo "ASSEMBLY_VERSION=$AssemblyVersion" >> $GITHUB_ENV
+        echo "File Version: $FileVersion"
+        echo "Assembly Version: $AssemblyVersion"
+
     - name: Reset branch to specified tag
-      run: git reset --hard v${{ env.VERSION }}
+      run: git reset --hard ${{ inputs.version_tag }}
+
     - name: Restore dependencies
       run: dotnet restore
+
     - name: Build and pack for publishing
       run: |  
-        # For version e.g. "5.1.0-pre.1", the FileVersion will be "5.1.0" and the AssemblyVersion will be "5.0.0"
-        # AssemblyVersion must only change for major releases
-        dotnet build --configuration Release Ical.Net/Ical.Net.csproj -p:Version=${{env.VERSION}} -p:FileVersion=${{env.FILE_VERSION}} -p:AssemblyVersion=${{env.ASSEMBLY_VERSION}} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -p:ContinuousIntegrationBuild=true
-        dotnet pack --configuration Release Ical.Net/Ical.Net.csproj -p:Version=${{env.VERSION}} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg --no-build -p:PackageVersion=${{env.VERSION}}
+        dotnet build --configuration Release Ical.Net/Ical.Net.csproj \
+          -p:Version=${{env.VERSION}} \
+          -p:FileVersion=${{env.FILE_VERSION}} \
+          -p:AssemblyVersion=${{env.ASSEMBLY_VERSION}} \
+          -p:IncludeSymbols=true \
+          -p:SymbolPackageFormat=snupkg \
+          -p:ContinuousIntegrationBuild=true
+
+        dotnet pack --configuration Release Ical.Net/Ical.Net.csproj \
+          -p:Version=${{env.VERSION}} \
+          -p:IncludeSymbols=true \
+          -p:SymbolPackageFormat=snupkg \
+          --no-build
+
     - name: Store artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -91,6 +128,11 @@ jobs:
         path: |
           Ical.Net/bin/Release/**/*.nupkg
           Ical.Net/bin/Release/**/*.snupkg
+
     - name: Push package to NuGet
       # Does not fail, if the package already exists
-      run: dotnet nuget push Ical.Net/bin/Release/Ical.Net.${{env.VERSION}}.nupkg --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      run: |
+        dotnet nuget push Ical.Net/bin/Release/Ical.Net.${{env.VERSION}}.nupkg \
+          --api-key ${{secrets.NUGET_API_KEY}} \
+          --source https://api.nuget.org/v3/index.json \
+          --skip-duplicate


### PR DESCRIPTION
The workflow now supports manual triggering with a specified version tag, replacing the previous automatic version detection. Added steps to verify the existence of the provided tag and set version variables.