### PR TITLE
Fix weekly bymonth

### DIFF
--- a/Ical.Net.Tests/RecurrenceTests_From_Issues.cs
+++ b/Ical.Net.Tests/RecurrenceTests_From_Issues.cs
@@ -10,6 +10,7 @@ using System.Globalization;
 using System.Linq;
 using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
+using Ical.Net.Evaluation;
 using NUnit.Framework;
 
 namespace Ical.Net.Tests;
@@ -512,5 +513,22 @@ public class RecurrenceTests_From_Issues
                 Assert.That(excludedDays, Does.Not.Contain(occurrence.Period.StartTime.DayOfWeek));
             }
         });
+    }
+
+    [Test]
+    public void Weekly_ByDay_ByMonth()
+    {
+        // Bug #879
+
+        var rp = new RecurrencePattern("FREQ=WEEKLY;BYDAY=SU,MO,TU,WE,TH,FR;BYMONTH=5,6,7,8,9");
+        var rpe = new RecurrencePatternEvaluator(rp);
+
+        var referenceDate = new CalDateTime(2025, 11, 07, 0, 0, 0, "Central Standard Time");
+        var recurringPeriods = rpe.Evaluate(referenceDate, null, null);
+
+        var result = recurringPeriods.FirstOrDefault()?.StartTime;
+
+        var expected = new CalDateTime(2026, 05, 01, 0, 0, 0, "Central Standard Time");
+        Assert.That(result, Is.EqualTo(expected));
     }
 }

--- a/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
+++ b/Ical.Net/Evaluation/RecurrencePatternEvaluator.cs
@@ -308,7 +308,18 @@ public class RecurrencePatternEvaluator : Evaluator
         }
 
         // Limit behavior
-        return dates.Where(date => pattern.ByMonth.Contains(date.Month));
+        if (pattern.Frequency == FrequencyType.Weekly)
+        {
+            // The dates here represent weeks, with each date being the
+            // start of a week except for the initial reference date.
+            // Return weeks that have any day within BYMONTH.
+            return dates.Where(date => pattern.ByMonth.Contains(date.Month)
+                || pattern.ByMonth.Contains(date.AddDays(6).Month));
+        }
+        else
+        {
+            return dates.Where(date => pattern.ByMonth.Contains(date.Month));
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Weekly rules that include BYMONTH were only including weeks that start inside the given months. This fix checks the end of the week also to see if any part of the week is inside the given months.

The date will not always be the start of a week, since the reference date is first, but extra months are filtered out later.

Fixes #879