### PR TITLE
Use UTF-8 Encoding Without BOM by Default in All Serializers

### DIFF
--- a/Ical.Net/Serialization/ISerializer.cs
+++ b/Ical.Net/Serialization/ISerializer.cs
@@ -14,6 +14,6 @@ public interface ISerializer : IServiceProvider
     SerializationContext SerializationContext { get; set; }
 
     Type TargetType { get; }
-    void Serialize(object obj, Stream stream, Encoding encoding);
+    void Serialize(object obj, Stream stream, Encoding? encoding = null);
     object? Deserialize(Stream stream, Encoding encoding);
 }

--- a/Ical.Net/Serialization/SerializerBase.cs
+++ b/Ical.Net/Serialization/SerializerBase.cs
@@ -43,13 +43,28 @@ public abstract class SerializerBase : IStringSerializer
         return obj;
     }
 
-    public void Serialize(object obj, Stream stream, Encoding encoding)
+    /// <summary>
+    /// Serializes the specified object to the provided stream using the specified encoding.
+    /// </summary>
+    /// <remarks>This method writes the serialized representation of the object to the stream without closing
+    /// the stream, allowing the caller to continue using it.
+    /// bytes.</remarks>
+    /// <param name="obj">The object to serialize. Must not be null.</param>
+    /// <param name="stream">The stream to which the serialized data will be written. Must be writable.</param>
+    /// <param name="encoding">
+    /// The character encoding to use for serialization.
+    /// If <see langword="null"/> or missing, UTF-8 encoding
+    /// without a byte order mark (BOM) is used.
+    /// A BOM is incompatible with many iCalendar apps.
+    /// </param>
+    public void Serialize(object obj, Stream stream, Encoding? encoding = null)
     {
-        // NOTE: we don't use a 'using' statement here because
-        // we don't want the stream to be closed by this serialization.
-        // Fixes bug #3177278 - Serialize closes stream
+        // Ensure that no BOM is written to the stream
+        encoding ??= new UTF8Encoding(false);
 
-        const int defaultBuffer = 1024;     //This is StreamWriter's built-in default buffer size
+        //This is StreamWriter's built-in default buffer size
+        const int defaultBuffer = 1024;
+        // Important: leave the stream open so that the caller can continue to use it
         using var sw = new StreamWriter(stream, encoding, defaultBuffer, leaveOpen: true);
 
         // Push the current object onto the serialization stack


### PR DESCRIPTION
Summary:
Changed the default encoding for all serializers to UTF-8 without BOM (`new UTF8Encoding(false)`). This ensures compatibility with iCalendar consumers that do not support BOM and provides consistent encoding across all serialization operations.

Affected serializers:
All serializers inheriting from `SerializerBase`, `ComponentSerializer`, `EncodableDataTypeSerializer`, or `DataTypeSerializer` now default to UTF-8 without BOM unless an explicit encoding is provided.

- **Directly from `SerializerBase`:**
  - `SimpleDeserializer`
  - `ComponentSerializer`
  - `DataMapSerializer`
  - `DataTypes.DataTypeSerializer`
  - `DataTypes.DateTimeSerializer`
  - `DataTypes.DurationSerializer`
  - `GenericListSerializer`
  - `ParameterSerializer`
  - `PropertySerializer`

- **From `ComponentSerializer`:**
  - `CalendarSerializer`
  - `EventSerializer`
  - `SerializerFactory`

- **From `EncodableDataTypeSerializer` or `DataTypeSerializer`:**
  - `DataTypes.AttachmentSerializer`
  - `DataTypes.EnumSerializer`
  - `DataTypes.GeographicLocationSerializer`
  - `DataTypes.IntegerSerializer`
  - `DataTypes.PeriodListSerializer`
  - `DataTypes.PeriodSerializer`
  - `DataTypes.RecurrencePatternSerializer`
  - `DataTypes.StringSerializer`
  - `DataTypes.UriSerializer`
  - `DataTypes.UtcOffsetSerializer`
  - `DataTypes.WeekDaySerializer`

**Rationale:**
Ensures all iCalendar output is encoded in UTF-8 without BOM by default, as required by many consumers.

Resolves #823 