### PR TITLE
Fix: Exception for Blazor WebAssembly using FileVersionInfo

### DIFF
--- a/Ical.Net/Constants.cs
+++ b/Ical.Net/Constants.cs
@@ -254,12 +254,21 @@ public static class LibraryMetadata
 
     private static string GetAssemblyVersion()
     {
+        string? version;
         var assembly = typeof(LibraryMetadata).Assembly;
-        var fileVersionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
+
         // Prefer the file version, but fall back to the assembly version if it's not available.
-        return fileVersionInfo.FileVersion
-               ?? assembly.GetName().Version?.ToString() // will only change for major versions
-               ?? "1.0.0.0";
+        try
+        {
+            var fileVersionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
+            version = fileVersionInfo.FileVersion;
+        }
+        catch (Exception)
+        {
+            version = assembly.GetName().Version?.ToString();
+        }
+
+        return version ?? "1.0.0.0";
     }
 }
 

--- a/Ical.Net/Constants.cs
+++ b/Ical.Net/Constants.cs
@@ -268,7 +268,7 @@ public static class LibraryMetadata
             version = assembly.GetName().Version?.ToString();
         }
 
-        return version ?? "1.0.0.0";
+        return version ?? "2.0";
     }
 }
 

--- a/Ical.Net/Constants.cs
+++ b/Ical.Net/Constants.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Reflection;
 
 namespace Ical.Net;
 
@@ -254,21 +255,9 @@ public static class LibraryMetadata
 
     private static string GetAssemblyVersion()
     {
-        string? version;
         var assembly = typeof(LibraryMetadata).Assembly;
-
-        // Prefer the file version, but fall back to the assembly version if it's not available.
-        try
-        {
-            var fileVersionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
-            version = fileVersionInfo.FileVersion;
-        }
-        catch (Exception)
-        {
-            version = assembly.GetName().Version?.ToString();
-        }
-
-        return version ?? "2.0";
+        var fileVersionAttribute = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>();
+        return fileVersionAttribute?.Version ?? assembly.GetName().Version?.ToString() ?? "1.0.0.0";
     }
 }
 

--- a/Ical.Net/Ical.Net.csproj
+++ b/Ical.Net/Ical.Net.csproj
@@ -5,7 +5,6 @@
         <AssemblyOriginatorKeyFile>..\IcalNetStrongnameKey.snk</AssemblyOriginatorKeyFile>
         <nullable>enable</nullable>
         <LangVersion>latest</LangVersion>
-        <AssemblyVersion>2.0</AssemblyVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="NodaTime" Version="3.2.2" />

--- a/Ical.Net/Ical.Net.csproj
+++ b/Ical.Net/Ical.Net.csproj
@@ -5,6 +5,7 @@
         <AssemblyOriginatorKeyFile>..\IcalNetStrongnameKey.snk</AssemblyOriginatorKeyFile>
         <nullable>enable</nullable>
         <LangVersion>latest</LangVersion>
+        <FileVersion>2.0</FileVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="NodaTime" Version="3.2.2" />

--- a/Ical.Net/Ical.Net.csproj
+++ b/Ical.Net/Ical.Net.csproj
@@ -5,7 +5,7 @@
         <AssemblyOriginatorKeyFile>..\IcalNetStrongnameKey.snk</AssemblyOriginatorKeyFile>
         <nullable>enable</nullable>
         <LangVersion>latest</LangVersion>
-        <FileVersion>2.0</FileVersion>
+        <AssemblyVersion>2.0</AssemblyVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="NodaTime" Version="3.2.2" />


### PR DESCRIPTION
Correct fallback solution when 'FileVersionInfo.GetVersionInfo' is not available on a specific platform. 
Synchronize versions.

Resolves #819 