### PR TITLE
Fix `GetOccurrences(periodStart)` to return still active occurrences

### DIFF
--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -4170,4 +4170,42 @@ END:VCALENDAR";
 
         Assert.That(occurrences, Is.EqualTo(expectedDates));
     }
+
+    [Test]
+    public void GetOccurrences_WithPeriodStart_ShouldConsiderDurationCorrectly()
+    {
+        var cal = Calendar.Load("""
+            BEGIN:VCALENDAR
+            BEGIN:VEVENT
+            DTSTART:20250701T000000
+            DURATION:P3D
+            RRULE:FREQ=WEEKLY
+            RDATE;VALUE=PERIOD:20250707T000000/P4D,20250709T000000/P1D
+            RDATE;VALUE=DATE:20250706T000000,20250710T000000
+            END:VEVENT
+            END:VCALENDAR
+            """)!;
+
+        var occurrences = cal.GetOccurrences(new CalDateTime("20250710T120000"))
+            .Select(o => o.Period.StartTime)
+            .Take(5)
+            .ToList();
+
+        var expectedDates = new string[]
+        {
+            // RDATE
+            "20250707T000000",
+            // RRULE
+            "20250708T000000",
+            // RDATE
+            "20250710T000000",
+            // RRULE
+            "20250715T000000",
+            // RRULE
+            "20250722T000000",
+        }.Select(x => new CalDateTime(x))
+        .ToList();
+
+        Assert.That(occurrences, Is.EqualTo(expectedDates));
+    }
 }

--- a/Ical.Net/CalendarComponents/RecurringComponent.cs
+++ b/Ical.Net/CalendarComponents/RecurringComponent.cs
@@ -22,7 +22,7 @@ namespace Ical.Net.CalendarComponents;
 /// RRULEs, RDATE, EXRULEs, and EXDATEs, as well as the DTSTART
 /// for the recurring item (all recurring items must have a DTSTART).
 /// </remarks>
