### PR TITLE
Refactor `FreeBusy` attendee filtering and status logic

### DIFF
--- a/Ical.Net.Tests/FreeBusyTest.cs
+++ b/Ical.Net.Tests/FreeBusyTest.cs
@@ -9,7 +9,10 @@ using System.Collections.Generic;
 using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
 using Ical.Net.Utility;
+using NodaTime;
 using NUnit.Framework;
+using Duration = Ical.Net.DataTypes.Duration;
+using Period = Ical.Net.DataTypes.Period;
 
 namespace Ical.Net.Tests;
 
@@ -194,7 +197,9 @@ public class FreeBusyTest
     [Test]
     public void PeriodCollidesWith_WhenNoDurationShouldThrow()
     {
-        Assert.Throws<ArgumentException>(() => _ = new FreeBusyEntry(new(new CalDateTime(2025, 1, 1, 0, 0, 0, "UTC")), FreeBusyStatus.Free));
+        Assert.Throws<ArgumentException>(() =>
+            _ = new FreeBusyEntry(new(new CalDateTime(2025, 1, 1, 0, 0, 0, "UTC")), FreeBusyStatus.Free));
+    }
 
     [Test, Category("FreeBusy")]
     public void CreateReturnsBusyWhenAcceptedParticipantIsRequested()
@@ -249,6 +254,7 @@ public class FreeBusyTest
         var organizer = new Organizer("mailto:organizer@example.com");
         var contacts = new[] { new Attendee("mailto:busy@example.com ") };
         var freeBusy = cal.GetFreeBusy(
+            DateTimeZone.Utc,
             organizer,
             contacts,
             new CalDateTime(2025, 9, 1, 0, 0, 0),
@@ -258,7 +264,7 @@ public class FreeBusyTest
         {
             Assert.That(freeBusy.Entries, Has.Count.EqualTo(1));
             Assert.That(freeBusy.Entries[0].Status, Is.EqualTo(FreeBusyStatus.Busy));
-            Assert.That(freeBusy.Entries[0].StartTime, Is.EqualTo(busyEvent.Start));
+            Assert.That(freeBusy.Entries[0].StartTime.AsUtc, Is.EqualTo(busyEvent.Start.AsUtc));
         }
     }
 
@@ -278,7 +284,7 @@ public class FreeBusyTest
         evt.Attendees.Add(attendee);
 
         var organizer = new Organizer("mailto:organizer@example.com");
-        var freeBusy = calendar.GetFreeBusy(organizer, contacts, new(2025, 9, 1, 0, 0, 0), new(2025, 9, 2, 0, 0, 0));
+        var freeBusy = calendar.GetFreeBusy(DateTimeZone.Utc, organizer, contacts, new(2025, 9, 1, 0, 0, 0), new(2025, 9, 2, 0, 0, 0));
         return freeBusy ?? throw new InvalidOperationException("GetFreeBusy returned null.");
     }
 }

