### PR TITLE
Update logo image syntax in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,6 @@
-﻿# ![iCal.NET](https://github.com/ical-org/ical.net/raw/main/assets/logo_300px.png)
+<p margin="0" padding="0">
+  <img src="https://github.com/ical-org/ical.net/raw/main/assets/logo_300px.png" alt="iCal.NET" />
+</p>
 
 | [![GitHub release](https://img.shields.io/github/release/ical-org/ical.net.svg?sort=semver)](https://github.com/ical-org/ical.net/releases/latest) | [![codecov](https://codecov.io/gh/ical-org/ical.net/branch/main/graph/badge.svg)](https://codecov.io/gh/ical-org/ical.net) | [![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://github.com/ical-org/ical.net/blob/main/license.md) |  
 |----------|----------|----------|  


### PR DESCRIPTION
With the change, the logo should display correctly in the NuGet README.