### PR TITLE
Fixes for `RRULE:FREQ=YEARLY` combined with `BYMONTH`

### DIFF
--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -407,7 +407,7 @@ public class RecurrenceTests
             .TakeWhileBefore(new CalDateTime(2000, 12, 31)).ToList();
         var evt2Occurrences = evt2.GetOccurrences(new CalDateTime(1997, 9, 1))
             .TakeWhileBefore(new CalDateTime(2000, 12, 31)).ToList();
-        Assert.That(evt1Occurrences.Count == evt2Occurrences.Count, Is.True,
+        Assert.That(evt1Occurrences.Count, Is.EqualTo(evt2Occurrences.Count),
             "ByMonth1 does not match ByMonth2 as it should");
         for (var i = 0; i < evt1Occurrences.Count; i++)
             Assert.That(evt2Occurrences[i].Period, Is.EqualTo(evt1Occurrences[i].Period),
@@ -1654,7 +1654,7 @@ public class RecurrenceTests
                 new Period(new CalDateTime(1997, 9, 2, 9, 0, 0, _tzid), Duration.FromHours(1)),
                 new Period(new CalDateTime(1997, 9, 2, 12, 0, 0, _tzid), Duration.FromHours(1)),
                 new Period(new CalDateTime(1997, 9, 2, 15, 0, 0, _tzid), Duration.FromHours(1)),
-                new Period(new CalDateTime(1997, 9, 2, 18, 0, 0, _tzid), Duration.FromHours(1)),
+                new Period(new CalDateTime(1997, 9, 2, 18, 0, 0, _tzid), Duration.FromHours(1))
             },
             timeZones: null
         );
@@ -2009,13 +2009,16 @@ public class RecurrenceTests
         var iCal = Calendar.Load(IcsFiles.YearlyInterval1)!;
         EventOccurrenceTest(
             iCal,
-            new CalDateTime(2006, 1, 1, 7, 0, 0, _tzid),
-            new CalDateTime(2007, 1, 31, 7, 0, 0, _tzid),
-            new[]
-            {
-                new Period(new CalDateTime(2007, 1, 8, 7, 0, 0, _tzid), Duration.FromHours(24)),
-                new Period(new CalDateTime(2007, 1, 9, 7, 0, 0, _tzid), Duration.FromHours(24))
-            },
+            new CalDateTime(2005, 1, 11, 7, 0, 0, _tzid),
+            new CalDateTime(2010, 1, 31, 7, 0, 0, _tzid),
+            [
+                new Period(new CalDateTime(2005, 4, 11, 7, 0, 0, _tzid), Duration.FromHours(24)),
+                new Period(new CalDateTime(2005, 4, 12, 7, 0, 0, _tzid), Duration.FromHours(24)),
+                new Period(new CalDateTime(2007, 4, 9, 7, 0, 0, _tzid), Duration.FromHours(24)),
+                new Period(new CalDateTime(2007, 4, 10, 7, 0, 0, _tzid), Duration.FromHours(24)),
+                new Period(new CalDateTime(2009, 4, 13, 7, 0, 0, _tzid), Duration.FromHours(24)),
+                new Period(new CalDateTime(2009, 4, 14, 7, 0, 0, _tzid), Duration.FromHours(24))
+            ],
             null
         );
     }

--- a/Ical.Net/Evaluation/Evaluator.cs
+++ b/Ical.Net/Evaluation/Evaluator.cs
@@ -41,7 +41,18 @@ public abstract class Evaluator : IEvaluator
                     dt = old.AddDays(-old.Day + 1).AddMonths(interval);
                     break;
                 case FrequencyType.Yearly:
-                    dt = old.AddDays(-old.DayOfYear + 1).AddYears(interval);
+                    if (pattern.ByWeekNo.Count != 0)
+                    {
+                        // When a rule uses BYWEEKNO, recurrence enumeration
+                        // is based on week numbers relative to the year.
+                        // So we preserve January 1st when adding years
+                        dt = old.AddDays(-old.DayOfYear + 1).AddYears(interval);
+                    }
+                    else
+                    {
+                        // preserve month/day when adding years
+                        dt = old.AddYears(interval);
+                    }
                     break;
                 default:
                     // Frequency should always be valid at this stage.

--- a/Ical.Net/Evaluation/Evaluator.cs
+++ b/Ical.Net/Evaluation/Evaluator.cs
@@ -41,18 +41,12 @@ public abstract class Evaluator : IEvaluator
                     dt = old.AddDays(-old.Day + 1).AddMonths(interval);
                     break;
                 case FrequencyType.Yearly:
-                    if (pattern.ByWeekNo.Count != 0)
-                    {
-                        // When a rule uses BYWEEKNO, recurrence enumeration
-                        // is based on week numbers relative to the year.
-                        // So we preserve January 1st when adding years
-                        dt = old.AddDays(-old.DayOfYear + 1).AddYears(interval);
-                    }
-                    else
-                    {
-                        // preserve month/day when adding years
-                        dt = old.AddYears(interval);
-                    }
+                    // When a rule uses BYWEEKNO, recurrence enumeration
+                    // is based on week numbers relative to the year.
+                    // So we preserve January 1st when adding years; otherwise, preserve month/day.
+                    dt = (pattern.ByWeekNo.Count != 0)
+                        ? old.AddDays(-old.DayOfYear + 1).AddYears(interval)
+                        : old.AddYears(interval);
                     break;
                 default:
                     // Frequency should always be valid at this stage.


### PR DESCRIPTION
## Fixes for `RRULE:FREQ=YEARLY` combined with `BYMONTH`

### `RecurrencePatternEvaluator`:
1. Extended `GetIntervalLowerLimit` calculation:
  * YEARLY + BYMONTH: compute a conservative earliest possible candidate inside the interval
  * YEARLY + BYWEEKNO: shift interval start to the week’s first day
  * default return intervalRefTime
2. Intoduced an `anchorMonth` as an explicit month anchor used when FREQ=YEARLY and BYMONTH is not specified so that BYMONTHDAY expansion/limiting is performed relative to the original DTSTART month rather than the current intervalRefTime month. `anchorMonth` only affects cases where BYMONTH is absent.

### `Evaluator`:
Added a distinction for case `FrequencyType.Yearly`: Is BYWEEKNO present or not.

### `RecurrenceTests`:
Extended `YearlyInterval1()` to test more occurrences and taking latest code changes into account.

See comments in https://github.com/ical-org/ical.net/issues/791#issuecomment-3553325859 for reference
Fixes #885 