### PR TITLE
breaking: Update target frameworks

### DIFF
--- a/Ical.Net.Benchmarks/Ical.Net.Benchmarks.csproj
+++ b/Ical.Net.Benchmarks/Ical.Net.Benchmarks.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net10.0</TargetFrameworks>
         <OutputType>Exe</OutputType>
         <nullable>enable</nullable>
         <LangVersion>latest</LangVersion>

--- a/Ical.Net.Tests/Ical.Net.Tests.csproj
+++ b/Ical.Net.Tests/Ical.Net.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
+        <TargetFrameworks>net10.0;net8.0;net48</TargetFrameworks>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>..\IcalNetStrongnameKey.snk</AssemblyOriginatorKeyFile>
         <nullable>disable</nullable>

--- a/Ical.Net/Ical.Net.csproj
+++ b/Ical.Net/Ical.Net.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net10.0;net8.0;netstandard2.0</TargetFrameworks>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>..\IcalNetStrongnameKey.snk</AssemblyOriginatorKeyFile>
         <nullable>enable</nullable>

--- a/Ical.Net/Utility/TextUtil.cs
+++ b/Ical.Net/Utility/TextUtil.cs
@@ -57,11 +57,8 @@ internal static class TextUtil
             byteIndex += chBytes;
         }
 
-        // Append the remaining characters to the result
-        if (charIndex > 0)
-        {
-            result.Append(lineArray, 0, charIndex);
-        }
+        // Append the remaining characters (if any, i.e. charIndex > 0) to the result
+        result.Append(lineArray, 0, charIndex);
 
         result.Append(SerializationConstants.LineBreak);
     }


### PR DESCRIPTION
Supported target frameworks

`Ical.Net`: net10.0  net8.0  netstandard2.0
`Ical.Net.Tests`: net10.0  net8.0  net48
`Ical.Net.Benchmarks`: net10.0

(Drop support for net6.0, netstandard2.1)

Resolves #902 