### PR TITLE
fix: Evaluation of `EXDATE` when date-only while `DTSTART` is date-time

### DIFF
--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -4093,4 +4093,38 @@ END:VCALENDAR";
 
         Assert.That(occurrences, Is.EqualTo(expectedDates));
     }
+
+    [Test]
+    public void GetOccurrences_WithMixedKindExDates_ShouldProperlyConsiderAll()
+    {
+        var cal = new CalendarEvent
+        {
+            Start = new CalDateTime("20250702T100000"),
+            End = new CalDateTime("20250702T200000"),
+            RecurrenceRules = [new RecurrencePattern("FREQ=DAILY")],
+        };
+
+
+        // Should be considered only at the exact time
+        cal.ExceptionDates.Add(new CalDateTime("20250703T000000"));
+
+        // Should be considered all-day
+        cal.ExceptionDates.Add(new CalDateTime("20250703"));
+
+        // Should be considered only at the exact time
+        cal.ExceptionDates.Add(new CalDateTime("20250703T150000"));
+
+        var occurrences = cal.GetOccurrences()
+            .Take(2)
+            .Select(o => o.Period.StartTime)
+            .ToList();
+
+        var expectedDates = new[]
+        {
+            new CalDateTime("20250702T100000"),
+            new CalDateTime("20250704T100000")
+        };
+
+        Assert.That(occurrences, Is.EqualTo(expectedDates));
+    }
 }

--- a/Ical.Net/Evaluation/RecurringEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurringEvaluator.cs
@@ -46,7 +46,7 @@ public class RecurringEvaluator : Evaluator
     }
 
     /// <summary> Evaluates the RDate component. </summary>
-    protected IEnumerable<Period> EvaluateRDate(CalDateTime referenceDate, CalDateTime? periodStart)
+    protected IEnumerable<Period> EvaluateRDate(CalDateTime? periodStart)
     {
         var recurrences = Recurrable.RecurrenceDates
                 .GetAllPeriodsByKind(PeriodKind.Period, PeriodKind.DateOnly, PeriodKind.DateTime)
@@ -85,9 +85,9 @@ public class RecurringEvaluator : Evaluator
     /// <summary>
     /// Evaluates the ExDate component.
     /// </summary>
-    /// <param name="referenceDate"></param>
     /// <param name="periodStart">The beginning date of the range to evaluate.</param>
-    private IEnumerable<Period> EvaluateExDate(CalDateTime referenceDate, CalDateTime? periodStart, params PeriodKind[] periodKinds)
+    /// <param name="periodKinds">The period kinds to be returned. Used as a filter.</param>
+    private IEnumerable<Period> EvaluateExDate(CalDateTime? periodStart, params PeriodKind[] periodKinds)
     {
         var exDates = Recurrable.ExceptionDates.GetAllPeriodsByKind(periodKinds)
             .AsEnumerable();
@@ -109,7 +109,7 @@ public class RecurringEvaluator : Evaluator
             ? [new Period(referenceDate)]
             : EvaluateRRule(referenceDate, periodStart, options);
 
-        var rdateOccurrences = EvaluateRDate(referenceDate, periodStart);
+        var rdateOccurrences = EvaluateRDate(periodStart);
 
         var exRuleExclusions = EvaluateExRule(referenceDate, periodStart, options);
 
@@ -119,8 +119,8 @@ public class RecurringEvaluator : Evaluator
         // before `periodStart`. We therefore start 2 days earlier (2 for safety regarding the TZ).
         // DISCUSS: Should we support date-only EXDATEs being mixed with date-time DTSTARTs at all? What
         // if one has a time zone and the other doesn't? Many details are unclear.
-        var exDateExclusionsDateOnly = EvaluateExDate(referenceDate, periodStart?.AddDays(-2), PeriodKind.DateOnly);
-        var exDateExclusionsDateTime = EvaluateExDate(referenceDate, periodStart, PeriodKind.DateTime);
+        var exDateExclusionsDateOnly = EvaluateExDate(periodStart?.AddDays(-2), PeriodKind.DateOnly);
+        var exDateExclusionsDateTime = EvaluateExDate(periodStart, PeriodKind.DateTime);
 
         var periods =
             rruleOccurrences

--- a/Ical.Net/Evaluation/RecurringEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurringEvaluator.cs
@@ -112,7 +112,14 @@ public class RecurringEvaluator : Evaluator
         var rdateOccurrences = EvaluateRDate(referenceDate, periodStart);
 
         var exRuleExclusions = EvaluateExRule(referenceDate, periodStart, options);
-        var exDateExclusions = EvaluateExDate(referenceDate, periodStart);
+
+        // EXDATEs could contain date-only entries while DTSTART is date-time. Probably this isn't supported
+        // by the RFC, but it seems to be used in the wild (see https://github.com/ical-org/ical.net/issues/829).
+        // So we must make sure to return all-day EXDATEs that could overlap with recurrences, even if the day starts
+        // before `periodStart`. We therefore start 2 days earlier (2 for safety regarding the TZ).
+        // DISCUSS: Should we support date-only EXDATEs being mixed with date-time DTSTARTs at all? What
+        // if one has a time zone and the other doesn't? Many details are unclear.
+        var exDateExclusions = EvaluateExDate(referenceDate, periodStart?.AddDays(-2));
 
         var periods =
             rruleOccurrences


### PR DESCRIPTION
Fix multiple issues related to the evaluation of `EXDATE`s:

* If `EXDATE`s of type `DATE`-only were used together with `DTSTART` of type `DATE-TIME`, and `GetOccurrences()` was used with a `periodStart` on the day of an `EXDATE`, then this EXDATE could be ignored.
* If `EXDATE`s of type `DATE` were mixed with those of type `DATE-TIME`, then the order could be confused, which could cause individual `EXDATE`s to be ignored

Its not clear from RFC 5545, whether EXDATEs and DTSTARTs of mixed, mismatching value types should be supported. Probably it shouldn't, because many things become unclear in such cases, especially when DTSTART has a time zone. Anyhow, because it seems to be used in the wild and has been supported in v4, we should probably continue to support it.

fixes #829, #832