### PR TITLE
Skip `CalDateTime.Add(Duration)` for Empty Durations

### DIFF
--- a/Ical.Net/DataTypes/CalDateTime.cs
+++ b/Ical.Net/DataTypes/CalDateTime.cs
@@ -478,6 +478,9 @@ public sealed class CalDateTime : IComparable<CalDateTime>, IFormattable
     /// </exception>
     public CalDateTime Add(Duration d)
     {
+        // If NOOP
+        if (d.IsEmpty) return this;
+
         if (!HasTime && d.HasTime)
         {
             throw new InvalidOperationException($"This instance represents a 'date-only' value '{ToString()}'. Only multiples of full days can be added to a 'date-only' instance, not '{d}'");


### PR DESCRIPTION
Introduce a shortcut to bypass the operation when the duration is empty: `if (d.IsEmpty) return this;`

Resolves #876 