### PR TITLE
GetOccurrences(): Fix NPE when returning a ToDo's occurrences that don't have a duration

### DIFF
--- a/Ical.Net.Tests/TodoTest.cs
+++ b/Ical.Net.Tests/TodoTest.cs
@@ -3,9 +3,11 @@
 // Licensed under the MIT license.
 //
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
 using NUnit.Framework;
 
@@ -217,5 +219,25 @@ public class TodoTest
         Assert.That(
             occurrences,
             Has.Count.EqualTo(items.Count));
+    }
+
+    [Test, Category("Todo")]
+    public void Todo_WithFutureStart_AndNoDuration_ShouldSucceed()
+    {
+        var today = CalDateTime.Today;
+
+        var todo = new Todo
+        {
+            Start = today,
+            RecurrenceRules = [new RecurrencePattern("FREQ=DAILY")]
+        };
+
+        // periodStart is in the future, so filtering the first occurrence will also require
+        // looking at the todo's duration, which is unset/null. It must therefore be ignored.
+        var firstOccurrence = todo.GetOccurrences(today.AddDays(2)).FirstOrDefault();
+
+        Assert.That(firstOccurrence, Is.Not.Null);
+        Assert.That(firstOccurrence.Period.StartTime, Is.Not.Null);
+        Assert.That(firstOccurrence.Period.Duration, Is.Null);
     }
 }

--- a/Ical.Net/Evaluation/RecurrenceUtil.cs
+++ b/Ical.Net/Evaluation/RecurrenceUtil.cs
@@ -39,7 +39,7 @@ internal static class RecurrenceUtil
                 let effectiveEndTime = p.EffectiveEndTime
                 where
                     p.StartTime.GreaterThanOrEqual(periodStart)
-                    || effectiveEndTime.GreaterThan(periodStart)
+                    || ((effectiveEndTime != null) && effectiveEndTime.GreaterThan(periodStart))
                 select p;
         }
 


### PR DESCRIPTION
TODO's don't necessarily have a duration, so the occurrences returned by `GetOccurrences` may return an `EffectiveDuration` of `null`. Such cases caused an NPE that is fixed with this PR.

fixes #824