### PR TITLE
Mark classes and interfaces using `EXRULE` as obsolete

### DIFF
--- a/Ical.Net/CalendarComponents/IRecurrable.cs
+++ b/Ical.Net/CalendarComponents/IRecurrable.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 //
 
+using System;
 using System.Collections.Generic;
 using Ical.Net.DataTypes;
 using Ical.Net.Evaluation;
@@ -17,7 +18,10 @@ public interface IRecurrable : IGetOccurrences
     CalDateTime? Start { get; set; }
 
     ExceptionDates ExceptionDates { get; }
+
+    [Obsolete("EXRULE is marked as deprecated in RFC 5545 and will be removed in a future version")]
     IList<RecurrencePattern> ExceptionRules { get; set; }
+
     RecurrenceDates RecurrenceDates { get; }
     IList<RecurrencePattern> RecurrenceRules { get; set; }
     CalDateTime? RecurrenceId { get; set; }

--- a/Ical.Net/CalendarComponents/RecurringComponent.cs
+++ b/Ical.Net/CalendarComponents/RecurringComponent.cs
@@ -80,6 +80,7 @@ public abstract class RecurringComponent : UniqueComponent, IRecurringComponent
 
     public virtual ExceptionDates ExceptionDates { get; internal set; } = null!;
 
+    [Obsolete("EXRULE is marked as deprecated in RFC 5545 and will be removed in a future version")]
     public virtual IList<RecurrencePattern> ExceptionRules
     {
         get => Properties.GetMany<RecurrencePattern>("EXRULE");

--- a/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
@@ -618,7 +618,6 @@ public class RecurrencePatternEvaluator : Evaluator
 
         //When we manage weekly recurring pattern and we have boundary case:
         //Weekdays: Dec 31, Jan 1, Feb 1, Mar 1, Apr 1, May 1, June 1, Dec 31 - It's the 53th week of the year, but all another are 1st week number.
-        //So we need an EXRULE for this situation, but only for weekly events
         while (currentWeekNo == weekNo || (nextWeekNo < weekNo && currentWeekNo == nextWeekNo && pattern.Frequency == FrequencyType.Weekly))
         {
             if ((byWeekNoNormalized.Count == 0 || byWeekNoNormalized.Contains(currentWeekNo))

--- a/Ical.Net/Evaluation/RecurringEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurringEvaluator.cs
@@ -60,6 +60,7 @@ public abstract class RecurringEvaluator : Evaluator
     /// </summary>
     /// <param name="referenceDate"></param>
     /// <param name="options"></param>
+    [Obsolete("EXRULE is marked as deprecated in RFC 5545 and will be removed in a future version")]
     private IEnumerable<Period> EvaluateExRule(CalDateTime referenceDate, EvaluationOptions? options)
     {
         if (!Recurrable.ExceptionRules.Any())

--- a/Ical.Net/VTimeZoneInfo.cs
+++ b/Ical.Net/VTimeZoneInfo.cs
@@ -110,6 +110,7 @@ public class VTimeZoneInfo : CalendarComponent, IRecurrable
 
     public virtual ExceptionDates ExceptionDates { get; private set; } = null!;
 
+    [Obsolete("EXRULE is marked as deprecated in RFC 5545 and will be removed in a future version")]
     public virtual IList<RecurrencePattern> ExceptionRules
     {
         get => Properties.GetMany<RecurrencePattern>("EXRULE");


### PR DESCRIPTION
Reasoning:
* `EXRULE` is marked as deprecated in RFC 5545.
* Neither Google Calendar nor Microsoft Outlook/Exchange support it.
* Removing it will decrease complexity.

Resolves #867