--- a/Ical.Net.Tests/FreeBusyTest.cs
+++ b/Ical.Net.Tests/FreeBusyTest.cs
@@ -195,5 +195,90 @@ public class FreeBusyTest
     public void PeriodCollidesWith_WhenNoDurationShouldThrow()
     {
         Assert.Throws<ArgumentException>(() => _ = new FreeBusyEntry(new(new CalDateTime(2025, 1, 1, 0, 0, 0, "UTC")), FreeBusyStatus.Free));
+
+    [Test, Category("FreeBusy")]
+    public void CreateReturnsBusyWhenAcceptedParticipantIsRequested()
+    {
+        var contacts = new[] { new Attendee("MAILTO:BUSY@EXAMPLE.COM") };
+        var freeBusy = BuildFreeBusyWithContacts("mailto:busy@example.com", EventParticipationStatus.Accepted, contacts);
+
+        Assert.That(freeBusy.Entries, Has.Count.EqualTo(1));
+        Assert.That(freeBusy.Entries[0].Status, Is.EqualTo(FreeBusyStatus.Busy));
+    }
+
+    [Test, Category("FreeBusy")]
+    public void CreateReturnsBusyTentativeWhenTentativeParticipantIsRequested()
+    {
+        var contacts = new[] { new Attendee("mailto:busy@example.com") };
+        var freeBusy = BuildFreeBusyWithContacts("MAILTO:busy@example.com", EventParticipationStatus.Tentative, contacts);
+
+        Assert.That(freeBusy.Entries, Has.Count.EqualTo(1));
+        Assert.That(freeBusy.Entries[0].Status, Is.EqualTo(FreeBusyStatus.BusyTentative));
+    }
+
+    [Test, Category("FreeBusy")]
+    public void CreateIgnoresParticipantsWithDeclinedStatus()
+    {
+        var contacts = new[] { new Attendee("MAILTO:BUSY@EXAMPLE.COM") };
+        var freeBusy = BuildFreeBusyWithContacts("mailto:busy@example.com", EventParticipationStatus.Declined, contacts);
+
+        Assert.That(freeBusy.Entries, Is.Empty);
+    }
+
+    [Test, Category("FreeBusy")]
+    public void CreateFiltersOccurrencesByRequestAttendees()
+    {
+        var cal = new Calendar();
+
+        var busyEvent = cal.Create<CalendarEvent>();
+        busyEvent.Start = new CalDateTime(2025, 9, 1, 9, 0, 0);
+        busyEvent.End = new CalDateTime(2025, 9, 1, 10, 0, 0);
+        busyEvent.Attendees.Add(new Attendee("MAILTO:busy@example.com")
+        {
+            ParticipationStatus = EventParticipationStatus.Accepted
+        });
+
+        var otherEvent = cal.Create<CalendarEvent>();
+        otherEvent.Start = new CalDateTime(2025, 9, 1, 11, 0, 0);
+        otherEvent.End = new CalDateTime(2025, 9, 1, 12, 0, 0);
+        otherEvent.Attendees.Add(new Attendee("MAILTO:friend@example.com")
+        {
+            ParticipationStatus = EventParticipationStatus.Accepted
+        });
+
+        var organizer = new Organizer("mailto:organizer@example.com");
+        var contacts = new[] { new Attendee("mailto:busy@example.com ") };
+        var freeBusy = cal.GetFreeBusy(
+            organizer,
+            contacts,
+            new CalDateTime(2025, 9, 1, 0, 0, 0),
+            new CalDateTime(2025, 9, 2, 0, 0, 0))!;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(freeBusy.Entries, Has.Count.EqualTo(1));
+            Assert.That(freeBusy.Entries[0].Status, Is.EqualTo(FreeBusyStatus.Busy));
+            Assert.That(freeBusy.Entries[0].StartTime, Is.EqualTo(busyEvent.Start));
+        }
+    }
+
+    // Helper method to build FreeBusy with specified attendee and contacts.
+    private static FreeBusy BuildFreeBusyWithContacts(string eventAttendeeUri, string? participantStatus, IEnumerable<Attendee> contacts)
+    {
+        var calendar = new Calendar();
+        var evt = calendar.Create<CalendarEvent>();
+        evt.Start = new CalDateTime(2025, 9, 1, 9, 0, 0);
+        evt.End = new CalDateTime(2025, 9, 1, 10, 0, 0);
+
+        var attendee = new Attendee(eventAttendeeUri);
+        if (participantStatus != null)
+        {
+            attendee.ParticipationStatus = participantStatus;
+        }
+        evt.Attendees.Add(attendee);
+
+        var organizer = new Organizer("mailto:organizer@example.com");
+        var freeBusy = calendar.GetFreeBusy(organizer, contacts, new(2025, 9, 1, 0, 0, 0), new(2025, 9, 2, 0, 0, 0));
+        return freeBusy ?? throw new InvalidOperationException("GetFreeBusy returned null.");
     }
 }

--- a/Ical.Net/CalendarComponents/FreeBusy.cs
+++ b/Ical.Net/CalendarComponents/FreeBusy.cs
@@ -11,6 +11,7 @@ using Ical.Net.DataTypes;
 using Ical.Net.Evaluation;
 using Ical.Net.Utility;
 using NodaTime;
+using Period = Ical.Net.DataTypes.Period;
 
 namespace Ical.Net.CalendarComponents;
 
@@ -36,7 +37,7 @@ public class FreeBusy : UniqueComponent, IMergeable
 
         foreach (var o in occurrences)
         {
-            // We only "opaque" events
+            // Ignore transparent events. Only opaque events are considered as busy time.
             if (o.Source is not CalendarEvent evt || evt.Transparency == TransparencyType.Transparent)
             {
                 continue;
@@ -51,7 +52,7 @@ public class FreeBusy : UniqueComponent, IMergeable
                 continue;
             }
 
-            fb.Entries.Add(new FreeBusyEntry(o.Period, status.Value));
+            fb.Entries.Add(new FreeBusyEntry(new Period(o.Start.ToInstant(), o.End.ToInstant()), status.Value));
         }
 
         return fb;

