### PR TITLE
Fix `GetOccurrences()` not properly dealing with `periodStart`'s TZ

### DIFF
--- a/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
@@ -117,7 +117,6 @@ public class RecurrencePatternEvaluator : Evaluator
     private IEnumerable<CalDateTime> GetDates(CalDateTime seed, CalDateTime? periodStart, RecurrencePattern pattern,
          EvaluationOptions? options)
     {
-        // In the first step, we work with DateTime values, so we need to convert the CalDateTime to DateTime
         var originalDate = seed;
         var seedCopy = seed;
         var periodStartDt = periodStart?.ToTimeZone(seed.TzId);

--- a/Ical.Net/Evaluation/RecurrenceUtil.cs
+++ b/Ical.Net/Evaluation/RecurrenceUtil.cs
@@ -22,14 +22,7 @@ internal static class RecurrenceUtil
             return [];
         }
 
-        // Ensure the start time is associated with the object being queried
         var start = recurrable.Start;
-
-        // Change the time zone of periodStart as needed
-        // so they can be used during the evaluation process.
-
-        if (periodStart != null)
-            periodStart = new CalDateTime(periodStart.Date, periodStart.Time, start.TzId);
 
         var periods = evaluator.Evaluate(start, periodStart, options);
         if (periodStart != null)


### PR DESCRIPTION
`GetOccurrences()` used to ignore the TZ of `periodStart`, which is fixed by this PR.

fixes #840
