### PR TITLE
Occurrence issue test

### DIFF
--- a/Ical.Net.Tests/OccurrenceIssue.cs
+++ b/Ical.Net.Tests/OccurrenceIssue.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Linq;
+using Ical.Net.CalendarComponents;
+using Ical.Net.DataTypes;
+using NUnit.Framework;
+
+namespace Ical.Net.Tests;
+
+[TestFixture]
+public class OccurrenceIssue
+{
+    [Test, Explicit]
+    public void MissingOccurrences()
+    {
+        var cal = Calendar.Load("""
+            BEGIN:VCALENDAR
+            PRODID:-//Google Inc//Google Calendar 70.9054//EN
+            VERSION:2.0
+            CALSCALE:GREGORIAN
+            METHOD:PUBLISH
+            X-WR-CALNAME:Non-Critical Support Roster
+            X-WR-TIMEZONE:UTC
+            BEGIN:VEVENT
+            DTSTART;VALUE=DATE:20251103
+            DTEND;VALUE=DATE:20251124
+            RRULE:FREQ=WEEKLY;WKST=MO;INTERVAL=48;BYDAY=MO
+            DTSTAMP:20250912T100327Z
+            UID:00p0ja7t2446ja22sl02ah2uun@google.com
+            CREATED:20250214T230308Z
+            LAST-MODIFIED:20250409T173619Z
+            SEQUENCE:1
+            STATUS:CONFIRMED
+            SUMMARY:QWERTY
+            TRANSP:TRANSPARENT
+            END:VEVENT
+            BEGIN:VEVENT
+            DTSTART;VALUE=DATE:20251103
+            DTEND;VALUE=DATE:20251124
+            DTSTAMP:20250912T100327Z
+            UID:00p0ja7t2446ja22sl02ah2uun@google.com
+            RECURRENCE-ID;VALUE=DATE:20251103
+            CREATED:20250214T230308Z
+            LAST-MODIFIED:20250428T170953Z
+            SEQUENCE:1
+            STATUS:CONFIRMED
+            SUMMARY:QWERTY
+            TRANSP:TRANSPARENT
+            END:VEVENT
+            END:VCALENDAR
+            """)!;
+
+        Console.WriteLine("Events:");
+        foreach (var e in cal.Events.OrderBy(x=>x.Start))
+        {
+            Console.WriteLine($"\t{e.Uid.Substring(0,7)} {e.Start.Value} {e.End.Value} {e.Summary}");
+        }
+
+        var dt = new CalDateTime(DateOnly.FromDateTime(new DateTime(2026,1,1)));
+        var occurrences = cal
+            .GetOccurrences<CalendarEvent>()
+            .TakeWhile(p => p.Period.StartTime <= dt);
+
+        Console.WriteLine("Occurrences:");
+        foreach (var o in occurrences)
+        {
+            var e = (CalendarEvent)o.Source;
+            Console.WriteLine($"\t{e.Uid.Substring(0,7)} {o.Period.StartTime.Value} {o.Period.EffectiveEndTime.Value} {e.Summary}");
+        }
+
+        Assert.That(occurrences, Is.Not.Empty);
+    }
+}


### PR DESCRIPTION
The calendar data used with the test originates from a Google Calender ICS url. I removed a few properties with PID data and remove many events.

The test fails is it does not return occurrences in 2025. However, in the original ICS many events results in occurrences for 2025. 



With v5.1.0 the console output is:

```
Events:
	00p0ja7 11/3/2025 12:00:00 AM 11/24/2025 12:00:00 AM QWERTY
	00p0ja7 11/3/2025 12:00:00 AM 11/24/2025 12:00:00 AM QWERTY
Occurrences:
	10/5/2026 12:00:00 AM
	10/5/2026 12:00:00 AM
	10/5/2026 12:00:00 AM
```

With v4 is does return an occurrence for 2025.


When I remove the `.OrderedDistinct()` call in `GetOccurrences<T>` I see too many results but I do see the occurrence there. 

Maybe a issue in the `EqualityComparer`?