### PR TITLE
chore: Update `publish.yml`

### DIFF
--- a/.github/workflows/PublishResolveVersion.sh
+++ b/.github/workflows/PublishResolveVersion.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Enable strict mode when running inside GitHub Actions runner
+if [[ "${GITHUB_ACTIONS:-false}" == "true" ]]; then
+    set -euo pipefail
+fi
+
+Major="${1:-}"
+if [[ -z "$Major" ]]; then
+    echo "::error::No major version argument supplied. Usage: $0 <major> (e.g. v3)" >&2
+    exit 1
+fi
+echo "Looking for tags that start with: $Major"
+
+# Fetch tags
+git fetch --tags --quiet
+
+# Collect matching tags (newest first by creatordate)
+mapfile -t MATCHING < <(
+    git for-each-ref --sort=-creatordate --format='%(refname:short)' refs/tags \
+    | grep -E "^${Major}(\.|$)" || true
+)
+
+if [[ ${#MATCHING[@]} -eq 0 ]]; then
+    echo "::error::No tag found starting with '${Major}'. Showing latest tags:" >&2
+    git for-each-ref --sort=-creatordate --format='%(refname:short)' refs/tags | head -n 10 >&2
+    exit 1
+fi
+
+echo "Showing up to 10 of top ${#MATCHING[@]} matching tags (newest first):"
+for tag in "${MATCHING[@]:0:10}"; do
+    echo " - $tag"
+done
+
+Tag="${MATCHING[0]}"
+Version="${Tag#v}"
+
+echo "Selected tag: $Tag -> version: $Version"
+
+# If running in GitHub Actions, write to the runner files
+if [[ -n "${GITHUB_OUTPUT-}" ]]; then
+    printf 'TAG_NAME=%s\n' "$Tag" >> "$GITHUB_OUTPUT"
+    printf 'VERSION=%s\n' "$Version" >> "$GITHUB_OUTPUT"
+fi
+
+if [[ -n "${GITHUB_ENV-}" ]]; then
+    printf 'TAG_NAME=%s\n' "$Tag" >> "$GITHUB_ENV"
+    printf 'VERSION=%s\n' "$Version" >> "$GITHUB_ENV"
+fi
+
+# Always print results
+printf 'TAG_NAME=%s\n' "$Tag"
+printf 'VERSION=%s\n' "$Version"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,9 @@
-﻿name: Publish
-# Build and publish package to NuGet.
-# Choose a main version (e.g. v5 or v6). The workflow prints matching tags and picks
-# the most recent tag that starts with the chosen major (by creatordate).
+﻿name: Publish Nuget Package
+# This job builds and publishes the package to NuGet.
+# It depends on the included tests job to complete successfully.
+# This workflow finds the most recent tag that starts with 
+# the selected major version (sorted by creatordate)
+# and runs the test, build and publish tasks for that tag.
 on:
   workflow_dispatch:
     inputs:
@@ -25,42 +27,13 @@ jobs:
       with:
         fetch-depth: 0  # Fetch full history and tags
 
-    - name: Show matches for selected major and select latest tag
+    - name: Show matching major version tags and select latest by creatordate
       id: resolve
+      shell: bash
       run: |
         set -euo pipefail
-
-        Major='${{ github.event.inputs.major_version }}'
-        echo "Selected major: $Major"
-
-        git fetch --tags --quiet
-
-        # Get matching tags sorted by creatordate (newest first)
-        mapfile -t MATCHING < <(git for-each-ref --sort=-creatordate --format='%(refname:short)' refs/tags | grep -E "^${Major}(\.|$)" || true)
-
-        if [ ${#MATCHING[@]} -eq 0 ]; then
-          echo "::error::No tag found for major '$Major'. Showing latest tags:"
-          git for-each-ref --sort=-creatordate --format='%(refname:short)' refs/tags | head -n 50
-          exit 1
-        fi
-
-        echo "Matching tags (newest to oldest):"
-        for t in "${MATCHING[@]}"; do
-          echo " - $t"
-        done
-
-        # Choose the first (newest) matching tag
-        Tag="${MATCHING[0]}"
-        # Strip 'v' prefix for VERSION variable
-        Version="${Tag#v}"
-
-        echo "Selected tag: $Tag -> version: $Version"
-
-        # Export for later steps and other jobs
-        echo "TAG_NAME=$Tag" >> $GITHUB_OUTPUT
-        echo "VERSION=$Version" >> $GITHUB_OUTPUT
-        echo "TAG_NAME=$Tag" >> $GITHUB_ENV
-        echo "VERSION=$Version" >> $GITHUB_ENV
+        # no need for chmod when using bash to run the resolver script
+        bash .github/workflows/PublishResolveVersion.sh "${{ github.event.inputs.major_version }}"
 
     - name: Set Git config for line endings
       run: git config --global core.autocrlf true


### PR DESCRIPTION
Use a bash script to resolve the latest version for a specified major version (e.g. tag v5.6.7 for major v5)