-public class RecurringComponent : UniqueComponent, IRecurringComponent
+public abstract class RecurringComponent : UniqueComponent, IRecurringComponent
 {
     public static IEnumerable<IRecurringComponent> SortByDate(IEnumerable<IRecurringComponent> list) => SortByDate<IRecurringComponent>(list);
 
@@ -151,17 +151,15 @@ public class RecurringComponent : UniqueComponent, IRecurringComponent
     /// </summary>
     public virtual ICalendarObjectList<Alarm> Alarms => new CalendarObjectListProxy<Alarm>(Children);
 
-    private RecurringEvaluator? _evaluator;
+    public abstract IEvaluator? Evaluator { get; }
 
-    public virtual IEvaluator? Evaluator => _evaluator;
-
-    public RecurringComponent()
+    protected RecurringComponent()
     {
         Initialize();
         EnsureProperties();
     }
 
-    public RecurringComponent(string name) : base(name)
+    protected RecurringComponent(string name) : base(name)
     {
         Initialize();
         EnsureProperties();
@@ -169,7 +167,6 @@ public class RecurringComponent : UniqueComponent, IRecurringComponent
 
     private void Initialize()
     {
-        _evaluator = new RecurringEvaluator(this);
         ExceptionDates = new ExceptionDates(ExceptionDatesPeriodLists);
         RecurrenceDates = new RecurrenceDates(RecurrenceDatesPeriodLists);
     }

--- a/Ical.Net/Evaluation/EventEvaluator.cs
+++ b/Ical.Net/Evaluation/EventEvaluator.cs
@@ -18,6 +18,8 @@ public class EventEvaluator : RecurringEvaluator
 {
     protected CalendarEvent CalendarEvent => (CalendarEvent) Recurrable;
 
+    protected override Duration? DefaultDuration => CalendarEvent.EffectiveDuration;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="EventEvaluator"/> class.
     /// </summary>

--- a/Ical.Net/Evaluation/RecurringEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurringEvaluator.cs
@@ -12,11 +12,11 @@ using Ical.Net.Utility;
 
 namespace Ical.Net.Evaluation;
 
-public class RecurringEvaluator : Evaluator
+public abstract class RecurringEvaluator : Evaluator
 {
     protected IRecurrable Recurrable { get; set; }
 
-    public RecurringEvaluator(IRecurrable obj)
+    protected RecurringEvaluator(IRecurrable obj)
     {
         Recurrable = obj;
     }

--- a/Ical.Net/Evaluation/RecurringEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurringEvaluator.cs
@@ -16,6 +16,8 @@ public abstract class RecurringEvaluator : Evaluator
 {
     protected IRecurrable Recurrable { get; set; }
 
+    protected abstract Duration? DefaultDuration { get; }
+
     protected RecurringEvaluator(IRecurrable obj)
     {
         Recurrable = obj;
@@ -32,10 +34,13 @@ public abstract class RecurringEvaluator : Evaluator
         if (!Recurrable.RecurrenceRules.Any())
             return [];
 
+        var d = this.DefaultDuration;
+        var effPeriodStart = (d != null) ? periodStart?.AddLeniently(-d.Value) : periodStart;
+
         var periodsQueries = Recurrable.RecurrenceRules.Select(rule =>
         {
             var ruleEvaluator = new RecurrencePatternEvaluator(rule);
-            return ruleEvaluator.Evaluate(referenceDate, periodStart, options);
+            return ruleEvaluator.Evaluate(referenceDate, effPeriodStart, options);
         })
             // Enumerate the outer sequence (not the inner sequences of periods themselves) now to ensure
             // the initialization code is run, including validation and error handling.
@@ -46,33 +51,28 @@ public abstract class RecurringEvaluator : Evaluator
     }
 
     /// <summary> Evaluates the RDate component. </summary>
-    protected IEnumerable<Period> EvaluateRDate(CalDateTime? periodStart)
-    {
-        var recurrences = Recurrable.RecurrenceDates
-                .GetAllPeriodsByKind(PeriodKind.Period, PeriodKind.DateOnly, PeriodKind.DateTime)
-                .AsEnumerable();
-
-        if (periodStart != null)
-            recurrences = recurrences.Where(p => p.StartTime.GreaterThanOrEqual(periodStart));
-
-        return new SortedSet<Period>(recurrences);
-    }
+    protected IEnumerable<Period> EvaluateRDate()
+        => new SortedSet<Period>(Recurrable.RecurrenceDates
+                .GetAllPeriodsByKind(PeriodKind.Period, PeriodKind.DateOnly, PeriodKind.DateTime));
 
     /// <summary>
     /// Evaluates the ExRule component.
     /// </summary>
     /// <param name="referenceDate"></param>
-    /// <param name="periodStart">The beginning date of the range to evaluate.</param>
     /// <param name="options"></param>
-    protected IEnumerable<Period> EvaluateExRule(CalDateTime referenceDate, CalDateTime? periodStart, EvaluationOptions? options)
+    private IEnumerable<Period> EvaluateExRule(CalDateTime referenceDate, EvaluationOptions? options)
     {
         if (!Recurrable.ExceptionRules.Any())
             return [];
 
+        // We don't apply periodStart here, because calculating it would be quire complex, because
+        // RDATE's may have arbitrary durations.
+        CalDateTime? effPeriodStart = null;
+
         var exRuleEvaluatorQueries = Recurrable.ExceptionRules.Select(exRule =>
         {
             var exRuleEvaluator = new RecurrencePatternEvaluator(exRule);
-            return exRuleEvaluator.Evaluate(referenceDate, periodStart, options);
+            return exRuleEvaluator.Evaluate(referenceDate, effPeriodStart, options);
         })
             // Enumerate the outer sequence (not the inner sequences of periods themselves) now to ensure
             // the initialization code is run, including validation and error handling.
@@ -85,18 +85,9 @@ public abstract class RecurringEvaluator : Evaluator
     /// <summary>
     /// Evaluates the ExDate component.
     /// </summary>
-    /// <param name="periodStart">The beginning date of the range to evaluate.</param>
     /// <param name="periodKinds">The period kinds to be returned. Used as a filter.</param>
-    private IEnumerable<Period> EvaluateExDate(CalDateTime? periodStart, params PeriodKind[] periodKinds)
-    {
-        var exDates = Recurrable.ExceptionDates.GetAllPeriodsByKind(periodKinds)
-            .AsEnumerable();
-
-        if (periodStart != null)
-            exDates = exDates.Where(p => p.StartTime.GreaterThanOrEqual(periodStart));
-
-        return new SortedSet<Period>(exDates);
-    }
+    private IEnumerable<Period> EvaluateExDate(params PeriodKind[] periodKinds)
+        => new SortedSet<Period>(Recurrable.ExceptionDates.GetAllPeriodsByKind(periodKinds));
 
     public override IEnumerable<Period> Evaluate(CalDateTime referenceDate, CalDateTime? periodStart, EvaluationOptions? options)
     {
@@ -109,23 +100,39 @@ public abstract class RecurringEvaluator : Evaluator
             ? [new Period(referenceDate)]
             : EvaluateRRule(referenceDate, periodStart, options);
 
-        var rdateOccurrences = EvaluateRDate(periodStart);
-
-        var exRuleExclusions = EvaluateExRule(referenceDate, periodStart, options);
-
-        // EXDATEs could contain date-only entries while DTSTART is date-time. Probably this isn't supported
-        // by the RFC, but it seems to be used in the wild (see https://github.com/ical-org/ical.net/issues/829).
-        // So we must make sure to return all-day EXDATEs that could overlap with recurrences, even if the day starts
-        // before `periodStart`. We therefore start 2 days earlier (2 for safety regarding the TZ).
-        var exDateExclusionsDateOnly = new HashSet<DateOnly>(EvaluateExDate(periodStart?.AddDays(-2), PeriodKind.DateOnly)
-            .Select(x => x.StartTime.Date));
-
-        var exDateExclusionsDateTime = EvaluateExDate(periodStart, PeriodKind.DateTime);
+        var rdateOccurrences = EvaluateRDate();
 
         var periods =
             rruleOccurrences
             .OrderedMerge(rdateOccurrences)
-            .OrderedDistinct()
+            .OrderedDistinct();
+
+        // Apply the default duration, if any.
+        var d = this.DefaultDuration;
+        if (d != null)
+            periods = periods.Select(p => (p.EffectiveDuration != null) ? p : new Period(p.StartTime, d.Value));
+
+        // Filter by periodStart
+        if (periodStart is not null)
+        {
+            // Include occurrences that start before periodStart, but end after periodStart.
+            periods = periods.Where(p => (p.StartTime >= periodStart) || (p.EffectiveEndTime > periodStart));
+        }
+
+        var exRuleExclusions = EvaluateExRule(referenceDate, options);
+
+        // EXDATEs could contain date-only entries while DTSTART is date-time. This case isn't clearly defined
+        // by the RFC, but it seems to be used in the wild (see https://github.com/ical-org/ical.net/issues/829).
+        // Different systems handle this differently, e.g. Outlook excludes any occurrences where the date portion
+        // matches an date-only EXDATE, while Google Calendar ignores such EXDATEs completely, if DTSTART is date-time.
+        // In Ical.Net we follow the Outlook approach, which requires us to handle date-only EXDATEs separately.
+        var exDateExclusionsDateOnly = new HashSet<DateOnly>(EvaluateExDate(PeriodKind.DateOnly)
+            .Select(x => x.StartTime.Date));
+
+        var exDateExclusionsDateTime = EvaluateExDate(PeriodKind.DateTime);
+
+        // Exclude occurrences according to EXRULEs and EXDATEs.
+        periods = periods
             .OrderedExclude(exRuleExclusions)
             .OrderedExclude(exDateExclusionsDateTime)
 
@@ -136,8 +143,9 @@ public abstract class RecurringEvaluator : Evaluator
             // The order of dates in the EXDATEs doesn't necessarily match the order of dates returned by RDATEs
             // due to RDATEs could have different time zones. We therefore use a regular `.Where()` to look up
             // the EXDATEs in the HashSet rather than using `.OrderedExclude()`, which would require correct ordering.
-            .Where(dt => !exDateExclusionsDateOnly.Contains(dt.StartTime.Date))
+            .Where(dt => !exDateExclusionsDateOnly.Contains(dt.StartTime.Date));
 
+        periods = periods
             // Convert overflow exceptions to expected ones.
             .HandleEvaluationExceptions();
 

--- a/Ical.Net/Evaluation/TimeZoneInfoEvaluator.cs
+++ b/Ical.Net/Evaluation/TimeZoneInfoEvaluator.cs
@@ -18,5 +18,7 @@ public class TimeZoneInfoEvaluator : RecurringEvaluator
         set => Recurrable = value;
     }
 
+    protected override Duration? DefaultDuration => null;
+
     public TimeZoneInfoEvaluator(IRecurrable tzi) : base(tzi) { }
 }

--- a/Ical.Net/Evaluation/TodoEvaluator.cs
+++ b/Ical.Net/Evaluation/TodoEvaluator.cs
@@ -15,6 +15,8 @@ public class TodoEvaluator : RecurringEvaluator
 {
     protected Todo Todo => Recurrable as Todo ?? throw new InvalidOperationException();
 
+    protected override Duration? DefaultDuration => Todo.EffectiveDuration;
+
     public TodoEvaluator(Todo todo) : base(todo) { }
 
     internal IEnumerable<Period> EvaluateToPreviousOccurrence(CalDateTime completedDate, CalDateTime currDt, EvaluationOptions? options)

--- a/Ical.Net/Utility/DateUtil.cs
+++ b/Ical.Net/Utility/DateUtil.cs
@@ -132,4 +132,12 @@ internal static class DateUtil
     /// </remarks>
     internal static DataTypes.Duration ToDuration(this TimeSpan timeSpan)
         => DataTypes.Duration.FromTimeSpan(timeSpan);
+
+    internal static CalDateTime AddLeniently(this CalDateTime dt, DataTypes.Duration d)
+    {
+        if (d.HasTime && !dt.HasTime)
+            dt = new CalDateTime(dt.Date, TimeOnly.MinValue);
+
+        return dt.Add(d);
+    }
 }


### PR DESCRIPTION
See #825: According to existing code, `GetOccurrences(periodStart)` seems to be intended to return not only those recurrences that start at or after `periodStart`, but also those still active at that date-time. There's has been some discussion in #825 about whether to follow the original intention or rather just return those that _start_ at or after `periodStart`.

This PR introduces a new evaluation option that allows to control the intended behavior. By default only those are returned that start at or after `periodStart`. By setting the new option `EvaluationOptions.IncludeStillActiveOccurrences`, also those are returned that started in the past but are still active at the given point in time.

Fixes #825 