--- a/Ical.Net/CalendarComponents/FreeBusy.cs
+++ b/Ical.Net/CalendarComponents/FreeBusy.cs
@@ -18,7 +18,7 @@ public class FreeBusy : UniqueComponent, IMergeable
 {
     public static FreeBusy? Create(ICalendarObject obj, DateTimeZone timeZone, FreeBusy freeBusyRequest, EvaluationOptions? options = null)
     {
-        if ((obj is not IGetOccurrencesTyped occ))
+        if (obj is not IGetOccurrencesTyped occ)
         {
             return null;
         }
@@ -26,17 +26,8 @@ public class FreeBusy : UniqueComponent, IMergeable
         var occurrences = occ.GetOccurrences<CalendarEvent>(timeZone, freeBusyRequest.Start?.ToZonedDateTime(timeZone).ToInstant(), options)
             .TakeWhile(p => (freeBusyRequest.End == null) || (p.Start.ToInstant() < freeBusyRequest.End.ToInstant()));
 
-        var contacts = new List<string>();
-        var isFilteredByAttendees = false;
-
-        if (freeBusyRequest.Attendees.Count > 0)
-        {
-            isFilteredByAttendees = true;
-            var attendees = freeBusyRequest.Attendees
-                .Where(a => a.Value != null)
-                .Select(a => a.Value!.OriginalString.Trim());
-            contacts.AddRange(attendees);
-        }
+        var attendeeContacts = BuildAttendeeContacts(freeBusyRequest);
+        var isFilteredByAttendees = attendeeContacts.Count > 0;
 
         var fb = freeBusyRequest;
         fb.Uid = Guid.NewGuid().ToString();
@@ -45,61 +36,61 @@ public class FreeBusy : UniqueComponent, IMergeable
 
         foreach (var o in occurrences)
         {
-            if (o.Source is not IUniqueComponent uc)
+            // We only "opaque" events
+            if (o.Source is not CalendarEvent evt || evt.Transparency == TransparencyType.Transparent)
+            {
                 continue;
-
-            var evt = uc as CalendarEvent;
-            var accepted = false;
-            var type = FreeBusyStatus.Busy;
-
-            // We only accept events, and only "opaque" events.
-            if (evt != null && evt.Transparency != TransparencyType.Transparent)
-            {
-                accepted = true;
             }
 
-            // If the result is filtered by attendees, then
-            // we won't accept it until we find an event
-            // that is being attended by this person.
-            if (accepted && isFilteredByAttendees)
+            var status = isFilteredByAttendees
+                ? GetStatusByAttendees(evt, attendeeContacts)
+                : FreeBusyStatus.Busy;
+
+            if (status == null)
             {
-                accepted = false;
-
-                var participatingAttendeeQuery = uc.Attendees
-                    .Where(attendee =>
-                        attendee.Value != null
-                        && attendee.ParticipationStatus != null
-                        && contacts.Contains(attendee.Value.OriginalString.Trim()))
-                    .Select(pa => pa.ParticipationStatus!.ToUpperInvariant());
-
-                foreach (var participatingAttendee in participatingAttendeeQuery)
-                {
-                    switch (participatingAttendee)
-                    {
-                        case EventParticipationStatus.Tentative:
-                            accepted = true;
-                            type = FreeBusyStatus.BusyTentative;
-                            break;
-                        case EventParticipationStatus.Accepted:
-                            accepted = true;
-                            type = FreeBusyStatus.Busy;
-                            break;
-                    }
-                }
+                continue;
             }
 
-            if (accepted)
-            {
-                // If the entry was accepted, add it to our list!
-
-                // Values MUST always be in UTC on FREEBUSY
-                var period = new DataTypes.Period(o.Start.ToInstant(), o.End.ToInstant());
-
-                fb.Entries.Add(new FreeBusyEntry(period, type));
-            }
+            fb.Entries.Add(new FreeBusyEntry(o.Period, status.Value));
         }
 
         return fb;
+    }
+
+    private static HashSet<string> BuildAttendeeContacts(FreeBusy freeBusyRequest)
+    {
+        var contacts = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var attendee in freeBusyRequest.Attendees)
+        {
+            var value = attendee.Value?.OriginalString.Trim();
+            if (!string.IsNullOrEmpty(value))
+            {
+                contacts.Add(value);
+            }
+        }
+        return contacts;
+    }
+
+    private static FreeBusyStatus? GetStatusByAttendees(CalendarEvent evt, HashSet<string> contacts)
+    {
+        foreach (var attendee in evt.Attendees)
+        {
+            var trimmed = attendee.Value?.OriginalString.Trim();
+            if (string.IsNullOrEmpty(trimmed) || attendee.ParticipationStatus == null || !contacts.Contains(trimmed))
+            {
+                continue;
+            }
+
+            switch (attendee.ParticipationStatus.ToUpperInvariant())
+            {
+                case EventParticipationStatus.Tentative:
+                    return FreeBusyStatus.BusyTentative;
+                case EventParticipationStatus.Accepted:
+                    return FreeBusyStatus.Busy;
+            }
+        }
+
+        return null;
     }
 
     public static FreeBusy CreateRequest(CalDateTime fromInclusive, CalDateTime toExclusive, Organizer? organizer, IEnumerable<Attendee>? contacts)
@@ -110,6 +101,7 @@ public class FreeBusy : UniqueComponent, IMergeable
             DtStart = fromInclusive,
             DtEnd = toExclusive
         };
+
         if (organizer != null)
         {
             fb.Organizer = organizer;


### PR DESCRIPTION
- Simplify `FreeBusy` entry generation: extract attendee contact and status logic into helper methods.
- Replace complex nested logic with code that efficiently filters by attendee and event transparency.
- Improve readability / reduce cognitive complexity
- Increase code coverage

(Resolves [Sonar Cloud Issue](https://sonarcloud.io/project/issues?sinceLeakPeriod=true&issueStatuses=OPEN%2CCONFIRMED&pullRequest=854&id=ical-org_ical.net&open=AZqsdZZS8JCxfjKb9ls1) in #854 after rebase)