### PR TITLE
Enable nullable reference types in `Ical.Net.Tests.csproj` 

### DIFF
--- a/Ical.Net.Tests/AlarmTest.cs
+++ b/Ical.Net.Tests/AlarmTest.cs
@@ -51,13 +51,12 @@ public class AttendeeTest
 
         evt.Attendees.Add(_attendees[0]);
         Assert.That(evt.Attendees, Has.Count.EqualTo(1));
-
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             //the properties below had been set to null during the Attendees.Add operation in NuGet version 2.1.4
             Assert.That(evt.Attendees[0].Role, Is.EqualTo(ParticipationRole.RequiredParticipant));
             Assert.That(evt.Attendees[0].ParticipationStatus, Is.EqualTo(EventParticipationStatus.Tentative));
-        });
+        }
     }
 
     [Test, Category("Attendee")]

--- a/Ical.Net.Tests/AlarmTest.cs
+++ b/Ical.Net.Tests/AlarmTest.cs
@@ -3,14 +3,11 @@
 // Licensed under the MIT license.
 //
 
-#nullable enable
 using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
 using NUnit.Framework;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using Ical.Net.Serialization.DataTypes;
 
 namespace Ical.Net.Tests;
 

--- a/Ical.Net.Tests/AttendeeTest.cs
+++ b/Ical.Net.Tests/AttendeeTest.cs
@@ -51,12 +51,12 @@ public class AttendeeTest
         evt.Attendees.Add(_attendees[0]);
         Assert.That(evt.Attendees, Has.Count.EqualTo(1));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             //the properties below had been set to null during the Attendees.Add operation in NuGet version 2.1.4
             Assert.That(evt.Attendees[0].Role, Is.EqualTo(ParticipationRole.RequiredParticipant));
             Assert.That(evt.Attendees[0].ParticipationStatus, Is.EqualTo(EventParticipationStatus.Tentative));
-        });
+        }
     }
 
     [Test, Category("Attendee")]

--- a/Ical.Net.Tests/CalDateTimeTests.cs
+++ b/Ical.Net.Tests/CalDateTimeTests.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 //
 
-#nullable enable
 using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
 using NUnit.Framework;

--- a/Ical.Net.Tests/CalDateTimeTests.cs
+++ b/Ical.Net.Tests/CalDateTimeTests.cs
@@ -44,12 +44,12 @@ public class CalDateTimeTests
         var floating = dt.ToTimeZone(null);
         var dt2 = floating.ToTimeZone("Europe/Vienna");
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(dt, Is.EqualTo(dt2));
             Assert.That(floating.TzId, Is.Null);
             Assert.That(floating.Value, Is.EqualTo(dt.Value));
-        });
+        }
     }
 
     [Test, TestCaseSource(nameof(ToTimeZoneTestCases))]
@@ -287,13 +287,13 @@ public class CalDateTimeTests
     {
         var dt = new CalDateTime(2025, 1, 15);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(() => dt.Add(Duration.FromHours(1)), Throws.TypeOf<InvalidOperationException>());
             Assert.That(() => dt.AddHours(2), Throws.TypeOf<InvalidOperationException>());
             Assert.That(() => dt.AddMinutes(3), Throws.TypeOf<InvalidOperationException>());
             Assert.That(() => dt.AddSeconds(4), Throws.TypeOf<InvalidOperationException>());
-        });
+        }
     }
 
     [Test]
@@ -308,7 +308,7 @@ public class CalDateTimeTests
         var c3 = new CalDateTime(new NodaTime.LocalDate(dt.Year, dt.Month, dt.Day),
             new NodaTime.LocalTime(dt.Hour, dt.Minute, dt.Second), c.TzId);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(c2.Value, Is.EqualTo(c3.Value));
             Assert.That(c2.TzId, Is.EqualTo(c3.TzId));
@@ -318,7 +318,7 @@ public class CalDateTimeTests
             Assert.That(c.Time, Is.EqualTo(NodaTime.LocalDateTime.FromDateTime(dt).TimeOfDay));
             Assert.That(c.Add(-Duration.FromSeconds(dt.Second)).Value.Second, Is.EqualTo(0));
             Assert.That(c.ToString("dd.MM.yyyy", CultureInfo.InvariantCulture), Is.EqualTo("02.01.2025 Europe/Berlin"));
-        });
+        }
     }
 
     private static TestCaseData[] CalDateTime_FromDateTime_HandlesKindCorrectlyTestCases =>
@@ -343,14 +343,14 @@ public class CalDateTimeTests
     public void ConstructorWithIso8601UtcString_ShouldResultInUtc(string value, string? tzId)
     {
         var dt = new CalDateTime(value, tzId);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(dt.Value, Is.EqualTo(new DateTime(2025, 7, 3, 6, 0, 0, DateTimeKind.Utc)));
 #pragma warning disable CA1305
             Assert.That(dt.ToString("yyyy-MM-dd HH:mm:ss"), Is.EqualTo("2025-07-03 06:00:00 UTC"));
 #pragma warning restore CA1305
             Assert.That(dt.IsUtc, Is.True);
-        });
+        }
     }
 
     [Test]

--- a/Ical.Net.Tests/CalendarEventTest.cs
+++ b/Ical.Net.Tests/CalendarEventTest.cs
@@ -57,17 +57,17 @@ public class CalendarEventTest
         };
 
         cal.Events.Add(evt);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(cal.Children, Has.Count.EqualTo(1));
             Assert.That(cal.Children[0], Is.SameAs(evt));
-        });
+        }
         cal.RemoveChild(evt);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(cal.Children.Count, Is.EqualTo(0));
             Assert.That(cal.Events.Count, Is.EqualTo(0));
-        });
+        }
     }
 
     /// <summary>
@@ -86,18 +86,18 @@ public class CalendarEventTest
         };
 
         cal.Events.Add(evt);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(cal.Children, Has.Count.EqualTo(1));
             Assert.That(cal.Children[0], Is.SameAs(evt));
-        });
+        }
 
         cal.Events.Remove(evt);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(cal.Children.Count, Is.EqualTo(0));
             Assert.That(cal.Events.Count, Is.EqualTo(0));
-        });
+        }
     }
 
     /// <summary>
@@ -196,11 +196,11 @@ public class CalendarEventTest
 
         var newResources = new[] { "Hello", "Goodbye" };
         e.Resources = new List<string>(newResources);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(newResources, Is.EquivalentTo(e.Resources));
             Assert.That(e.Resources.Any(r => resources.Contains(r)), Is.False);
-        });
+        }
 
         //See https://github.com/rianjs/ical.net/issues/208
         e.Resources = Array.Empty<string>();
@@ -265,13 +265,13 @@ public class CalendarEventTest
             DtStart = new CalDateTime(2025, 10, 11, 12, 13, 14, CalDateTime.UtcTzId)
         };
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(() => evt.DtEnd = new CalDateTime(2025, 12, 11), Throws.Nothing);
             Assert.That(() => evt.Duration = Duration.FromDays(1), Throws.InvalidOperationException);
             Assert.That(() => evt.DtEnd = null, Throws.Nothing);
             Assert.That(() => evt.Duration = Duration.FromDays(1), Throws.Nothing);
             Assert.That(() => evt.DtEnd = new CalDateTime(2025, 12, 11), Throws.InvalidOperationException);
-        });
+        }
     }
 }

--- a/Ical.Net.Tests/CalendarEventTest.cs
+++ b/Ical.Net.Tests/CalendarEventTest.cs
@@ -136,7 +136,7 @@ public class CalendarEventTest
         };
 
         cal.Events.Add(evt);
-        Assert.That(evt.DtStamp.IsUtc, Is.True, "DTSTAMP should always be of type UTC.");
+        Assert.That(evt.DtStamp?.IsUtc, Is.True, "DTSTAMP should always be of type UTC.");
     }
 
     /// <summary>
@@ -238,7 +238,7 @@ public class CalendarEventTest
             END:VTIMEZONE
             END:VCALENDAR
             """;
-        var timezones = Calendar.Load(ical)
+        var timezones = Calendar.Load(ical)!
             .TimeZones.First()
             .Children.Cast<CalendarComponent>()
             .ToArray();

--- a/Ical.Net.Tests/CalendarPropertiesTest.cs
+++ b/Ical.Net.Tests/CalendarPropertiesTest.cs
@@ -24,7 +24,7 @@ public class CalendarPropertiesTest
         var iCal = new Calendar();
         iCal.AddProperty(propName, propValue);
 
-        var result = new CalendarSerializer().SerializeToString(iCal);
+        var result = new CalendarSerializer().SerializeToString(iCal)!;
 
         var lines = result.Split(new[] { SerializationConstants.LineBreak }, StringSplitOptions.None);
         var propLine = lines.FirstOrDefault(x => x.StartsWith("X-WR-CALNAME:"));

--- a/Ical.Net.Tests/CalendarPropertiesTest.cs
+++ b/Ical.Net.Tests/CalendarPropertiesTest.cs
@@ -83,7 +83,7 @@ public class CalendarPropertiesTest
         var propDescription = calEvent.Properties.FirstOrDefault(x => x.Name == "X-ALT-DESC")!;
         var propProjects = calEvent.Properties.FirstOrDefault(x => x.Name == "X-PROJECTS")!;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(propDescription.Parameters, Has.Count.EqualTo(1));
             Assert.That(propDescription.Value, Is.EqualTo("<html><body>BodyText</body></html>"));
@@ -93,7 +93,7 @@ public class CalendarPropertiesTest
             Assert.That(propProjects.Value, Is.EqualTo("ProjectA,ProjectB"));
             Assert.That(propProjects.Parameters.FirstOrDefault(p => p.Name == "PROP")!.Value!.ToString(), Is.EqualTo("name"));
             Assert.That(propProjects.Parameters.FirstOrDefault(p => p.Name == "PRIO")!.Value!.ToString(), Is.EqualTo("high"));
-        });
+        }
     }
 
     [Test]

--- a/Ical.Net.Tests/CollectionHelpersTests.cs
+++ b/Ical.Net.Tests/CollectionHelpersTests.cs
@@ -22,11 +22,11 @@ internal class CollectionHelpersTests
     [Test]
     public void ExDateTests()
     {
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(GetExceptionDates(), Is.Not.Null);
             Assert.That(GetExceptionDates(), Is.Not.EqualTo(null));
-        });
+        }
 
         var changedPeriod = GetExceptionDates();
         changedPeriod[0][0] = new Period(new CalDateTime(_now.AddHours(-1)), changedPeriod[0][0].EndTime);

--- a/Ical.Net.Tests/CollectionHelpersTests.cs
+++ b/Ical.Net.Tests/CollectionHelpersTests.cs
@@ -38,8 +38,8 @@ internal class CollectionHelpersTests
     [TestCase(new int[] { }, new int[] { }, new int[] { })]
     [TestCase(new int[] { }, new[] { 2, 4, 6 }, new[] { 2, 4, 6 })]
     [TestCase(new[] { 2, 4, 6 }, new int[] { }, new[] { 2, 4, 6 })]
-    [TestCase(new[] { 3, 4 }, new int[] { 1, 2 }, new[] { 1, 2, 3, 4 })]
-    [TestCase(new[] { 1, 2, 3 }, new int[] { 2, 3, 4 }, new[] { 1, 2, 2, 3, 3, 4 })]
+    [TestCase(new[] { 3, 4 }, new[] { 1, 2 }, new[] { 1, 2, 3, 4 })]
+    [TestCase(new[] { 1, 2, 3 }, new[] { 2, 3, 4 }, new[] { 1, 2, 2, 3, 3, 4 })]
     public void TestMerge(IList<int> seq1, IList<int> seq2, IList<int> expected)
     {
         var result = seq1.OrderedMerge(seq2).ToList();

--- a/Ical.Net.Tests/ComponentTest.cs
+++ b/Ical.Net.Tests/ComponentTest.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 //
 
-#nullable enable
 using Ical.Net.CalendarComponents;
 using NUnit.Framework;
 

--- a/Ical.Net.Tests/ComponentTest.cs
+++ b/Ical.Net.Tests/ComponentTest.cs
@@ -16,11 +16,11 @@ public class ComponentTest
         var iCal = new Calendar();
         var evt = iCal.Create<CalendarEvent>();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(evt.Uid, Is.Not.Null);
             Assert.That(evt.Created, Is.Null); // We don't want this to be set automatically
             Assert.That(evt.DtStamp, Is.Not.Null);
-        });
+        }
     }
 }

--- a/Ical.Net.Tests/CopyComponentTests.cs
+++ b/Ical.Net.Tests/CopyComponentTests.cs
@@ -4,7 +4,6 @@
 //
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Ical.Net.CalendarComponents;

--- a/Ical.Net.Tests/CopyComponentTests.cs
+++ b/Ical.Net.Tests/CopyComponentTests.cs
@@ -28,7 +28,7 @@ public class CopyComponentTests
         DtEnd = new CalDateTime(_later),
     };
 
-    private static string SerializeEvent(CalendarEvent e) => new CalendarSerializer().SerializeToString(new Calendar { Events = { e } });
+    private static string SerializeEvent(CalendarEvent e) => new CalendarSerializer().SerializeToString(new Calendar { Events = { e } })!;
 
     [Test]
     public void CopyCalendarEventTest()
@@ -40,7 +40,7 @@ public class CopyComponentTests
         orig.GeographicLocation = new GeographicLocation(48.210033, 16.363449);
         orig.Transparency = TransparencyType.Opaque;
         orig.Attachments.Add(new Attachment("https://original.org/"));
-        var copy = orig.Copy<CalendarEvent>();
+        var copy = orig.Copy<CalendarEvent>()!;
 
         copy.Uid = "Goodbye";
         copy.Summary = "Copy summary";
@@ -78,7 +78,7 @@ public class CopyComponentTests
             Entries = { new FreeBusyEntry(new Period(new CalDateTime(2024, 10, 1), Duration.FromDays(1)), FreeBusyStatus.Busy) { Language = "English" }}
         };
 
-        var copy = orig.Copy<FreeBusy>();
+        var copy = orig.Copy<FreeBusy>()!;
 
         Assert.Multiple(() =>
         {
@@ -102,7 +102,7 @@ public class CopyComponentTests
             Description = "Test Alarm"
         };
 
-        var copy = orig.Copy<Alarm>();
+        var copy = orig.Copy<Alarm>()!;
 
         Assert.Multiple(() =>
         {
@@ -125,7 +125,7 @@ public class CopyComponentTests
             Status = "NeedsAction"
         };
 
-        var copy = orig.Copy<Todo>();
+        var copy = orig.Copy<Todo>()!;
 
         Assert.Multiple(() =>
         {
@@ -151,7 +151,7 @@ public class CopyComponentTests
             Status = "Draft"
         };
 
-        var copy = orig.Copy<Journal>();
+        var copy = orig.Copy<Journal>()!;
 
         Assert.Multiple(() =>
         {

--- a/Ical.Net.Tests/CopyComponentTests.cs
+++ b/Ical.Net.Tests/CopyComponentTests.cs
@@ -52,7 +52,7 @@ public class CopyComponentTests
         var serializedOrig = SerializeEvent(orig);
         var serializedCopy = SerializeEvent(copy);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // Should be a deep copy and changes only apply to the copy instance
             Assert.That(copy.Uid, Is.Not.EqualTo(orig.Uid));
@@ -65,7 +65,7 @@ public class CopyComponentTests
 
             Assert.That(Regex.Matches(serializedOrig, uidPattern, RegexOptions.Compiled, TimeSpan.FromSeconds(100)), Has.Count.EqualTo(1));
             Assert.That(Regex.Matches(serializedCopy, uidPattern, RegexOptions.Compiled, TimeSpan.FromSeconds(100)), Has.Count.EqualTo(1));
-        });
+        }
     }
 
     [Test]
@@ -80,7 +80,7 @@ public class CopyComponentTests
 
         var copy = orig.Copy<FreeBusy>()!;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // Start/DtStart and End/DtEnd are the same
             Assert.That(copy.Start, Is.EqualTo(orig.DtStart));
@@ -89,7 +89,7 @@ public class CopyComponentTests
             Assert.That(copy.Entries[0].StartTime, Is.EqualTo(orig.Entries[0].StartTime));
             Assert.That(copy.Entries[0].Duration, Is.EqualTo(orig.Entries[0].Duration));
             Assert.That(copy.Entries[0].Status, Is.EqualTo(orig.Entries[0].Status));
-        });
+        }
     }
 
     [Test]
@@ -104,12 +104,12 @@ public class CopyComponentTests
 
         var copy = orig.Copy<Alarm>()!;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(copy.Action, Is.EqualTo(orig.Action));
             Assert.That(copy.Trigger?.DateTime, Is.EqualTo(orig.Trigger.DateTime));
             Assert.That(copy.Description, Is.EqualTo(orig.Description));
-        });
+        }
     }
 
     [Test]
@@ -127,7 +127,7 @@ public class CopyComponentTests
 
         var copy = orig.Copy<Todo>()!;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(copy.Summary, Is.EqualTo(orig.Summary));
             Assert.That(copy.Description, Is.EqualTo(orig.Description));
@@ -135,7 +135,7 @@ public class CopyComponentTests
             Assert.That(copy.Priority, Is.EqualTo(orig.Priority));
             Assert.That(copy.Contacts, Is.EquivalentTo(orig.Contacts));
             Assert.That(copy.Status, Is.EqualTo(orig.Status));
-        });
+        }
     }
 
     [Test]
@@ -153,7 +153,7 @@ public class CopyComponentTests
 
         var copy = orig.Copy<Journal>()!;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(copy.Summary, Is.EqualTo(orig.Summary));
             Assert.That(copy.Description, Is.EqualTo(orig.Description));
@@ -161,6 +161,6 @@ public class CopyComponentTests
             Assert.That(copy.Categories, Is.EquivalentTo(orig.Categories));
             Assert.That(copy.Priority, Is.EqualTo(orig.Priority));
             Assert.That(copy.Status, Is.EqualTo(orig.Status));
-        });
+        }
     }
 }

--- a/Ical.Net.Tests/DataTypeTest.cs
+++ b/Ical.Net.Tests/DataTypeTest.cs
@@ -14,15 +14,13 @@ public class DataTypeTest
 {
     [Test, Category("DataType")]
     public void OrganizerConstructorMustAcceptNull()
-    {
-        Assert.DoesNotThrow(() => { var o = new Organizer(null); });
-    }
+        => Assert.DoesNotThrow(() => { var o = new Organizer(null!); });
 
     [Test, Category("DataType")]
     public void AttachmentConstructorMustAcceptNull()
     {
-        Assert.DoesNotThrow(() => { var o = new Attachment((byte[]) null); });
-        Assert.DoesNotThrow(() => { var o = new Attachment((string) null); });
+        Assert.DoesNotThrow(() => { var o = new Attachment((byte[]?) null); });
+        Assert.DoesNotThrow(() => { var o = new Attachment((string) null!); });
     }
 
     public static IEnumerable<TestCaseData> TestWeekDayEqualsTestCases => [

--- a/Ical.Net.Tests/DataTypeTest.cs
+++ b/Ical.Net.Tests/DataTypeTest.cs
@@ -35,22 +35,22 @@ public class DataTypeTest
     [Test, TestCaseSource(nameof(TestWeekDayEqualsTestCases)), Category("DataType")]
     public void TestWeekDayEquals(WeekDay w1, WeekDay w2)
     {
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(w1.Equals(w1), Is.True);
             Assert.That(w1.Equals(w2), Is.False);
-        });
+        }
     }
 
     [Test, TestCaseSource(nameof(TestWeekDayEqualsTestCases)), Category("DataType")]
     public void TestWeekDayCompareTo(WeekDay w1, WeekDay w2)
     {
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(w1.CompareTo(w1), Is.EqualTo(0));
 
             if (w2 != null)
                 Assert.That(w1.CompareTo(w2), Is.Not.EqualTo(0));
-        });
+        }
     }
 }

--- a/Ical.Net.Tests/DataTypeTest.cs
+++ b/Ical.Net.Tests/DataTypeTest.cs
@@ -14,13 +14,13 @@ public class DataTypeTest
 {
     [Test, Category("DataType")]
     public void OrganizerConstructorMustAcceptNull()
-        => Assert.DoesNotThrow(() => { var o = new Organizer(null!); });
+        => Assert.DoesNotThrow(() => { _ = new Organizer(null); });
 
     [Test, Category("DataType")]
     public void AttachmentConstructorMustAcceptNull()
     {
-        Assert.DoesNotThrow(() => { var o = new Attachment((byte[]?) null); });
-        Assert.DoesNotThrow(() => { var o = new Attachment((string) null!); });
+        Assert.DoesNotThrow(() => { _ = new Attachment((byte[]?) null); });
+        Assert.DoesNotThrow(() => { _ = new Attachment((string?) null); });
     }
 
     public static IEnumerable<TestCaseData> TestWeekDayEqualsTestCases => [

--- a/Ical.Net.Tests/DeserializationTests.cs
+++ b/Ical.Net.Tests/DeserializationTests.cs
@@ -24,7 +24,7 @@ public class DeserializationTests
     [Test]
     public void Attendee1()
     {
-        var iCal = Calendar.Load(IcsFiles.Attendee1);
+        var iCal = Calendar.Load(IcsFiles.Attendee1)!;
         Assert.That(iCal.Events, Has.Count.EqualTo(1));
 
         var evt = iCal.Events.First();
@@ -69,7 +69,7 @@ public class DeserializationTests
     [Test]
     public void Attendee2()
     {
-        var iCal = Calendar.Load(IcsFiles.Attendee2);
+        var iCal = Calendar.Load(IcsFiles.Attendee2)!;
         Assert.That(iCal.Events, Has.Count.EqualTo(1));
 
         var evt = iCal.Events.First();
@@ -99,11 +99,11 @@ public class DeserializationTests
     [Test]
     public void Bug2033495()
     {
-        var iCal = Calendar.Load(IcsFiles.Bug2033495);
+        var iCal = Calendar.Load(IcsFiles.Bug2033495)!;
         Assert.Multiple(() =>
         {
             Assert.That(iCal.Events, Has.Count.EqualTo(1));
-            Assert.That(iCal.Properties["X-LOTUS-CHILD_UID"].Value, Is.EqualTo("XXX"));
+            Assert.That(iCal.Properties["X-LOTUS-CHILD_UID"]?.Value, Is.EqualTo("XXX"));
         });
     }
 
@@ -114,14 +114,14 @@ public class DeserializationTests
     [Test]
     public void Bug2938007()
     {
-        var iCal = Calendar.Load(IcsFiles.Bug2938007);
+        var iCal = Calendar.Load(IcsFiles.Bug2938007)!;
         Assert.That(iCal.Events, Has.Count.EqualTo(1));
 
         var evt = iCal.Events.First();
         Assert.Multiple(() =>
         {
-            Assert.That(evt.Start.HasTime, Is.EqualTo(true));
-            Assert.That(evt.End.HasTime, Is.EqualTo(true));
+            Assert.That(evt.Start?.HasTime, Is.True);
+            Assert.That(evt.End?.HasTime, Is.True);
         });
 
         var results = evt.GetOccurrences(new LocalDateTime(2010, 1, 17, 0, 0, 0).InZoneLeniently("Asia/Tokyo"))
@@ -158,7 +158,7 @@ public class DeserializationTests
     [Test]
     public void CaseInsensitive4()
     {
-        var iCal = Calendar.Load(IcsFiles.CaseInsensitive4);
+        var iCal = Calendar.Load(IcsFiles.CaseInsensitive4)!;
         Assert.That(iCal.Version, Is.EqualTo("2.5"));
     }
 
@@ -192,7 +192,7 @@ public class DeserializationTests
     [Test]
     public void EmptyLines1()
     {
-        var iCal = Calendar.Load(IcsFiles.EmptyLines1);
+        var iCal = Calendar.Load(IcsFiles.EmptyLines1)!;
         Assert.That(iCal.Events, Has.Count.EqualTo(2), "iCalendar should have 2 events");
     }
 
@@ -215,7 +215,7 @@ public class DeserializationTests
     [Test]
     public void EmptyLines3()
     {
-        var iCal = Calendar.Load(IcsFiles.EmptyLines3);
+        var iCal = Calendar.Load(IcsFiles.EmptyLines3)!;
         Assert.That(iCal.Todos, Has.Count.EqualTo(1), "iCalendar should have 1 todo");
     }
 
@@ -225,14 +225,14 @@ public class DeserializationTests
     [Test]
     public void EmptyLines4()
     {
-        var iCal = Calendar.Load(IcsFiles.EmptyLines4);
+        var iCal = Calendar.Load(IcsFiles.EmptyLines4)!;
         Assert.That(iCal.Events, Has.Count.EqualTo(28));
     }
 
     [Test]
     public void Encoding2()
     {
-        var iCal = Calendar.Load(IcsFiles.Encoding2);
+        var iCal = Calendar.Load(IcsFiles.Encoding2)!;
         ProgramTest.TestCal(iCal);
         var evt = iCal.Events.First();
 
@@ -256,7 +256,7 @@ public class DeserializationTests
     [Test]
     public void Encoding3()
     {
-        var iCal = Calendar.Load(IcsFiles.Encoding3);
+        var iCal = Calendar.Load(IcsFiles.Encoding3)!;
         ProgramTest.TestCal(iCal);
         var evt = iCal.Events.First();
 
@@ -301,7 +301,7 @@ public class DeserializationTests
                  END:VEVENT
                  END:VCALENDAR
                  """;
-        var iCal = Calendar.Load(sr);
+        var iCal = Calendar.Load(sr)!;
         Assert.That(iCal.Events.Count == 2, Is.True, "There should be 2 events in the parsed calendar");
         Assert.That(iCal.Events["fd940618-45e2-4d19-b118-37fd7a8e3906"], Is.Not.Null, "Event fd940618-45e2-4d19-b118-37fd7a8e3906 should exist in the calendar");
         Assert.That(iCal.Events["ebfbd3e3-cc1e-4a64-98eb-ced2598b3908"], Is.Not.Null, "Event ebfbd3e3-cc1e-4a64-98eb-ced2598b3908 should exist in the calendar");
@@ -310,14 +310,14 @@ public class DeserializationTests
     [Test]
     public void GeographicLocation1_2()
     {
-        var iCal = Calendar.Load(IcsFiles.GeographicLocation1);
+        var iCal = Calendar.Load(IcsFiles.GeographicLocation1)!;
         ProgramTest.TestCal(iCal);
         var evt = iCal.Events.First();
 
         Assert.Multiple(() =>
         {
-            Assert.That(evt.GeographicLocation.Latitude, Is.EqualTo(37.386013), "Latitude should be 37.386013; it is not.");
-            Assert.That(evt.GeographicLocation.Longitude, Is.EqualTo(-122.082932), "Longitude should be -122.082932; it is not.");
+            Assert.That(evt.GeographicLocation?.Latitude, Is.EqualTo(37.386013), "Latitude should be 37.386013; it is not.");
+            Assert.That(evt.GeographicLocation?.Longitude, Is.EqualTo(-122.082932), "Longitude should be -122.082932; it is not.");
         });
     }
 
@@ -325,7 +325,7 @@ public class DeserializationTests
     public void Google1()
     {
         var tzId = "Europe/Berlin";
-        var iCal = Calendar.Load(IcsFiles.Google1);
+        var iCal = Calendar.Load(IcsFiles.Google1)!;
         var evt = iCal.Events["594oeajmftl3r9qlkb476rpr3c@google.com"];
         Assert.That(evt, Is.Not.Null);
         var dtStart2 = new CalDateTime(2006, 12, 18);
@@ -357,7 +357,7 @@ public class DeserializationTests
     [Test]
     public void RecurrenceDates1()
     {
-        var iCal = Calendar.Load(IcsFiles.RecurrenceDates1);
+        var iCal = Calendar.Load(IcsFiles.RecurrenceDates1)!;
 
         var expectedStartTimes = new List<CalDateTime>
         {
@@ -380,15 +380,15 @@ public class DeserializationTests
 
         var expectedEndTime = new CalDateTime(new DateTime(1996, 4, 3, 4, 0, 0, DateTimeKind.Utc));
 
-        var actualStartTimes = iCal.Events[0].RecurrenceDates.GetAllPeriods()
+        var actualStartTimes = iCal.Events[0]!.RecurrenceDates.GetAllPeriods()
             .Select(p => p.StartTime)
-            .Union(iCal.Events[0].RecurrenceDates.GetAllDates())
+            .Union(iCal.Events[0]!.RecurrenceDates.GetAllDates())
             .ToList();
 
         Assert.Multiple(() =>
         {
             Assert.That(iCal.Events, Has.Count.EqualTo(1));
-            Assert.That(iCal.Events[0].RecurrenceDatesPeriodLists, Has.Count.EqualTo(3));
+            Assert.That(iCal.Events[0]!.RecurrenceDatesPeriodLists, Has.Count.EqualTo(3));
             Assert.That(actualStartTimes, Has.Count.EqualTo(expectedStartTimes.Count));
 
             foreach (var date in expectedStartTimes)
@@ -397,7 +397,7 @@ public class DeserializationTests
                     Is.EqualTo(date), "Should contain " + date);
             }
 
-            Assert.That(iCal.Events[0].RecurrenceDates.Contains(new DataTypes.Period(expectedStartTimes[1], expectedEndTime)));
+            Assert.That(iCal.Events[0]!.RecurrenceDates.Contains(new DataTypes.Period(expectedStartTimes[1], expectedEndTime)));
         });
     }
 
@@ -407,15 +407,15 @@ public class DeserializationTests
     [Test]
     public void RequestStatus1()
     {
-        var iCal = Calendar.Load(IcsFiles.RequestStatus1);
+        var iCal = Calendar.Load(IcsFiles.RequestStatus1)!;
         Assert.That(iCal.Events, Has.Count.EqualTo(1));
         Assert.That(iCal.Events.First().RequestStatuses, Has.Count.EqualTo(4));
 
         var rs = iCal.Events.First().RequestStatuses[0];
         Assert.Multiple(() =>
         {
-            Assert.That(rs.StatusCode.Primary, Is.EqualTo(2));
-            Assert.That(rs.StatusCode.Secondary, Is.EqualTo(0));
+            Assert.That(rs.StatusCode?.Primary, Is.EqualTo(2));
+            Assert.That(rs.StatusCode?.Secondary, Is.EqualTo(0));
             Assert.That(rs.Description, Is.EqualTo("Success"));
         });
         Assert.That(rs.ExtraData, Is.Null);
@@ -423,8 +423,8 @@ public class DeserializationTests
         rs = iCal.Events.First().RequestStatuses[1];
         Assert.Multiple(() =>
         {
-            Assert.That(rs.StatusCode.Primary, Is.EqualTo(3));
-            Assert.That(rs.StatusCode.Secondary, Is.EqualTo(1));
+            Assert.That(rs.StatusCode?.Primary, Is.EqualTo(3));
+            Assert.That(rs.StatusCode?.Secondary, Is.EqualTo(1));
             Assert.That(rs.Description, Is.EqualTo("Invalid property value"));
             Assert.That(rs.ExtraData, Is.EqualTo("DTSTART:96-Apr-01"));
         });
@@ -432,8 +432,8 @@ public class DeserializationTests
         rs = iCal.Events.First().RequestStatuses[2];
         Assert.Multiple(() =>
         {
-            Assert.That(rs.StatusCode.Primary, Is.EqualTo(2));
-            Assert.That(rs.StatusCode.Secondary, Is.EqualTo(8));
+            Assert.That(rs.StatusCode?.Primary, Is.EqualTo(2));
+            Assert.That(rs.StatusCode?.Secondary, Is.EqualTo(8));
             Assert.That(rs.Description, Is.EqualTo(" Success, repeating event ignored. Scheduled as a single event."));
             Assert.That(rs.ExtraData, Is.EqualTo("RRULE:FREQ=WEEKLY;INTERVAL=2"));
         });
@@ -441,8 +441,8 @@ public class DeserializationTests
         rs = iCal.Events.First().RequestStatuses[3];
         Assert.Multiple(() =>
         {
-            Assert.That(rs.StatusCode.Primary, Is.EqualTo(4));
-            Assert.That(rs.StatusCode.Secondary, Is.EqualTo(1));
+            Assert.That(rs.StatusCode?.Primary, Is.EqualTo(4));
+            Assert.That(rs.StatusCode?.Secondary, Is.EqualTo(1));
             Assert.That(rs.Description, Is.EqualTo("Event conflict. Date/time is busy."));
         });
         Assert.That(rs.ExtraData, Is.Null);
@@ -456,16 +456,16 @@ public class DeserializationTests
     {
         var serializer = new StringSerializer();
         var value = @"test\with\;characters";
-        var unescaped = (string)serializer.Deserialize(new StringReader(value));
+        var unescaped = (string?) serializer.Deserialize(new StringReader(value));
 
         Assert.That(unescaped, Is.EqualTo(@"test\with;characters"), "String unescaping was incorrect.");
 
         value = @"C:\Path\To\My\New\Information";
-        unescaped = (string)serializer.Deserialize(new StringReader(value));
+        unescaped = (string?) serializer.Deserialize(new StringReader(value));
         Assert.That(unescaped, Is.EqualTo("C:\\Path\\To\\My\new\\Information"), "String unescaping was incorrect.");
 
         value = @"\""This\r\nis\Na\, test\""\;\\;,";
-        unescaped = (string)serializer.Deserialize(new StringReader(value));
+        unescaped = (string?) serializer.Deserialize(new StringReader(value));
 
         Assert.That(unescaped, Is.EqualTo("\"This\\r\nis\na, test\";\\;,"), "String unescaping was incorrect.");
     }
@@ -473,7 +473,7 @@ public class DeserializationTests
     [Test]
     public void Transparency2()
     {
-        var iCal = Calendar.Load(IcsFiles.Transparency2);
+        var iCal = Calendar.Load(IcsFiles.Transparency2)!;
 
         Assert.That(iCal.Events, Has.Count.EqualTo(1));
         var evt = iCal.Events.First();
@@ -500,7 +500,7 @@ public class DeserializationTests
     [Test]
     public void Outlook2007_LineFolds1()
     {
-        var iCal = Calendar.Load(IcsFiles.Outlook2007LineFolds);
+        var iCal = Calendar.Load(IcsFiles.Outlook2007LineFolds)!;
         var events = iCal.GetOccurrences(new CalDateTime(2009, 06, 20).ToZonedDateTime("America/New_York")).TakeWhileBefore(new CalDateTime(2009, 06, 22).ToZonedDateTime("America/New_York").ToInstant()).ToList();
         Assert.That(events, Has.Count.EqualTo(1));
     }
@@ -509,7 +509,7 @@ public class DeserializationTests
     public void Outlook2007_LineFolds2()
     {
         var longName = "The Exceptionally Long Named Meeting Room Whose Name Wraps Over Several Lines When Exported From Leading Calendar and Office Software Application Microsoft Office 2007";
-        var iCal = Calendar.Load(IcsFiles.Outlook2007LineFolds);
+        var iCal = Calendar.Load(IcsFiles.Outlook2007LineFolds)!;
         var events = iCal.GetOccurrences<CalendarEvent>(new CalDateTime(2009, 06, 20).ToZonedDateTime("America/New_York")).TakeWhileBefore(new CalDateTime(2009, 06, 22).ToZonedDateTime("America/New_York").ToInstant()).ToList();
         Assert.That(((CalendarEvent)events[0].Source).Location, Is.EqualTo(longName));
     }
@@ -520,10 +520,10 @@ public class DeserializationTests
     [Test]
     public void Parameter1()
     {
-        var iCal = Calendar.Load(IcsFiles.Parameter1);
+        var iCal = Calendar.Load(IcsFiles.Parameter1)!;
 
         var evt = iCal.Events.First();
-        IList<CalendarParameter> parms = evt.Properties["DTSTART"].Parameters.AllOf("VALUE").ToList();
+        IList<CalendarParameter> parms = evt.Properties["DTSTART"]!.Parameters.AllOf("VALUE").ToList();
         Assert.Multiple(() =>
         {
             Assert.That(parms, Has.Count.EqualTo(2));
@@ -538,7 +538,7 @@ public class DeserializationTests
     [Test]
     public void Parameter2()
     {
-        var iCal = Calendar.Load(IcsFiles.Parameter2);
+        var iCal = Calendar.Load(IcsFiles.Parameter2)!;
         Assert.That(iCal.Events, Has.Count.EqualTo(2));
     }
 
@@ -561,7 +561,7 @@ public class DeserializationTests
     [Test]
     public void Property1()
     {
-        var iCal = Calendar.Load(IcsFiles.Property1);
+        var iCal = Calendar.Load(IcsFiles.Property1)!;
 
         IList<ICalendarProperty> props = iCal.Properties.AllOf("VERSION").ToList();
         Assert.That(props, Has.Count.EqualTo(2));
@@ -586,7 +586,7 @@ public class DeserializationTests
                       END:VCALENDAR
                       """;
 
-        var calendar = Calendar.Load(calStr);
+        var calendar = Calendar.Load(calStr)!;
 
         Assert.Multiple(() =>
         {
@@ -607,7 +607,7 @@ public class DeserializationTests
                       END:VCALENDAR
                       """;
 
-        var calendar = Calendar.Load(ics);
+        var calendar = Calendar.Load(ics)!;
         var deserialized = new CalendarSerializer(calendar).SerializeToString();
 
         Assert.Multiple(() =>

--- a/Ical.Net.Tests/DeserializationTests.cs
+++ b/Ical.Net.Tests/DeserializationTests.cs
@@ -34,7 +34,7 @@ public class DeserializationTests
         var attendee1 = evt.Attendees[0];
         var attendee2 = evt.Attendees[1];
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // Values
             Assert.That(attendee1.Value, Is.EqualTo(new Uri("mailto:joecool@example.com")));
@@ -43,8 +43,8 @@ public class DeserializationTests
             // MEMBERS
             Assert.That(attendee1.Members, Has.Count.EqualTo(1));
             Assert.That(attendee2.Members.Count, Is.EqualTo(0));
-        });
-        Assert.Multiple(() =>
+        }
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(attendee1.Members[0], Is.EqualTo(new Uri("mailto:DEV-GROUP@example.com").ToString()));
 
@@ -52,13 +52,13 @@ public class DeserializationTests
             Assert.That(attendee1.DelegatedFrom.Count, Is.EqualTo(0));
             Assert.That(attendee2.DelegatedFrom, Has.Count.EqualTo(1));
             Assert.That(attendee2.DelegatedFrom[0], Is.EqualTo(new Uri("mailto:immud@example.com").ToString()));
-        });
-        Assert.Multiple(() =>
+        }
+        using (Assert.EnterMultipleScope())
         {
             // DELEGATED-TO
             Assert.That(attendee1.DelegatedTo.Count, Is.EqualTo(0));
             Assert.That(attendee2.DelegatedTo.Count, Is.EqualTo(0));
-        });
+        }
     }
 
     /// <summary>
@@ -81,14 +81,14 @@ public class DeserializationTests
         // Values
         Assert.That(attendee1[0].Value, Is.EqualTo(new Uri("mailto:joecool@example.com")));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // MEMBERS
             Assert.That(attendee1[0].Members, Has.Count.EqualTo(3));
             Assert.That(attendee1[0].Members[0], Is.EqualTo(new Uri("mailto:DEV-GROUP@example.com").ToString()));
             Assert.That(attendee1[0].Members[1], Is.EqualTo(new Uri("mailto:ANOTHER-GROUP@example.com").ToString()));
             Assert.That(attendee1[0].Members[2], Is.EqualTo(new Uri("mailto:THIRD-GROUP@example.com").ToString()));
-        });
+        }
     }
 
     /// <summary>
@@ -100,11 +100,11 @@ public class DeserializationTests
     public void Bug2033495()
     {
         var iCal = Calendar.Load(IcsFiles.Bug2033495)!;
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(iCal.Events, Has.Count.EqualTo(1));
             Assert.That(iCal.Properties["X-LOTUS-CHILD_UID"]?.Value, Is.EqualTo("XXX"));
-        });
+        }
     }
 
     /// <summary>
@@ -118,21 +118,18 @@ public class DeserializationTests
         Assert.That(iCal.Events, Has.Count.EqualTo(1));
 
         var evt = iCal.Events.First();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(evt.Start?.HasTime, Is.True);
             Assert.That(evt.End?.HasTime, Is.True);
-        });
+        }
 
         var results = evt.GetOccurrences(new LocalDateTime(2010, 1, 17, 0, 0, 0).InZoneLeniently("Asia/Tokyo"))
             .TakeWhileBefore(new LocalDateTime(2010, 2, 1, 0, 0, 0).InZoneLeniently("Asia/Tokyo").ToInstant());
 
         foreach (var o in results)
         {
-            Assert.Multiple(() =>
-            {
-                Assert.That(o.Start.ToInstant(), Is.LessThan(o.End.ToInstant()));
-            });
+            Assert.That(o.Start.ToInstant(), Is.LessThan(o.End.ToInstant()));
         }
     }
 
@@ -201,11 +198,11 @@ public class DeserializationTests
     {
         var calendars = CalendarCollection.Load(IcsFiles.EmptyLines2);
         Assert.That(calendars, Has.Count.EqualTo(2));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(calendars[0].Events, Has.Count.EqualTo(2), "iCalendar should have 2 events");
             Assert.That(calendars[1].Events, Has.Count.EqualTo(2), "iCalendar should have 2 events");
-        });
+        }
     }
 
     /// <summary>
@@ -260,11 +257,11 @@ public class DeserializationTests
         ProgramTest.TestCal(iCal);
         var evt = iCal.Events.First();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(evt.Uid, Is.EqualTo("uuid1153170430406"), "UID should be 'uuid1153170430406'; it is " + evt.Uid);
             Assert.That(evt.Sequence, Is.EqualTo(1), "SEQUENCE should be 1; it is " + evt.Sequence);
-        });
+        }
     }
 
     [Test]
@@ -314,11 +311,11 @@ public class DeserializationTests
         ProgramTest.TestCal(iCal);
         var evt = iCal.Events.First();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(evt.GeographicLocation?.Latitude, Is.EqualTo(37.386013), "Latitude should be 37.386013; it is not.");
             Assert.That(evt.GeographicLocation?.Longitude, Is.EqualTo(-122.082932), "Longitude should be -122.082932; it is not.");
-        });
+        }
     }
 
     [Test]
@@ -385,7 +382,7 @@ public class DeserializationTests
             .Union(iCal.Events[0]!.RecurrenceDates.GetAllDates())
             .ToList();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(iCal.Events, Has.Count.EqualTo(1));
             Assert.That(iCal.Events[0]!.RecurrenceDatesPeriodLists, Has.Count.EqualTo(3));
@@ -398,7 +395,7 @@ public class DeserializationTests
             }
 
             Assert.That(iCal.Events[0]!.RecurrenceDates.Contains(new DataTypes.Period(expectedStartTimes[1], expectedEndTime)));
-        });
+        }
     }
 
     /// <summary>
@@ -412,39 +409,39 @@ public class DeserializationTests
         Assert.That(iCal.Events.First().RequestStatuses, Has.Count.EqualTo(4));
 
         var rs = iCal.Events.First().RequestStatuses[0];
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(rs.StatusCode?.Primary, Is.EqualTo(2));
             Assert.That(rs.StatusCode?.Secondary, Is.EqualTo(0));
             Assert.That(rs.Description, Is.EqualTo("Success"));
-        });
+        }
         Assert.That(rs.ExtraData, Is.Null);
 
         rs = iCal.Events.First().RequestStatuses[1];
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(rs.StatusCode?.Primary, Is.EqualTo(3));
             Assert.That(rs.StatusCode?.Secondary, Is.EqualTo(1));
             Assert.That(rs.Description, Is.EqualTo("Invalid property value"));
             Assert.That(rs.ExtraData, Is.EqualTo("DTSTART:96-Apr-01"));
-        });
+        }
 
         rs = iCal.Events.First().RequestStatuses[2];
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(rs.StatusCode?.Primary, Is.EqualTo(2));
             Assert.That(rs.StatusCode?.Secondary, Is.EqualTo(8));
             Assert.That(rs.Description, Is.EqualTo(" Success, repeating event ignored. Scheduled as a single event."));
             Assert.That(rs.ExtraData, Is.EqualTo("RRULE:FREQ=WEEKLY;INTERVAL=2"));
-        });
+        }
 
         rs = iCal.Events.First().RequestStatuses[3];
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(rs.StatusCode?.Primary, Is.EqualTo(4));
             Assert.That(rs.StatusCode?.Secondary, Is.EqualTo(1));
             Assert.That(rs.Description, Is.EqualTo("Event conflict. Date/time is busy."));
-        });
+        }
         Assert.That(rs.ExtraData, Is.Null);
     }
 
@@ -524,12 +521,12 @@ public class DeserializationTests
 
         var evt = iCal.Events.First();
         IList<CalendarParameter> parms = evt.Properties["DTSTART"]!.Parameters.AllOf("VALUE").ToList();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(parms, Has.Count.EqualTo(2));
             Assert.That(parms[0].Values.First(), Is.EqualTo("DATE"));
             Assert.That(parms[1].Values.First(), Is.EqualTo("OTHER"));
-        });
+        }
     }
 
     /// <summary>
@@ -588,11 +585,11 @@ public class DeserializationTests
 
         var calendar = Calendar.Load(calStr)!;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(calendar.Events.Single().DtEnd != null, Is.EqualTo(useDtEnd));
             Assert.That(calendar.Events.Single().Duration != null, Is.EqualTo(!useDtEnd));
-        });
+        }
     }
 
     [Test]
@@ -610,13 +607,13 @@ public class DeserializationTests
         var calendar = Calendar.Load(ics)!;
         var deserialized = new CalendarSerializer(calendar).SerializeToString();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(calendar.ProductId, Is.EqualTo(null));
             Assert.That(calendar.Version, Is.EqualTo(null));
             // The serialized calendar should not contain the PRODID or VERSION properties, which are required
             Assert.That(deserialized, Does.Not.Contain("PRODID:").And.Not.Contains("VERSION:"));
-        });
+        }
     }
 
     [Test, Category("DurationSerializer")]
@@ -653,10 +650,10 @@ public class DeserializationTests
     [TestCase("Invalid")]
     public void Duration_InvalidArguments_ShouldThrow(string text)
     {
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(new DurationSerializer().Deserialize(new StringReader(text)), Is.Null);
             Assert.That(DataTypes.Duration.Parse(text), Is.Null);
-        });
+        }
     }
 }

--- a/Ical.Net.Tests/EncodingProviderTests.cs
+++ b/Ical.Net.Tests/EncodingProviderTests.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 //
 
-#nullable enable
 using System;
 using System.Runtime.Serialization;
 using Ical.Net.Serialization;

--- a/Ical.Net.Tests/EqualityAndHashingTests.cs
+++ b/Ical.Net.Tests/EqualityAndHashingTests.cs
@@ -55,7 +55,7 @@ public class EqualityAndHashingTests
         DtEnd = new CalDateTime(_later),
     };
 
-    private static string SerializeEvent(CalendarEvent e) => new CalendarSerializer().SerializeToString(new Calendar { Events = { e } });
+    private static string SerializeEvent(CalendarEvent e) => new CalendarSerializer().SerializeToString(new Calendar { Events = { e } })!;
 
     [Test]
     public void Resources_Tests()
@@ -179,7 +179,7 @@ public class EqualityAndHashingTests
         Assert.That(asUtc, Is.Not.EqualTo(asLocal));
     }
 
-    private void TestComparison(Func<CalDateTime, CalDateTime, bool> calOp, Func<int?, int?, bool> intOp)
+    private void TestComparison(Func<CalDateTime?, CalDateTime?, bool> calOp, Func<int?, int?, bool> intOp)
     {
         int? intSome = 1;
         int? intGreater = 2;

--- a/Ical.Net.Tests/EqualityAndHashingTests.cs
+++ b/Ical.Net.Tests/EqualityAndHashingTests.cs
@@ -26,13 +26,13 @@ public class EqualityAndHashingTests
     [Test, TestCaseSource(nameof(CalDateTime_TestCases))]
     public void CalDateTime_Tests(CalDateTime incomingDt, CalDateTime expectedDt)
     {
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(expectedDt.Value, Is.EqualTo(incomingDt.Value));
             Assert.That(expectedDt.GetHashCode(), Is.EqualTo(incomingDt.GetHashCode()));
             Assert.That(expectedDt.TzId, Is.EqualTo(incomingDt.TzId));
             Assert.That(incomingDt.Equals(expectedDt), Is.True);
-        });
+        }
     }
 
     public static IEnumerable CalDateTime_TestCases()
@@ -84,13 +84,13 @@ public class EqualityAndHashingTests
         e.Resources.AddRange(origContents);
         Assert.That(origContents, Is.EquivalentTo(e.Resources));
         serialized = SerializeEvent(e);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(serialized, Does.Contain("Foo"));
             Assert.That(serialized, Does.Contain("Bar"));
             Assert.That(serialized, Does.Not.Contain("Baz"));
             Assert.That(serialized, Does.Not.Contain("Hello"));
-        });
+        }
     }
 
     private static (byte[] original, byte[] copy) GetAttachments()
@@ -104,11 +104,11 @@ public class EqualityAndHashingTests
     [Test, TestCaseSource(nameof(PeriodTestCases))]
     public void PeriodTests(Period a, Period b)
     {
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(b.GetHashCode(), Is.EqualTo(a.GetHashCode()));
             Assert.That(b, Is.EqualTo(a));
-        });
+        }
     }
 
     public static IEnumerable PeriodTestCases()
@@ -160,11 +160,11 @@ public class EqualityAndHashingTests
         var aThenB = new List<PeriodList> { a, b };
         var bThenA = new List<PeriodList> { b, a };
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(collectionEqual, Is.EqualTo(true));
             Assert.That(CollectionHelpers.Equals(aThenB, bThenA), Is.True);
-        });
+        }
     }
 
     [Test]
@@ -187,7 +187,7 @@ public class EqualityAndHashingTests
         var dtSome = new CalDateTime(2018, 1, 1);
         var dtGreater = new CalDateTime(2019, 1, 1);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(calOp(null, null), Is.EqualTo(intOp(null, null)));
             Assert.That(calOp(null, dtSome), Is.EqualTo(intOp(null, intSome)));
@@ -195,7 +195,7 @@ public class EqualityAndHashingTests
             Assert.That(calOp(dtSome, dtSome), Is.EqualTo(intOp(intSome, intSome)));
             Assert.That(calOp(dtSome, dtGreater), Is.EqualTo(intOp(intSome, intGreater)));
             Assert.That(calOp(dtGreater, dtSome), Is.EqualTo(intOp(intGreater, intSome)));
-        });
+        }
     }
 
     [Test]

--- a/Ical.Net.Tests/FreeBusyTest.cs
+++ b/Ical.Net.Tests/FreeBusyTest.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 //
 
-#nullable enable
 using System;
 using System.Collections.Generic;
 using Ical.Net.CalendarComponents;

--- a/Ical.Net.Tests/FreeBusyTest.cs
+++ b/Ical.Net.Tests/FreeBusyTest.cs
@@ -36,7 +36,7 @@ public class FreeBusyTest
             new CalDateTime(2025, 10, 1, 0, 0, 0),
             new CalDateTime(2025, 10, 7, 11, 59, 59))!;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(freeBusy.GetFreeBusyStatus(new CalDateTime(2025, 10, 1, 7, 59, 59).ToTimeZone("America/New_York")),
                 Is.EqualTo(FreeBusyStatus.Free));
@@ -46,7 +46,7 @@ public class FreeBusyTest
                 Is.EqualTo(FreeBusyStatus.Busy));
             Assert.That(freeBusy.GetFreeBusyStatus(new CalDateTime(2025, 10, 1, 9, 0, 0).ToTimeZone("America/New_York")),
                 Is.EqualTo(FreeBusyStatus.Free));
-        });
+        }
     }
 
     [Test, Category("FreeBusy")]
@@ -64,7 +64,7 @@ public class FreeBusyTest
             new CalDateTime(2025, 6, 1, 0, 0, 0, "UTC"),
             new CalDateTime(2025, 6, 7, 0, 0, 0, "UTC"))!;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // Period completely before the event (ends when event starts)
             var periodBefore = new Period(new CalDateTime(2025, 6, 1, 7, 0, 0, "UTC"),
@@ -89,7 +89,7 @@ public class FreeBusyTest
                                          new CalDateTime(2025, 6, 1, 12, 0, 0, "UTC"));
             Assert.That(freeBusy.GetFreeBusyStatus(periodAfter),
                 Is.EqualTo(FreeBusyStatus.Free));
-        });
+        }
     }
 
     [Test]
@@ -104,7 +104,7 @@ public class FreeBusyTest
 
         // Period with duration: effective end time = start + 1 hour (exclusive)
         var periodWithDuration = new FreeBusyEntry(new(new(start), Duration.FromHours(1)), FreeBusyStatus.Free);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(periodWithDuration.Contains(null), Is.False, "Contains should return false for null dt.");
             Assert.That(periodWithDuration.Contains(dtBefore), Is.False, "Contains should return false if dt is before start.");
@@ -112,7 +112,7 @@ public class FreeBusyTest
             Assert.That(periodWithDuration.Contains(dtMid), Is.True, "Contains should return true for dt in the middle.");
             Assert.That(periodWithDuration.Contains(dtAtEnd), Is.False, "Contains should return false for dt equal to effective end (exclusive).");
             Assert.That(periodWithDuration.Contains(dtAfter), Is.False, "Contains should return false for dt after effective end.");
-        });
+        }
     }
 
 
@@ -122,12 +122,12 @@ public class FreeBusyTest
         var f1 = new FreeBusyEntry(period1, FreeBusyStatus.Free);
         var f2 = period2 is null ? null : new FreeBusyEntry(period2, FreeBusyStatus.Free);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(f1.CollidesWith(f2), Is.EqualTo(expected));
 
             Assert.That(f2?.CollidesWith(f1) == true, Is.EqualTo(expected));
-        });
+        }
     }
 
     private static IEnumerable<TestCaseData> CollidesWithPeriodTestCases

--- a/Ical.Net.Tests/Ical.Net.Tests.csproj
+++ b/Ical.Net.Tests/Ical.Net.Tests.csproj
@@ -3,7 +3,7 @@
         <TargetFrameworks>net10.0;net8.0;net48</TargetFrameworks>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>..\IcalNetStrongnameKey.snk</AssemblyOriginatorKeyFile>
-        <nullable>disable</nullable>
+        <nullable>enable</nullable>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/Ical.Net.Tests/IcsFiles.cs
+++ b/Ical.Net.Tests/IcsFiles.cs
@@ -14,10 +14,8 @@ internal class IcsFiles
 
     internal static string ReadStream(string manifestResource)
     {
-        using (var stream = _assembly.GetManifestResourceStream(manifestResource))
-        {
-            return new StreamReader(stream).ReadToEnd();
-        }
+        using var stream = _assembly.GetManifestResourceStream(manifestResource)!;
+        return new StreamReader(stream).ReadToEnd();
     }
 
     internal static string Alarm1 => ReadStream("Ical.Net.Tests.Calendars.Alarm.ALARM1.ics");

--- a/Ical.Net.Tests/JournalTest.cs
+++ b/Ical.Net.Tests/JournalTest.cs
@@ -15,7 +15,7 @@ public class JournalTest
     [Test, Category("Journal")]
     public void Journal1()
     {
-        var iCal = Calendar.Load(IcsFiles.Journal1);
+        var iCal = Calendar.Load(IcsFiles.Journal1)!;
         ProgramTest.TestCal(iCal);
         Assert.That(iCal.Journals, Has.Count.EqualTo(1));
         var j = iCal.Journals[0];
@@ -23,7 +23,7 @@ public class JournalTest
         Assert.Multiple(() =>
         {
             Assert.That(j, Is.Not.Null, "Journal entry was null");
-            Assert.That(j.Status, Is.EqualTo(JournalStatus.Draft), "Journal entry should have been in DRAFT status, but it was in " + j.Status + " status.");
+            Assert.That(j!.Status, Is.EqualTo(JournalStatus.Draft), "Journal entry should have been in DRAFT status, but it was in " + j.Status + " status.");
             Assert.That(j.Class, Is.EqualTo("PUBLIC"), "Journal class should have been PUBLIC, but was " + j.Class + ".");
         });
         Assert.That(j.Start, Is.Null);
@@ -32,7 +32,7 @@ public class JournalTest
     [Test, Category("Journal")]
     public void Journal2()
     {
-        var iCal = Calendar.Load(IcsFiles.Journal2);
+        var iCal = Calendar.Load(IcsFiles.Journal2)!;
         ProgramTest.TestCal(iCal);
         Assert.That(iCal.Journals, Has.Count.EqualTo(1));
         var j = iCal.Journals.First();
@@ -42,29 +42,29 @@ public class JournalTest
             Assert.That(j, Is.Not.Null, "Journal entry was null");
             Assert.That(j.Status, Is.EqualTo(JournalStatus.Final), "Journal entry should have been in FINAL status, but it was in " + j.Status + " status.");
             Assert.That(j.Class, Is.EqualTo("PRIVATE"), "Journal class should have been PRIVATE, but was " + j.Class + ".");
-            Assert.That(j.Organizer.CommonName, Is.EqualTo("JohnSmith"), "Organizer common name should have been JohnSmith, but was " + j.Organizer.CommonName);
+            Assert.That(j.Organizer?.CommonName, Is.EqualTo("JohnSmith"), "Organizer common name should have been JohnSmith, but was " + j.Organizer?.CommonName);
             Assert.That(
                 string.Equals(
-                    j.Organizer.SentBy.OriginalString,
+                    j.Organizer?.SentBy?.OriginalString,
                     "mailto:jane_doe@host.com",
                     StringComparison.OrdinalIgnoreCase),
                 Is.True,
-                "Organizer should have had been SENT-BY 'mailto:jane_doe@host.com'; it was sent by '" + j.Organizer.SentBy + "'");
+                "Organizer should have had been SENT-BY 'mailto:jane_doe@host.com'; it was sent by '" + j.Organizer?.SentBy + "'");
             Assert.That(
                 string.Equals(
-                    j.Organizer.DirectoryEntry.OriginalString,
+                    j.Organizer?.DirectoryEntry?.OriginalString,
                     "ldap://host.com:6666/o=3DDC%20Associates,c=3DUS??(cn=3DJohn%20Smith)",
                     StringComparison.OrdinalIgnoreCase),
                 Is.True,
-                "Organizer's directory entry should have been 'ldap://host.com:6666/o=3DDC%20Associates,c=3DUS??(cn=3DJohn%20Smith)', but it was '" + j.Organizer.DirectoryEntry + "'");
+                "Organizer's directory entry should have been 'ldap://host.com:6666/o=3DDC%20Associates,c=3DUS??(cn=3DJohn%20Smith)', but it was '" + j.Organizer?.DirectoryEntry + "'");
             Assert.That(
-                j.Organizer.Value.OriginalString,
+                j.Organizer?.Value?.OriginalString,
                 Is.EqualTo("MAILTO:jsmith@host.com"));
             Assert.That(
-                j.Organizer.Value.UserInfo,
+                j.Organizer?.Value?.UserInfo,
                 Is.EqualTo("jsmith"));
             Assert.That(
-                j.Organizer.Value.Host,
+                j.Organizer?.Value?.Host,
                 Is.EqualTo("host.com"));
             Assert.That(j.Start, Is.Null);
         });
@@ -73,11 +73,11 @@ public class JournalTest
     [Test, Category("Journal")]
     public void Journal3()
     {
-        var iCal = Calendar.Load(IcsFiles.Journal3);
+        var iCal = Calendar.Load(IcsFiles.Journal3)!;
         ProgramTest.TestCal(iCal);
         Assert.That(iCal.Journals, Has.Count.EqualTo(1));
         var j = iCal.Journals.First();
 
-        Assert.That(j.Organizer.SentBy, Is.Null, "Expected Organizer's SENT-BY to be null, but it was not.");
+        Assert.That(j.Organizer?.SentBy, Is.Null, "Expected Organizer's SENT-BY to be null, but it was not.");
     }
 }

--- a/Ical.Net.Tests/JournalTest.cs
+++ b/Ical.Net.Tests/JournalTest.cs
@@ -20,12 +20,12 @@ public class JournalTest
         Assert.That(iCal.Journals, Has.Count.EqualTo(1));
         var j = iCal.Journals[0];
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(j, Is.Not.Null, "Journal entry was null");
             Assert.That(j!.Status, Is.EqualTo(JournalStatus.Draft), "Journal entry should have been in DRAFT status, but it was in " + j.Status + " status.");
             Assert.That(j.Class, Is.EqualTo("PUBLIC"), "Journal class should have been PUBLIC, but was " + j.Class + ".");
-        });
+        }
         Assert.That(j.Start, Is.Null);
     }
 
@@ -37,7 +37,7 @@ public class JournalTest
         Assert.That(iCal.Journals, Has.Count.EqualTo(1));
         var j = iCal.Journals.First();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(j, Is.Not.Null, "Journal entry was null");
             Assert.That(j.Status, Is.EqualTo(JournalStatus.Final), "Journal entry should have been in FINAL status, but it was in " + j.Status + " status.");
@@ -67,7 +67,7 @@ public class JournalTest
                 j.Organizer?.Value?.Host,
                 Is.EqualTo("host.com"));
             Assert.That(j.Start, Is.Null);
-        });
+        }
     }
 
     [Test, Category("Journal")]

--- a/Ical.Net.Tests/Logging.Tests/LoggingProviderTests.cs
+++ b/Ical.Net.Tests/Logging.Tests/LoggingProviderTests.cs
@@ -2,7 +2,7 @@
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
-#nullable enable
+
 using System;
 using System.Linq;
 using System.Threading;

--- a/Ical.Net.Tests/Logging.Tests/SerilogAbstractionTests.cs
+++ b/Ical.Net.Tests/Logging.Tests/SerilogAbstractionTests.cs
@@ -2,13 +2,12 @@
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
-#nullable enable
+
 using System;
 using System.IO;
 using Ical.Net.Tests.Logging.Abstractions;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
-using Serilog;
 using Serilog.Events;
 
 namespace Ical.Net.Tests.Logging.Tests;

--- a/Ical.Net.Tests/Logging.Tests/TestLoggingManagerTests.cs
+++ b/Ical.Net.Tests/Logging.Tests/TestLoggingManagerTests.cs
@@ -2,7 +2,7 @@
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
-#nullable enable
+
 using System;
 using System.Linq;
 using Ical.Net.DataTypes;

--- a/Ical.Net.Tests/Logging/Abstractions/InMemorySink.cs
+++ b/Ical.Net.Tests/Logging/Abstractions/InMemorySink.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 //
 
-#nullable enable
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;

--- a/Ical.Net.Tests/Logging/Abstractions/InMemorySink.cs
+++ b/Ical.Net.Tests/Logging/Abstractions/InMemorySink.cs
@@ -13,13 +13,14 @@ namespace Ical.Net.Tests.Logging.Abstractions;
 
 internal class InMemorySink : ILogEventSink
 {
-    public static InMemorySink Instance;
+    public static InMemorySink Instance = null!;
 
-    private ConcurrentQueue<Serilog.Events.LogEvent> _events { get; } = new();
+    private ConcurrentQueue<Serilog.Events.LogEvent> Events { get; } = new();
 
     public InMemorySink()
     {
         Instance = this;
+        OutputTemplate = Options.DefaultOutputTemplate;
     }
 
     public int MaxLogsCount { get; set; } = Options.DefaultMaxLogsCount;
@@ -33,7 +34,7 @@ internal class InMemorySink : ILogEventSink
             var formatter = new MessageTemplateTextFormatter(OutputTemplate, CultureInfo.InvariantCulture);
             using var writer = new System.IO.StringWriter();
 
-            foreach (var logEvent in _events)
+            foreach (var logEvent in Events)
             {
                 formatter.Format(logEvent, writer);
                 yield return writer.ToString().TrimEnd(System.Environment.NewLine.ToCharArray());
@@ -44,10 +45,10 @@ internal class InMemorySink : ILogEventSink
 
     public void Emit(Serilog.Events.LogEvent logEvent)
     {
-        if (_events.Count >= MaxLogsCount)
+        if (Events.Count >= MaxLogsCount)
         {
-            _events.TryDequeue(out _);
+            Events.TryDequeue(out _);
         }
-        _events.Enqueue(logEvent);
+        Events.Enqueue(logEvent);
     }
 }

--- a/Ical.Net.Tests/Logging/Abstractions/InMemorySink.cs
+++ b/Ical.Net.Tests/Logging/Abstractions/InMemorySink.cs
@@ -15,7 +15,7 @@ internal class InMemorySink : ILogEventSink
 {
     public static InMemorySink Instance = null!;
 
-    private ConcurrentQueue<Serilog.Events.LogEvent> Events { get; } = new();
+    private readonly ConcurrentQueue<Serilog.Events.LogEvent> _events = new();
 
     public InMemorySink()
     {
@@ -34,7 +34,7 @@ internal class InMemorySink : ILogEventSink
             var formatter = new MessageTemplateTextFormatter(OutputTemplate, CultureInfo.InvariantCulture);
             using var writer = new System.IO.StringWriter();
 
-            foreach (var logEvent in Events)
+            foreach (var logEvent in _events)
             {
                 formatter.Format(logEvent, writer);
                 yield return writer.ToString().TrimEnd(System.Environment.NewLine.ToCharArray());
@@ -45,10 +45,10 @@ internal class InMemorySink : ILogEventSink
 
     public void Emit(Serilog.Events.LogEvent logEvent)
     {
-        if (Events.Count >= MaxLogsCount)
+        if (_events.Count >= MaxLogsCount)
         {
-            Events.TryDequeue(out _);
+            _events.TryDequeue(out _);
         }
-        Events.Enqueue(logEvent);
+        _events.Enqueue(logEvent);
     }
 }

--- a/Ical.Net.Tests/Logging/Abstractions/SerilogAbstractions.cs
+++ b/Ical.Net.Tests/Logging/Abstractions/SerilogAbstractions.cs
@@ -2,7 +2,7 @@
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
-#nullable enable
+
 using System.Globalization;
 using Ical.Net.Tests.Logging.Adapters;
 using Microsoft.Extensions.Logging;

--- a/Ical.Net.Tests/Logging/Abstractions/TestLoggerFactory.cs
+++ b/Ical.Net.Tests/Logging/Abstractions/TestLoggerFactory.cs
@@ -2,7 +2,7 @@
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
-#nullable enable
+
 using System;
 using Microsoft.Extensions.Logging;
 

--- a/Ical.Net.Tests/Logging/Adapters/MicrosoftLoggerAdapter.cs
+++ b/Ical.Net.Tests/Logging/Adapters/MicrosoftLoggerAdapter.cs
@@ -2,7 +2,7 @@
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
-#nullable enable
+
 using System;
 using Microsoft.Extensions.Logging;
 

--- a/Ical.Net.Tests/Logging/Adapters/MicrosoftLoggerFactoryAdapter.cs
+++ b/Ical.Net.Tests/Logging/Adapters/MicrosoftLoggerFactoryAdapter.cs
@@ -2,8 +2,6 @@
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
-#nullable enable
-using System;
 
 namespace Ical.Net.Tests.Logging.Adapters;
 

--- a/Ical.Net.Tests/Logging/Filter.cs
+++ b/Ical.Net.Tests/Logging/Filter.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using Microsoft.Extensions.Logging;
 
 namespace Ical.Net.Tests.Logging;

--- a/Ical.Net.Tests/Logging/Options.cs
+++ b/Ical.Net.Tests/Logging/Options.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 

--- a/Ical.Net.Tests/Logging/TestLoggingManager.cs
+++ b/Ical.Net.Tests/Logging/TestLoggingManager.cs
@@ -2,7 +2,6 @@
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
-#nullable enable
 
 namespace Ical.Net.Tests.Logging;
 

--- a/Ical.Net.Tests/Logging/TestLoggingManagerBase.cs
+++ b/Ical.Net.Tests/Logging/TestLoggingManagerBase.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 
-#nullable enable
 using System;
 using System.Collections.Generic;
 using Ical.Net.Tests.Logging.Abstractions;

--- a/Ical.Net.Tests/Logging/ToLogExtensions.cs
+++ b/Ical.Net.Tests/Logging/ToLogExtensions.cs
@@ -2,7 +2,7 @@
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
-#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Ical.Net.Tests/MatchTimeZoneTests.cs
+++ b/Ical.Net.Tests/MatchTimeZoneTests.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Linq;
 using Ical.Net.DataTypes;
-using Ical.Net.Utility;
 using NUnit.Framework;
 
 namespace Ical.Net.Tests;

--- a/Ical.Net.Tests/MatchTimeZoneTests.cs
+++ b/Ical.Net.Tests/MatchTimeZoneTests.cs
@@ -32,7 +32,7 @@ public class MatchTimeZoneTests
             END:VCALENDAR
             """;
 
-        var calendar = Calendar.Load(ical);
+        var calendar = Calendar.Load(ical)!;
         var evt = calendar.Events.First();
         var until = evt.RecurrenceRules.First().Until;
 
@@ -78,7 +78,7 @@ public class MatchTimeZoneTests
             END:VCALENDAR
             """;
 
-        var calendar = Calendar.Load(ical);
+        var calendar = Calendar.Load(ical)!;
         var evt = calendar.Events.First();
         var until = evt.RecurrenceRules.First().Until;
 
@@ -128,7 +128,7 @@ public class MatchTimeZoneTests
             END:VCALENDAR
             """;
 
-        var calendar = Calendar.Load(ical);
+        var calendar = Calendar.Load(ical)!;
         var evt = calendar.Events.First();
         var until = evt.RecurrenceRules.First().Until;
 
@@ -161,7 +161,7 @@ public class MatchTimeZoneTests
             END:VCALENDAR
             """;
 
-        var calendar = Calendar.Load(ical);
+        var calendar = Calendar.Load(ical)!;
         var evt = calendar.Events.First();
         var until = evt.RecurrenceRules.First().Until;
 
@@ -195,7 +195,7 @@ public class MatchTimeZoneTests
             END:VCALENDAR
             """;
 
-        var calendar = Calendar.Load(ical);
+        var calendar = Calendar.Load(ical)!;
         var evt = calendar.Events.First();
         var until = evt.RecurrenceRules.First().Until;
 
@@ -228,7 +228,7 @@ public class MatchTimeZoneTests
             END:VCALENDAR
             """;
 
-        var calendar = Calendar.Load(ical);
+        var calendar = Calendar.Load(ical)!;
         var evt = calendar.Events.First();
         var until = evt.RecurrenceRules.First().Until;
 

--- a/Ical.Net.Tests/MatchTimeZoneTests.cs
+++ b/Ical.Net.Tests/MatchTimeZoneTests.cs
@@ -39,7 +39,7 @@ public class MatchTimeZoneTests
         var expectedUntil = new CalDateTime(2023, 11, 05, 13, 00, 00, CalDateTime.UtcTzId);
         var occurrences = evt.GetOccurrences(new CalDateTime(2023, 11, 01)).TakeWhileBefore(new CalDateTime(2023, 11, 06));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(until, Is.EqualTo(expectedUntil));
             Assert.That(occurrences.Count, Is.EqualTo(4));
@@ -54,7 +54,7 @@ public class MatchTimeZoneTests
                must NOT be included, because 20231105T130000Z => November 5, 2023: 08:00 AM (America/New_York)
                (Daylight Saving Time in America/New_York ended on Sunday, November 5, 2023, at 2:00 AM)
            */
-        });
+        }
     }
 
     [Test, Category("Recurrence")]
@@ -90,7 +90,7 @@ public class MatchTimeZoneTests
         var occurrences = evt.GetOccurrences(new CalDateTime(2024, 10, 01).ToZonedDateTime("Australia/Sydney"))
             .TakeWhileBefore(new CalDateTime(2024, 10, 07));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(until, Is.EqualTo(expectedUntil));
             Assert.That(occurrences.Count, Is.EqualTo(expectedOccurrences));
@@ -106,7 +106,7 @@ public class MatchTimeZoneTests
                October 6, 2024: 01:00 AM - 02:00 AM (UTC+1100) (Australia/Sydney)
                (Daylight Saving Time in Australia/Sydney starts on Sunday, October 6, 2024, at 2:00 AM)
            */
-        });
+        }
     }
 
     [Test, Category("Recurrence")]
@@ -135,11 +135,11 @@ public class MatchTimeZoneTests
         var expectedUntil = new CalDateTime(2023, 11, 05, 09, 00, 00, CalDateTime.UtcTzId);
         var occurrences = evt.GetOccurrences(new CalDateTime(2023, 11, 01)).TakeWhileBefore(new CalDateTime(2023, 11, 06));
         
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(until, Is.EqualTo(expectedUntil));
             Assert.That(occurrences.Count, Is.EqualTo(5));
-        });
+        }
     }
 
     [Test, Category("Recurrence")]
@@ -168,11 +168,11 @@ public class MatchTimeZoneTests
         var expectedUntil = new CalDateTime(2023, 11, 05, 09, 00, 00, null);
         var occurrences = evt.GetOccurrences(new CalDateTime(2023, 11, 01)).TakeWhileBefore(new CalDateTime(2023, 11, 06));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(until, Is.EqualTo(expectedUntil));
             Assert.That(occurrences.Count, Is.EqualTo(5));
-        });
+        }
 
     }
 
@@ -202,11 +202,11 @@ public class MatchTimeZoneTests
         var expectedUntil = new CalDateTime(2023, 11, 05, 09, 00, 00, null);
         var occurrences = evt.GetOccurrences(new CalDateTime(2023, 11, 01)).TakeWhileBefore(new CalDateTime(2023, 11, 06));
         
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(until, Is.EqualTo(expectedUntil));
             Assert.That(occurrences.Count, Is.EqualTo(5));
-        });
+        }
     }
 
     [Test, Category("Recurrence")]
@@ -235,10 +235,10 @@ public class MatchTimeZoneTests
         var expectedUntil = new CalDateTime(2023, 11, 05);
         var occurrences = evt.GetOccurrences(new CalDateTime(2023, 11, 01)).TakeWhileBefore(new CalDateTime(2023, 11, 06));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(until, Is.EqualTo(expectedUntil));
             Assert.That(occurrences.Count, Is.EqualTo(5));
-        });
+        }
     }
 }

--- a/Ical.Net.Tests/PeriodListTest.cs
+++ b/Ical.Net.Tests/PeriodListTest.cs
@@ -3,8 +3,6 @@
 // Licensed under the MIT license.
 //
 
-#nullable enable
-using System;
 using System.IO;
 using Ical.Net.DataTypes;
 using Ical.Net.Utility;

--- a/Ical.Net.Tests/PeriodListTest.cs
+++ b/Ical.Net.Tests/PeriodListTest.cs
@@ -44,12 +44,12 @@ public class PeriodListTests
         periodList[1] = period2;
 
         // Assert
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(period1, Is.EqualTo(retrievedPeriod));
             Assert.That(periodList.Contains(period1), Is.True);
             Assert.That(periodList[periodList.IndexOf(period2)], Is.EqualTo(period2));
-        });
+        }
     }
 
     [Test]
@@ -81,7 +81,7 @@ public class PeriodListTests
         periodList.Add(dateTimeUtcPeriod);
 
         // Act & Assert
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(periodList.Count, Is.EqualTo(1));
 
@@ -95,7 +95,7 @@ public class PeriodListTests
             Assert.That(() => periodList.Insert(0, dateOnlyPeriod), Throws.ArgumentException);
             ;
             Assert.That(periodList.Count, Is.EqualTo(1));
-        });
+        }
 
     }
     [Test]
@@ -116,11 +116,11 @@ public class PeriodListTests
         periodList.Clear();
 
         // Assert
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(count, Is.EqualTo(2));
             Assert.That(periodList, Has.Count.EqualTo(0));
-        });
+        }
     }
 
     [Test]
@@ -134,7 +134,7 @@ public class PeriodListTests
         var periodList = PeriodList.FromStringReader(reader);
 
         // Assert
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(periodList, Has.Count.EqualTo(2));
             Assert.That(periodList[0].StartTime, Is.EqualTo(new CalDateTime(2025, 1, 1, 0, 0, 0, "UTC")));
@@ -142,7 +142,7 @@ public class PeriodListTests
             Assert.That(periodList[1].StartTime, Is.EqualTo(new CalDateTime(2025, 1, 2, 0, 0, 0, "UTC")));
             Assert.That(periodList[1].EndTime, Is.EqualTo(new CalDateTime(2025, 1, 2, 1, 0, 0, "UTC")));
             Assert.That(periodList.IsReadOnly, Is.EqualTo(false));
-        });
+        }
     }
 
     [Test]
@@ -160,11 +160,11 @@ public class PeriodListTests
         periodList.Insert(1, period2);
 
         // Assert
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(periodList, Has.Count.EqualTo(3));
             Assert.That(periodList[1], Is.EqualTo(period2));
-        });
+        }
     }
 
     [Test]
@@ -183,10 +183,10 @@ public class PeriodListTests
         periodList.RemoveAt(1);
 
         // Assert
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(periodList, Has.Count.EqualTo(2));
             Assert.That(periodList[1], Is.EqualTo(period3));
-        });
+        }
     }
 }

--- a/Ical.Net.Tests/PeriodListWrapperTests.cs
+++ b/Ical.Net.Tests/PeriodListWrapperTests.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 //
 
-#nullable enable
 using System.Linq;
 using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;

--- a/Ical.Net.Tests/PeriodListWrapperTests.cs
+++ b/Ical.Net.Tests/PeriodListWrapperTests.cs
@@ -41,7 +41,7 @@ public class PeriodListWrapperTests
 
         var serialized = new CalendarSerializer(cal).SerializeToString();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // 2 dedicate PeriodList objects
             Assert.That(evt.ExceptionDatesPeriodLists, Has.Count.EqualTo(3));
@@ -69,7 +69,7 @@ public class PeriodListWrapperTests
 
             // A flattened list of all dates
             Assert.That(exDates.GetAllDates().Count(), Is.EqualTo(5));
-        });
+        }
     }
 
     [Test]
@@ -89,7 +89,7 @@ public class PeriodListWrapperTests
         var dateOnlySuccess = exDates.Remove(dateOnly);
         var dateOnlyFail = !exDates.Remove(dateOnly); // already removed
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(dateOnlySuccess, Is.True);
             Assert.That(dateTimeSuccess, Is.True);
@@ -99,7 +99,7 @@ public class PeriodListWrapperTests
             // Empty lists should work as well
             evt.ExceptionDatesPeriodLists.Clear();
             Assert.That(() => exDates.Remove(dateTime), Is.False);
-        });
+        }
     }
 
     #endregion
@@ -127,7 +127,7 @@ public class PeriodListWrapperTests
 
         var serialized = new CalendarSerializer(cal).SerializeToString();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // 2 dedicate PeriodList objects
             Assert.That(evt.RecurrenceDatesPeriodLists, Has.Count.EqualTo(2));
@@ -149,7 +149,7 @@ public class PeriodListWrapperTests
 
             // A flattened list of all dates
             Assert.That(recDates.GetAllDates().Count(), Is.EqualTo(4));
-        });
+        }
     }
 
     [Test]
@@ -190,7 +190,7 @@ public class PeriodListWrapperTests
         evt = cal.Events[0];
 
         // Assert the serialized string and the deserialized event
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // 2 dedicate PeriodList objects
             Assert.That(evt!.RecurrenceDatesPeriodLists, Has.Count.EqualTo(3));
@@ -221,7 +221,7 @@ public class PeriodListWrapperTests
             Assert.That(recPeriod.GetAllDates().Count(), Is.EqualTo(0));
             // A flattened list of all periods
             Assert.That(recPeriod.GetAllPeriods().Count(), Is.EqualTo(6));
-        });
+        }
     }
 
     [Test]
@@ -240,14 +240,14 @@ public class PeriodListWrapperTests
         var period2Success = recDates.Remove(period2);
         var period2Fail = !recDates.Remove(period2); // already removed
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(period2Success, Is.True);
             Assert.That(period1Success, Is.True);
             Assert.That(period2Fail, Is.True);
             Assert.That(evt.RecurrenceDatesPeriodLists[0], Has.Count.EqualTo(1));
             Assert.That(evt.RecurrenceDatesPeriodLists[1], Is.Empty);
-        });
+        }
     }
 
     [Test]
@@ -261,11 +261,11 @@ public class PeriodListWrapperTests
 
         recDates.Add(period1).Add(period2);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(recDates.Contains(period1), Is.True);
             Assert.That(recDates.Contains(period2), Is.True);
-        });
+        }
     }
 
     [Test]
@@ -279,11 +279,11 @@ public class PeriodListWrapperTests
 
         recDates.AddRange([period1, period2]);
         
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(recDates.Contains(new Period(period1.StartTime.AddDays(1), Duration.FromDays(5))), Is.False);
             Assert.That(recDates.Contains(new Period(period2.StartTime.AddDays(1), Duration.FromHours(6))), Is.False);
-        });
+        }
     }
 
     #endregion
@@ -316,11 +316,11 @@ public class PeriodListWrapperTests
 
         exDates.Add(dateOnly).Add(dateTime);
         
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(exDates.Contains(dateOnly), Is.True);
             Assert.That(exDates.Contains(dateTime), Is.True);
-        });
+        }
     }
 
     [Test]
@@ -334,11 +334,11 @@ public class PeriodListWrapperTests
 
         exDates.AddRange([dateOnly, dateTime]);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(exDates.Contains(dateOnly.AddDays(1)), Is.False);
             Assert.That(exDates.Contains(dateTime.AddDays(1)), Is.False);
-        });
+        }
     }
 
     #endregion

--- a/Ical.Net.Tests/PeriodTests.cs
+++ b/Ical.Net.Tests/PeriodTests.cs
@@ -145,7 +145,7 @@ public class PeriodTests
                 "A period should not equal null.");
 
             // Test equality with object of different type.
-            Assert.That(period1.Equals("string"), Is.False,
+            Assert.That(period1!.Equals("string"), Is.False,
                 "A period should not be equal to an object of different type.");
         });
     }

--- a/Ical.Net.Tests/PeriodTests.cs
+++ b/Ical.Net.Tests/PeriodTests.cs
@@ -3,9 +3,7 @@
 // Licensed under the MIT license.
 //
 
-#nullable enable
 using System;
-using System.Collections.Generic;
 using Ical.Net.DataTypes;
 using Ical.Net.Evaluation;
 using NUnit.Framework;

--- a/Ical.Net.Tests/PeriodTests.cs
+++ b/Ical.Net.Tests/PeriodTests.cs
@@ -20,7 +20,7 @@ public class PeriodTests
         var periodWithEndTime = new Period(new CalDateTime(2025, 1, 1, 0, 0, 0, "America/New_York"), new CalDateTime(2025, 1, 1, 1, 0, 0, "America/New_York"));
         var periodWithDuration = new Period(new CalDateTime(2025, 1, 1, 0, 0, 0, "America/New_York"), Duration.FromHours(1));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(period.StartTime, Is.EqualTo(new CalDateTime(2025, 1, 1, 0, 0, 0, "America/New_York")));
             Assert.That(period.EndTime, Is.Null);
@@ -31,13 +31,13 @@ public class PeriodTests
             Assert.That(periodWithDuration.StartTime, Is.EqualTo(new CalDateTime(2025, 1, 1, 0, 0, 0, "America/New_York")));
 
             Assert.That(Period.Create(period.StartTime).Duration, Is.Null);
-        });
+        }
     }
 
     [Test]
     public void CreatePeriodWithInvalidArgumentsShouldThrow()
     {
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // EndTime is before StartTime
             Assert.Throws<ArgumentException>(() => _ = new Period(
@@ -56,7 +56,7 @@ public class PeriodTests
             // StartTime is date-only while EndTime has time
             Assert.Throws<ArgumentException>(() => _ = new Period(new CalDateTime(2025, 1, 2, 0, 0, 0),
                 new CalDateTime(2025, 1, 1)));
-        });
+        }
     }
 
     [Test]
@@ -72,13 +72,13 @@ public class PeriodTests
                 new CalDateTime(2025, 1, 1, 0, 0, 0, null))
         };
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             foreach (var p in periods)
             {
                 Assert.Throws<ArgumentException>(() => _ = new Period(p.Item1, p.Item2));
             }
-        });
+        }
     }
 
     [Test]
@@ -87,7 +87,7 @@ public class PeriodTests
         var dt = new CalDateTime(2025, 6, 1, 0, 0, 0, "Europe/Vienna")
             .ToZonedDateTime();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(new EvaluationPeriod(dt).CompareTo(null),
                 Is.EqualTo(1));
@@ -97,7 +97,7 @@ public class PeriodTests
                 Is.EqualTo(1));
             Assert.That(new EvaluationPeriod(dt).CompareTo(new EvaluationPeriod(dt.PlusHours(1))),
                 Is.EqualTo(-1));
-        });
+        }
     }
 
 
@@ -120,7 +120,7 @@ public class PeriodTests
         var period2 = new Period(new CalDateTime(2025, 1, 1, 0, 0, 0, "America/New_York"), duration1);
         var period3 = new Period(start, duration2);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // Test equality for identical periods.
             Assert.That(period1.Equals(period2), Is.True,
@@ -147,6 +147,6 @@ public class PeriodTests
             // Test equality with object of different type.
             Assert.That(period1!.Equals("string"), Is.False,
                 "A period should not be equal to an object of different type.");
-        });
+        }
     }
 }

--- a/Ical.Net.Tests/ProgramTest.cs
+++ b/Ical.Net.Tests/ProgramTest.cs
@@ -43,7 +43,7 @@ public class ProgramTest
         var iCal2 = Calendar.Load(IcsFiles.MonthlyByDay1)!;
 
         // Change the UID of the 2nd event to make sure it's different
-        iCal2.Events[iCal1.Events[0].Uid!].Uid = "1234567890";
+        iCal2.Events[iCal1.Events[0]!.Uid!].Uid = "1234567890";
         iCal1.MergeWith(iCal2);
 
         var evt1 = iCal1.Events.First();

--- a/Ical.Net.Tests/ProgramTest.cs
+++ b/Ical.Net.Tests/ProgramTest.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Linq;
 using Ical.Net.DataTypes;
-using Ical.Net.Utility;
 using NUnit.Framework;
 
 namespace Ical.Net.Tests;

--- a/Ical.Net.Tests/ProgramTest.cs
+++ b/Ical.Net.Tests/ProgramTest.cs
@@ -104,14 +104,16 @@ public class ProgramTest
             new CalDateTime(1998, 3, 31, 9, 0, 0, _tzid)
         }.Select(x => x.ToZonedDateTime()).ToArray();
 
-        for (var i = 0; i < dateTimes1.Length; i++)
+        using (Assert.EnterMultipleScope())
         {
-            var dt = dateTimes1[i];
-            var start = occurrences[i].Start;
-            Assert.Multiple(() =>
+            for (var i = 0; i < dateTimes1.Length; i++)
             {
-                Assert.That(start, Is.EqualTo(dt));
-            });
+                var dt = dateTimes1[i];
+                var start = occurrences[i].Start;
+                {
+                    Assert.That(start, Is.EqualTo(dt));
+                }
+            }
         }
 
         Assert.That(occurrences, Has.Count.EqualTo(dateTimes1.Length), "There should be exactly " + dateTimes1.Length + " occurrences; there were " + occurrences.Count);

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 //
 
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -120,11 +120,11 @@ public class RecurrenceTests
             {
                 var expectedStart = dt.InZoneLeniently(start.Zone);
                 var dt1 = dt.PlusHours(1).InZoneLeniently(start.Zone);
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(occurrences[i].Start, Is.EqualTo(expectedStart), "Event should occur at " + expectedStart);
                     Assert.That(occurrences[i + 1].Start, Is.EqualTo(dt1), "Event should occur at " + dt1);
-                });
+                }
                 i += 2;
             }
 
@@ -2320,13 +2320,13 @@ public class RecurrenceTests
             .Evaluate(start, start.ToZonedDateTime(_tzid)).TakeWhileBefore(end).ToList();
 
         Assert.That(recurringPeriods, Has.Count.EqualTo(4));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(recurringPeriods[0].Start, Is.EqualTo(new CalDateTime(2020, 1, 6).ToZonedDateTime(_tzid)));
             Assert.That(recurringPeriods[1].Start, Is.EqualTo(new CalDateTime(2020, 1, 13).ToZonedDateTime(_tzid)));
             Assert.That(recurringPeriods[2].Start, Is.EqualTo(new CalDateTime(2020, 1, 20).ToZonedDateTime(_tzid)));
             Assert.That(recurringPeriods[3].Start, Is.EqualTo(new CalDateTime(2020, 1, 27).ToZonedDateTime(_tzid)));
-        });
+        }
     }
 
     [Test, Category("Recurrence")]
@@ -2364,13 +2364,13 @@ public class RecurrenceTests
             .Evaluate(start, start.ToZonedDateTime(_tzid)).TakeWhileBefore(end).ToList();
 
         Assert.That(recurringPeriods, Has.Count.EqualTo(4));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(recurringPeriods[0].Start, Is.EqualTo(new CalDateTime(2020, 1, 6).ToZonedDateTime(_tzid)));
             Assert.That(recurringPeriods[1].Start, Is.EqualTo(new CalDateTime(2020, 1, 13).ToZonedDateTime(_tzid)));
             Assert.That(recurringPeriods[2].Start, Is.EqualTo(new CalDateTime(2020, 1, 20).ToZonedDateTime(_tzid)));
             Assert.That(recurringPeriods[3].Start, Is.EqualTo(new CalDateTime(2020, 1, 27).ToZonedDateTime(_tzid)));
-        });
+        }
     }
 
     /// <summary>
@@ -2546,13 +2546,13 @@ public class RecurrenceTests
         {
             var evt = o.Source as CalendarEvent;
             Assert.That(evt, Is.Not.Null);
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(items.ContainsKey(evt.Summary!), Is.True,
                     "Holiday text '" + evt.Summary + "' did not match known holidays.");
                 Assert.That(o.Start, Is.EqualTo(items[evt.Summary!].ToZonedDateTime(_tzid)),
                     "Date/time of holiday '" + evt.Summary + "' did not match.");
-            });
+            }
         }
     }
 
@@ -2591,11 +2591,11 @@ public class RecurrenceTests
             .Select(x => x.ToInstant())
             .ToList();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(occurrences.Select(x => x.End.ToInstant() > x.Start.ToInstant()), Is.All.True);
             Assert.That(startDates, Is.EqualTo(expectedStartDates));
-        });
+        }
     }
 
     [Test, Category("Recurrence")]
@@ -2614,13 +2614,13 @@ public class RecurrenceTests
             .ToList();
 
         Assert.That(occurrences, Has.Count.EqualTo(4));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(occurrences[0].Start, Is.EqualTo(new CalDateTime(2008, 3, 30, 23, 59, 40).ToZonedDateTime(_tzid)));
             Assert.That(occurrences[1].Start, Is.EqualTo(new CalDateTime(2008, 3, 30, 23, 59, 50).ToZonedDateTime(_tzid)));
             Assert.That(occurrences[2].Start, Is.EqualTo(new CalDateTime(2008, 3, 31, 00, 00, 00).ToZonedDateTime(_tzid)));
             Assert.That(occurrences[3].Start, Is.EqualTo(new CalDateTime(2008, 3, 31, 00, 00, 10).ToZonedDateTime(_tzid)));
-        });
+        }
     }
 
     [Test, Category("Recurrence")]
@@ -2690,7 +2690,7 @@ public class RecurrenceTests
     [Test, Category("Recurrence")]
     public void TryingToSetInvalidFrequency_ShouldThrow()
     {
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // Using the constructor
             Assert.That(() => _ = new RecurrencePattern((FrequencyType) int.MaxValue, 1),
@@ -2699,7 +2699,7 @@ public class RecurrenceTests
             // Using the property
             Assert.That(() => _ = new RecurrencePattern { Frequency = (FrequencyType) 9876543 },
                 Throws.TypeOf<ArgumentOutOfRangeException>());
-        });
+        }
     }
 
     [Test, Category("Recurrence")]
@@ -2744,7 +2744,7 @@ public class RecurrenceTests
             .ToList();
 
         Assert.That(periods, Has.Count.EqualTo(10));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(periods[0].Start.Day, Is.EqualTo(2));
             Assert.That(periods[1].Start.Day, Is.EqualTo(3));
@@ -2756,7 +2756,7 @@ public class RecurrenceTests
             Assert.That(periods[7].Start.Day, Is.EqualTo(24));
             Assert.That(periods[8].Start.Day, Is.EqualTo(30));
             Assert.That(periods[9].Start.Day, Is.EqualTo(31));
-        });
+        }
     }
 
     [Test]
@@ -3002,19 +3002,19 @@ END:VCALENDAR";
 
         var expectedSept1Start = new CalDateTime(DateTime.Parse("2016-09-01T16:30:00", CultureInfo.InvariantCulture), "Europe/Bucharest").ToZonedDateTime();
         var expectedSept1End = new CalDateTime(DateTime.Parse("2016-09-01T22:00:00", CultureInfo.InvariantCulture), "Europe/Bucharest").ToZonedDateTime();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(orderedOccurrences[3].Start, Is.EqualTo(expectedSept1Start));
             Assert.That(orderedOccurrences[3].End, Is.EqualTo(expectedSept1End));
-        });
+        }
 
         var expectedSept3Start = new CalDateTime(DateTime.Parse("2016-09-03T07:00:00", CultureInfo.InvariantCulture), "Europe/Bucharest").ToZonedDateTime();
         var expectedSept3End = new CalDateTime(DateTime.Parse("2016-09-03T12:30:00", CultureInfo.InvariantCulture), "Europe/Bucharest").ToZonedDateTime();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(orderedOccurrences[5].Start, Is.EqualTo(expectedSept3Start));
             Assert.That(orderedOccurrences[5].End, Is.EqualTo(expectedSept3End));
-        });
+        }
     }
 
     [Test]
@@ -3667,7 +3667,7 @@ END:VCALENDAR";
         var serializer = new RecurrencePatternSerializer();
         var recurrencePattern = serializer.Deserialize(new StringReader(rRule)) as RecurrencePattern;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(recurrencePattern, Is.Not.Null);
             Assert.That(recurrencePattern?.Until, Is.Not.Null);
@@ -3675,7 +3675,7 @@ END:VCALENDAR";
                 Is.EqualTo(new CalDateTime(2025, 4, 30, 0, 0, 0, CalDateTime.UtcTzId)));
             Assert.That(recurrencePattern?.Frequency, Is.EqualTo(FrequencyType.Daily));
             Assert.That(recurrencePattern?.Interval, Is.EqualTo(2));
-        });
+        }
     }
 
     [Test]
@@ -3713,28 +3713,28 @@ END:VCALENDAR";
         var recurrencePattern =
             serializer.Deserialize(new StringReader(";FREQ=DAILY;INTERVAL=2;UNTIL=20250430T000000Z")) as
                 RecurrencePattern;
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(recurrencePattern, Is.Not.Null);
             Assert.That(recurrencePattern?.Until,
                 Is.EqualTo(new CalDateTime(2025, 4, 30, 0, 0, 0, CalDateTime.UtcTzId)));
             Assert.That(recurrencePattern?.Frequency, Is.EqualTo(FrequencyType.Daily));
             Assert.That(recurrencePattern?.Interval, Is.EqualTo(2));
-        });
+        }
     }
 
     [Test]
     public void Disallowed_Recurrence_RangeChecks_Should_Throw()
     {
         var serializer = new RecurrencePatternSerializer();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(() => serializer.CheckMutuallyExclusive("a", "b", 1, CalDateTime.Now),
                 Throws.TypeOf<ArgumentOutOfRangeException>());
             Assert.That(() => serializer.CheckRange("a", 0, 1, 2, false), Throws.TypeOf<ArgumentOutOfRangeException>());
             Assert.That(() => serializer.CheckRange("a", (int?) 0, 1, 2, false),
                 Throws.TypeOf<ArgumentOutOfRangeException>());
-        });
+        }
     }
 
     [Test]
@@ -3759,7 +3759,7 @@ END:VCALENDAR";
 
         var occ = cal.GetOccurrences(tz).ToList();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(occ.Count, Is.EqualTo(2));
 
@@ -3770,7 +3770,7 @@ END:VCALENDAR";
             Assert.That(occ[1].Start, Is.EqualTo(tz.MapLocal(new(2020, 10, 25, 2, 30, 0)).First()));
             Assert.That(occ[1].End, Is.EqualTo(tz.MapLocal(new(2020, 10, 25, 2, 15, 0)).Last()));
             Assert.That(occ[1].End - occ[1].Start, Is.EqualTo(NodaTime.Duration.FromMinutes(45)));
-        });
+        }
     }
 
     [Test]
@@ -4184,20 +4184,20 @@ END:VCALENDAR";
         var firstOccurrence = occurrences.First();
         var firstStartCopy = firstStart.ToZonedDateTime(tz);
         var firstEndCopy = firstEnd.ToZonedDateTime(tz);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(firstOccurrence.Start, Is.EqualTo(firstStartCopy));
             Assert.That(firstOccurrence.End, Is.EqualTo(firstEndCopy));
-        });
+        }
 
         var secondOccurrence = occurrences.Last();
         var secondStartCopy = secondStart.ToZonedDateTime(tz);
         var secondEndCopy = secondEnd.ToZonedDateTime(tz);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(secondOccurrence.Start, Is.EqualTo(secondStartCopy));
             Assert.That(secondOccurrence.End, Is.EqualTo(secondEndCopy));
-        });
+        }
     }
 
     [Test]
@@ -4281,14 +4281,14 @@ END:VCALENDAR";
             .TakeWhileBefore(new CalDateTime("20161128T002000", "W. Europe Standard Time").ToInstant())
             .ToList();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // endTime = 20161211T000000
             Assert.That(occurrences.Select(x => x.Start), Is.EqualTo(expectedStartDates));
 
             // endTime = 20161128T002000
             Assert.That(occurrences2.Select(x => x.Start), Is.EqualTo(expectedStartDates.Take(4)));
-        });
+        }
     }
 
     [Test]
@@ -4334,14 +4334,14 @@ END:VCALENDAR";
             new(2023, 12, 1)
         }.Select(x => x.ToZonedDateTime(tz)).ToList();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // For endTime=20231002
             Assert.That(occurrences.Select(x => x.Start), Is.EqualTo(expectedStartDates.Take(1)));
 
             // For endTime=20231231
             Assert.That(occurrences2.Select(x => x.Start), Is.EqualTo(expectedStartDates.Take(3)));
-        });
+        }
     }
 
     [Test]

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -3897,7 +3897,7 @@ END:VCALENDAR";
             .Take(5)
             .ToList();
 
-        var expectedDates = new string[]
+        var expectedDates = new[]
         {
             // RDATE
             "20250707T000000",

--- a/Ical.Net.Tests/RecurrenceTests_From_Issues.cs
+++ b/Ical.Net.Tests/RecurrenceTests_From_Issues.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 //
 
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/Ical.Net.Tests/RecurrenceTests_From_Issues.cs
+++ b/Ical.Net.Tests/RecurrenceTests_From_Issues.cs
@@ -82,13 +82,13 @@ public class RecurrenceTests_From_Issues
         var occurrence = occurrences.Single();
 
         // Assert
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(occurrences.Count(), Is.EqualTo(1));
             Assert.That(occurrence.Source, Is.SameAs(myEvent));
             Assert.That(occurrence.Start, Is.EqualTo(myEvent.Start.ToZonedDateTime(tzId)));
             Assert.That(occurrence.End, Is.EqualTo(myEvent.End.ToZonedDateTime(tzId)));
-        });
+        }
     }
 
     [Test]
@@ -116,13 +116,13 @@ public class RecurrenceTests_From_Issues
         var occurrence = occurrences.Single();
 
         // Assert
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(occurrences.Count(), Is.EqualTo(1));
             Assert.That(occurrence.Source, Is.SameAs(myEvent));
             Assert.That(occurrence.Start, Is.EqualTo(myEvent.Start.ToZonedDateTime(tzId)));
             Assert.That(occurrence.End, Is.EqualTo(myEvent.End.ToZonedDateTime(tzId)));
-        });
+        }
     }
 
     [Test]
@@ -152,13 +152,13 @@ public class RecurrenceTests_From_Issues
         var occurrence = occurrences.Single();
 
         // Assert
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(occurrences.Count, Is.EqualTo(1));
             Assert.That(occurrence.Source, Is.SameAs(myEvent));
             Assert.That(occurrence.Start, Is.EqualTo(myEvent.Start.ToZonedDateTime(timeZoneId)));
             Assert.That(occurrence.End, Is.EqualTo(myEvent.End.ToZonedDateTime(timeZoneId)));
-        });
+        }
     }
 
     [Test]
@@ -189,13 +189,13 @@ public class RecurrenceTests_From_Issues
         var occurrence = occurrences.Single();
 
         // Assert
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(occurrences.Count, Is.EqualTo(1));
             Assert.That(occurrence.Source, Is.SameAs(myEvent));
             Assert.That(occurrence.Start, Is.EqualTo(myEvent.Start.ToZonedDateTime(timeZoneId)));
             Assert.That(occurrence.End, Is.EqualTo(myEvent.End.ToZonedDateTime(timeZoneId)));
-        });
+        }
     }
 
     [Test]
@@ -224,14 +224,14 @@ public class RecurrenceTests_From_Issues
         var occurrence = occurrences.Single();
 
         // Assert
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(myEvent.IsAllDay, Is.True);
             Assert.That(occurrences.Count, Is.EqualTo(1));
             Assert.That(occurrence.Source, Is.SameAs(myEvent));
             Assert.That(occurrence.Start, Is.EqualTo(myEvent.Start.ToZonedDateTime(timeZoneId)));
             Assert.That(occurrence.End, Is.EqualTo(myEvent.End.ToZonedDateTime(timeZoneId)));
-        });
+        }
     }
 
     [Test]
@@ -260,14 +260,14 @@ public class RecurrenceTests_From_Issues
         var occurrence = occurrences.Single();
 
         // Assert
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(occurrences.Count, Is.EqualTo(1));
             Assert.That(occurrence.Source, Is.SameAs(myEvent));
             Assert.That(myEvent.IsAllDay, Is.True);
             Assert.That(occurrence.Start, Is.EqualTo(myEvent.Start.ToZonedDateTime(timeZoneId)));
             Assert.That(occurrence.End, Is.EqualTo(myEvent.End.ToZonedDateTime(timeZoneId)));
-        });
+        }
     }
 
     [Test]
@@ -498,7 +498,7 @@ public class RecurrenceTests_From_Issues
         var occurrences = vEvent.GetOccurrences(new CalDateTime(2017, 06, 01, 00, 00, 00)).TakeWhileBefore(new CalDateTime(2017, 06, 30, 23, 59, 0)).ToList();
         var excludedDays = new List<DayOfWeek> { DayOfWeek.Sunday, DayOfWeek.Saturday, DayOfWeek.Tuesday, DayOfWeek.Thursday };
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(occurrences.Count, Is.EqualTo(13));
             // Assert that none of the occurrences contain a weekday from the ByDay list
@@ -506,7 +506,7 @@ public class RecurrenceTests_From_Issues
             {
                 Assert.That(excludedDays, Does.Not.Contain(occurrence.Start.DayOfWeek.ToDayOfWeek()));
             }
-        });
+        }
     }
 
     [Test]

--- a/Ical.Net.Tests/RecurrenceWithExDateTests.cs
+++ b/Ical.Net.Tests/RecurrenceWithExDateTests.cs
@@ -60,7 +60,7 @@ public class RecurrenceWithExDateTests
         var deserializedCalendar = Calendar.Load(ics)!;
         var occurrences = deserializedCalendar.GetOccurrences<CalendarEvent>(DateUtil.GetZone(timeZoneId)).ToList();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             if (useExDateWithTime)
             {
@@ -72,7 +72,7 @@ public class RecurrenceWithExDateTests
                 Assert.That(occurrences, Has.Count.EqualTo(0));
                 Assert.That(ics, Does.Contain("EXDATE;VALUE=DATE:20241019"));
             }
-        });
+        }
     }
 
     [Test]
@@ -112,7 +112,7 @@ public class RecurrenceWithExDateTests
         // 2024-10-19 21:00 (UTC Offset: +0100)
         // Excluded dates impact:
         // 2024-10-19 at 19:00 UTC (= 2024-10-19 20:00 in "GMT Standard Time")
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(occurrences.Count, Is.EqualTo(3));
             Assert.That(
@@ -122,7 +122,7 @@ public class RecurrenceWithExDateTests
                         .ExceptionDates.GetAllDates()
                         .Any(ex => ex.ToInstant().Equals(o.Start.ToInstant()))), Is.True);
             Assert.That(ics, Does.Contain("EXDATE:20241019T190000Z"));
-        });
+        }
     }
 
     [Test]
@@ -170,7 +170,7 @@ public class RecurrenceWithExDateTests
         // The recurrences are adjusted for the switch from Daylight Saving Time to
         // Standard Time, which occurs on October 29, 2023, in the Europe/Berlin time zone.
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(occurrences.Count, Is.EqualTo(10));
             Assert.That(cal.Events[0]!.ExceptionDates.GetAllDates().Count(), Is.EqualTo(3));
@@ -181,7 +181,7 @@ public class RecurrenceWithExDateTests
                         .ExceptionDates.GetAllDates()
                         .Any(ex => ex.ToInstant().Equals(o.Start.ToInstant()))), Is.True);
             Assert.That(ics, Does.Contain("EXDATE;TZID=Europe/Berlin:20231029T090000,20231105T090000,20231112T090000"));
-        });
+        }
     }
 
     [Test]
@@ -223,7 +223,7 @@ public class RecurrenceWithExDateTests
         // October 29, 2023, 09:00 AM (America/New_York): Excluded
         // November 1, 2023, 01:00 PM (Europe/London): Excluded - November 1, 2023, 09:00 AM (EDT, UTC-4)
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(occurrences.Count, Is.EqualTo(9));
             Assert.That(cal.Events[0]!.ExceptionDates.GetAllDates().Count(), Is.EqualTo(2));
@@ -233,6 +233,6 @@ public class RecurrenceWithExDateTests
                         .Events[0]!
                         .ExceptionDates.GetAllDates()
                         .Any(ex => ex.ToInstant().Equals(o.Start.ToInstant()))), Is.True);
-        });
+        }
     }
 }

--- a/Ical.Net.Tests/RecurrenceWithExDateTests.cs
+++ b/Ical.Net.Tests/RecurrenceWithExDateTests.cs
@@ -3,14 +3,12 @@
 // Licensed under the MIT license.
 //
 
-#nullable enable
 using System;
 using System.Linq;
 using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
 using Ical.Net.Serialization;
 using Ical.Net.Utility;
-using NodaTime;
 using NUnit.Framework;
 
 namespace Ical.Net.Tests;

--- a/Ical.Net.Tests/RecurrenceWithRDateTests.cs
+++ b/Ical.Net.Tests/RecurrenceWithRDateTests.cs
@@ -38,14 +38,14 @@ public class RecurrenceWithRDateTests
 
         var occurrences = calendarEvent.GetOccurrences(DateUtil.GetZone("America/New_York")).ToList();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(occurrences, Has.Count.EqualTo(2));
             Assert.That(occurrences[0].Start, Is.EqualTo(new CalDateTime(2023, 10, 1, 10, 0, 0).ToZonedDateTime("America/New_York")));
             Assert.That(occurrences[1].Start, Is.EqualTo(new CalDateTime(2023, 10, 2, 10, 0, 0).ToZonedDateTime("America/New_York")));
             Assert.That(ics, Does.Contain("RDATE:20231002T100000"));
             Assert.That(ics, Does.Contain("DURATION:PT1H"));
-        });
+        }
     }
 
     [Test]
@@ -71,14 +71,14 @@ public class RecurrenceWithRDateTests
 
         var occurrences = calendarEvent.GetOccurrences(DateUtil.GetZone("America/New_York")).ToList();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(occurrences, Has.Count.EqualTo(2));
             Assert.That(occurrences[0].Start, Is.EqualTo(new CalDateTime(2023, 10, 1, 10, 0, 0).ToZonedDateTime("America/New_York")));
             Assert.That(occurrences[1].Start, Is.EqualTo(new CalDateTime(2023, 10, 2).ToZonedDateTime("America/New_York")));
             Assert.That(ics, Does.Contain("RDATE;VALUE=DATE:20231002"));
             Assert.That(ics, Does.Not.Contain("DURATION:"));
-        });
+        }
     }
 
     [Test]
@@ -106,7 +106,7 @@ public class RecurrenceWithRDateTests
 
         var occurrences = calendarEvent.GetOccurrences(DateUtil.GetZone(tzId)).ToList();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(occurrences, Has.Count.EqualTo(3));
             Assert.That(occurrences[0].Start, Is.EqualTo(new CalDateTime(2023, 10, 1, 10, 0, 0, tzId).ToZonedDateTime(tzId)));
@@ -114,7 +114,7 @@ public class RecurrenceWithRDateTests
             Assert.That(occurrences[2].Start, Is.EqualTo(new CalDateTime(2023, 10, 3, 10, 0, 0, tzId).ToZonedDateTime(tzId)));
             Assert.That(ics, Does.Contain("RDATE;TZID=America/New_York:20231002T100000,20231003T100000"));
             Assert.That(ics, Does.Contain("DURATION:PT2H"));
-        });
+        }
     }
 
     [Test]
@@ -141,11 +141,11 @@ public class RecurrenceWithRDateTests
         // Serialization
 
         var serializer = new CalendarSerializer();
-        var ics = serializer.SerializeToString(cal);
+        var ics = serializer.SerializeToString(cal)!;
 
         var occurrences = calendarEvent.GetOccurrences(DateUtil.GetZone(tzId)).ToList();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(occurrences, Has.Count.EqualTo(3));
             Assert.That(occurrences[0].Start, Is.EqualTo(new CalDateTime(2023, 10, 1, 10, 0, 0, tzId).ToZonedDateTime(tzId)));
@@ -155,14 +155,14 @@ public class RecurrenceWithRDateTests
             Assert.That(occurrences[2].End, Is.EqualTo(new CalDateTime(2023, 10, 3, 15, 0, 0, tzId).ToZonedDateTime(tzId)));
             // Line folding is used for long lines
             Assert.That(ics, Does.Contain("RDATE;TZID=America/New_York;VALUE=PERIOD:20231002T100000/PT4H,20231003T1000\r\n 00/PT5H"));
-        });
+        }
 
         // Deserialization
 
         cal = Calendar.Load(ics)!;
         occurrences = cal.Events.First().GetOccurrences(DateUtil.GetZone(tzId)).ToList();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(occurrences, Has.Count.EqualTo(3));
             Assert.That(occurrences[0].Start, Is.EqualTo(new CalDateTime(2023, 10, 1, 10, 0, 0, tzId).ToZonedDateTime(tzId)));
@@ -170,7 +170,7 @@ public class RecurrenceWithRDateTests
             Assert.That(occurrences[2].Start, Is.EqualTo(new CalDateTime(2023, 10, 3, 10, 0, 0, tzId).ToZonedDateTime(tzId)));
             Assert.That(occurrences[1].End, Is.EqualTo(new CalDateTime(2023, 10, 2, 14, 0, 0, tzId).ToZonedDateTime(tzId)));
             Assert.That(occurrences[2].End, Is.EqualTo(new CalDateTime(2023, 10, 3, 15, 0, 0, tzId).ToZonedDateTime(tzId)));
-        });
+        }
     }
 
     [Test]
@@ -193,7 +193,7 @@ public class RecurrenceWithRDateTests
 
         var occurrences = calendarEvent.GetOccurrences(DateUtil.GetZone("America/New_York")).ToList();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(occurrences, Has.Count.EqualTo(3));
             Assert.That(occurrences[0].Start, Is.EqualTo(new CalDateTime(2023, 10, 1, 10, 0, 0).ToZonedDateTime("America/New_York")));
@@ -202,7 +202,7 @@ public class RecurrenceWithRDateTests
             Assert.That(occurrences[2].End, Is.EqualTo(new CalDateTime(2023, 10, 3, 13, 0, 0).ToZonedDateTime("America/New_York")));
             Assert.That(ics, Does.Contain("RDATE:20231002T100000"));
             Assert.That(ics, Does.Contain("RDATE;VALUE=PERIOD:20231003T100000/PT3H"));
-        });
+        }
     }
 
     [Test]
@@ -229,7 +229,7 @@ public class RecurrenceWithRDateTests
 
         var occurrences = calendarEvent.GetOccurrences(DateUtil.GetZone("America/New_York")).ToList();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(occurrences, Has.Count.EqualTo(3));
             Assert.That(occurrences[0].Start,
@@ -240,7 +240,7 @@ public class RecurrenceWithRDateTests
                 Is.EqualTo(new CalDateTime(2023, 10, 3, 10, 0, 0, "Europe/London").ToZonedDateTime("America/New_York")));
             Assert.That(ics, Does.Contain("RDATE;TZID=America/Los_Angeles:20231002T100000"));
             Assert.That(ics, Does.Contain("RDATE;TZID=Europe/London:20231003T100000"));
-        });
+        }
     }
 
     [Test]
@@ -263,7 +263,7 @@ public class RecurrenceWithRDateTests
 
         var occurrences = calendarEvent.GetOccurrences(DateUtil.GetZone("America/New_York")).ToList();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(occurrences, Has.Count.EqualTo(3));
             Assert.That(occurrences[0].Start, Is.EqualTo(eventStart.ToZonedDateTime("America/New_York")));
@@ -273,7 +273,7 @@ public class RecurrenceWithRDateTests
             Assert.That(ics, Does.Contain("RDATE;VALUE=PERIOD:20231002/P1D"));
             Assert.That(ics, Does.Contain("RDATE:20231003T100000"));
             Assert.That(ics, Does.Contain("DURATION:P2D"));
-        });
+        }
     }
 
     [Test]
@@ -300,14 +300,14 @@ public class RecurrenceWithRDateTests
 
         var occurrences = calendarEvent.GetOccurrences(DateUtil.GetZone("America/New_York")).ToList();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(occurrences, Has.Count.EqualTo(3));
             Assert.That(occurrences[0].Start, Is.EqualTo(new CalDateTime(2023, 10, 1, 10, 0, 0).ToZonedDateTime("America/New_York")));
             Assert.That(occurrences[1].Start, Is.EqualTo(new CalDateTime(2023, 10, 2, 10, 0, 0).ToZonedDateTime("America/New_York")));
             Assert.That(occurrences[2].Start, Is.EqualTo(new CalDateTime(2023, 10, 2, 11, 0, 0).ToZonedDateTime("America/New_York")));
             Assert.That(ics, Does.Contain("RDATE;VALUE=PERIOD:20231002T100000/PT2H,20231002T110000/PT2H"));
-        });
+        }
     }
 
     [Test]
@@ -334,7 +334,7 @@ public class RecurrenceWithRDateTests
 
         var occurrences = calendarEvent.GetOccurrences(DateUtil.GetZone("America/New_York")).ToList();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(occurrences, Has.Count.EqualTo(101)); // Including the original event
             for (var i = 0; i < 101; i++)
@@ -345,7 +345,7 @@ public class RecurrenceWithRDateTests
             Assert.That(ics, Does.Contain("RDATE:20231002T100000,20231003T100000,20231004T100000,20231005T100000,2023"));
             // Last folded line
             Assert.That(ics, Does.Contain(" 00,20240107T100000,20240108T100000,20240109T100000"));
-        });
+        }
     }
 
     [Test]
@@ -370,14 +370,14 @@ public class RecurrenceWithRDateTests
 
         var occurrences = calendarEvent.GetOccurrences(DateUtil.GetZone("America/New_York")).ToList();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(occurrences, Has.Count.EqualTo(2));
             Assert.That(occurrences[0].Start, Is.EqualTo(eventStart.ToZonedDateTime("America/New_York")));
             Assert.That(occurrences[1].Start, Is.EqualTo(periodDuplicate.StartTime.ToZonedDateTime("America/New_York")));
 
             Assert.That(ics, Does.Contain("RDATE;VALUE=PERIOD:20231002T100000/PT2H"));
-        });
+        }
     }
 
     [Test]

--- a/Ical.Net.Tests/RecurrenceWithRDateTests.cs
+++ b/Ical.Net.Tests/RecurrenceWithRDateTests.cs
@@ -3,17 +3,13 @@
 // Licensed under the MIT license.
 //
 
-#nullable enable
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Ical.Net.CalendarComponents;
-using Ical.Net.Collections;
 using Ical.Net.DataTypes;
 using Ical.Net.Evaluation;
 using Ical.Net.Serialization;
 using Ical.Net.Utility;
-using NodaTime;
 using NUnit.Framework;
 using Duration = Ical.Net.DataTypes.Duration;
 using Period = Ical.Net.DataTypes.Period;

--- a/Ical.Net.Tests/SerializationHelpers.cs
+++ b/Ical.Net.Tests/SerializationHelpers.cs
@@ -14,5 +14,5 @@ internal class SerializationHelpers
         => SerializeToString(new Calendar { Events = { calendarEvent } });
 
     public static string SerializeToString(Calendar iCalendar)
-        => new CalendarSerializer().SerializeToString(iCalendar);
+        => new CalendarSerializer().SerializeToString(iCalendar)!;
 }

--- a/Ical.Net.Tests/SerializationTests.cs
+++ b/Ical.Net.Tests/SerializationTests.cs
@@ -44,9 +44,9 @@ public class SerializationTests
                     if (((IComparable)p1.Value).CompareTo(p2.Value) != 0)
                         continue;
                 }
-                else if (p1.Value is IEnumerable)
+                else if (p1.Value is IEnumerable p1Enumerable)
                 {
-                    CompareEnumerables((IEnumerable)p1.Value, (IEnumerable) p2.Value!, p1.Name);
+                    Assert.That(p1Enumerable, Is.EquivalentTo((IEnumerable) p2.Value!));
                 }
                 else
                 {
@@ -74,24 +74,6 @@ public class SerializationTests
             {
                 Assert.That(child2, Is.EqualTo(child1), "The child objects are not equal.");
             }
-        }
-    }
-
-    public static void CompareEnumerables(IEnumerable? a1, IEnumerable? a2, string value)
-    {
-        if (a1 == null && a2 == null)
-        {
-            return;
-        }
-
-        Assert.That((a1 == null && a2 != null) || (a1 != null && a2 == null), Is.False, value + " do not match - one item is null");
-
-        var enum1 = a1!.GetEnumerator();
-        var enum2 = a2!.GetEnumerator();
-
-        while (enum1.MoveNext() && enum2.MoveNext())
-        {
-            Assert.That(enum2.Current, Is.EqualTo(enum1.Current), value + " do not match");
         }
     }
 

--- a/Ical.Net.Tests/SerializationTests.cs
+++ b/Ical.Net.Tests/SerializationTests.cs
@@ -46,7 +46,7 @@ public class SerializationTests
                 }
                 else if (p1.Value is IEnumerable p1Enumerable)
                 {
-                    Assert.That(p1Enumerable, Is.EquivalentTo((IEnumerable) p2.Value!));
+                    Assert.That(p1Enumerable, Is.EquivalentTo((IEnumerable) p2.Value!), message: p1.Name + " do not match");
                 }
                 else
                 {

--- a/Ical.Net.Tests/SerializationTests.cs
+++ b/Ical.Net.Tests/SerializationTests.cs
@@ -187,11 +187,11 @@ public class SerializationTests
         InspectSerializedSection(vTimezone, "DAYLIGHT",
             ["TZNAME:" + tzInfos[1]!.TimeZoneName, "TZOFFSETFROM:" + offset]);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserializedCalendar.TimeZones, Has.Count.EqualTo(1));
             Assert.That(deserializedCalendar.TimeZones[0]!.TimeZoneInfos, Has.Count.EqualTo(2));
-        });
+        }
     }
 
     [Test, Category("Serialization")]
@@ -224,11 +224,11 @@ public class SerializationTests
         var serializer = new CalendarSerializer();
         var serializedCalendar = serializer.SerializeToString(cal)!;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(serializedCalendar.StartsWith("BEGIN:VCALENDAR"), Is.True);
             Assert.That(serializedCalendar.EndsWith("END:VCALENDAR" + SerializationConstants.LineBreak), Is.True);
-        });
+        }
 
         var expectProperties = new[] { "METHOD:PUBLISH", "VERSION:2.0" };
 
@@ -307,11 +307,11 @@ public class SerializationTests
                 ["PARTSTAT"] = a.ParticipationStatus!
             })
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(vals.ContainsKey(v.Key), Is.True, $"could not find key '{v.Key}'");
                     Assert.That(vals[v.Key], Is.EqualTo(v.Value), $"ATTENDEE prop '{v.Key}' differ");
-                });
+                }
             }
         }
     }
@@ -338,11 +338,11 @@ public class SerializationTests
         var c = new Calendar();
         c.Events.Add(e);
         var serialized = SerializeToString(c);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(e.Duration, Is.EqualTo(originalDuration));
             Assert.That(serialized, Does.Contain("DURATION"));
-        });
+        }
     }
 
     [Test]
@@ -422,12 +422,12 @@ public class SerializationTests
            """;
         var deserializedEvent = Calendar.Load<CalendarEvent>(ics).Single();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(deserializedEvent.Description, Does.Contain("\t"));
             Assert.That(deserializedEvent.Description, Does.Contain("�"));
             Assert.That(deserializedEvent.Description, Does.Contain("�"));
-        });
+        }
     }
 
     [Test]
@@ -455,7 +455,7 @@ public class SerializationTests
         var timeZone = Calendar.Load<VTimeZone>(ics).Single();
         Assert.That(timeZone, Is.Not.Null, "Expected the TimeZone to be successfully deserialized");
         var timeZoneInfos = timeZone.TimeZoneInfos;
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(timeZoneInfos, Is.Not.Null, "Expected TimeZoneInfos to be deserialized");
             Assert.That(timeZoneInfos, Has.Count.EqualTo(2), "Expected 2 TimeZoneInfos");
@@ -465,7 +465,7 @@ public class SerializationTests
             Assert.That(timeZoneInfos[1]!.Name, Is.EqualTo("DAYLIGHT"));
             Assert.That(timeZoneInfos[1]!.OffsetFrom, Is.EqualTo(new UtcOffset("+0100")));
             Assert.That(timeZoneInfos[1]!.OffsetTo, Is.EqualTo(new UtcOffset("+0200")));
-        });
+        }
     }
 
     [Test]
@@ -507,22 +507,22 @@ public class SerializationTests
 
         var serialized = new CalendarSerializer().SerializeToString(c);
         
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(serialized, Does.Contain($"PRODID:{c.ProductId}"));
             Assert.That(serialized, Does.Contain($"VERSION:{c.Version}"));
-        });
+        }
     }
 
     [Test]
     public void ProductId_and_Version_HaveDefaultValues()
     {
         var c = new Calendar();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(c.ProductId, Is.EqualTo(LibraryMetadata.ProdId));
             Assert.That(c.Version, Is.EqualTo(LibraryMetadata.Version));
-        });
+        }
     }
 
     [Test]
@@ -562,11 +562,11 @@ public class SerializationTests
         };
 
         var serialized = new CalendarSerializer().SerializeToString(e)!;
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(serialized.Contains(expectedString, StringComparison.Ordinal), Is.True);
             Assert.That(!serialized.Contains("VCALENDAR", StringComparison.Ordinal), Is.True);
-        });
+        }
     }
 
     [TestCase("en-US")] // English (United States)
@@ -589,7 +589,7 @@ public class SerializationTests
             var culture = new CultureInfo(cultureStr);
             CultureInfo.CurrentCulture = culture;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 // Deserialize
                 Assert.That(() => Calendar.Load(
@@ -603,8 +603,7 @@ public class SerializationTests
                     """), Throws.Nothing);
                 // Serialize
                 Assert.That(() => new DurationSerializer().SerializeToString(new Duration(null, -1)), Is.EqualTo("-P1D"));
-
-            });
+            }
         }    
         finally
         {
@@ -637,10 +636,10 @@ public class SerializationTests
         bool HasBom(byte[] bytes) =>
             bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(HasBom(noBomBytes), Is.False, "Stream should not contain a UTF-8 BOM");
             Assert.That(HasBom(withBomBytes), Is.True, "Stream should contain a UTF-8 BOM");
-        });
+        }
     }
 }

--- a/Ical.Net.Tests/SimpleDeserializationTests.cs
+++ b/Ical.Net.Tests/SimpleDeserializationTests.cs
@@ -106,7 +106,7 @@ public class SimpleDeserializationTests
         Assert.Multiple(() =>
         {
             Assert.That(iCal.Events, Has.Count.EqualTo(1));
-            Assert.That(iCal.Properties["X-LOTUS-CHILD_UID"].Value, Is.EqualTo("XXX"));
+            Assert.That(iCal.Properties["X-LOTUS-CHILD_UID"]!.Value, Is.EqualTo("XXX"));
         });
     }
 
@@ -123,8 +123,8 @@ public class SimpleDeserializationTests
         var evt = iCal.Events.First();
         Assert.Multiple(() =>
         {
-            Assert.That(evt.Start.HasTime, Is.True);
-            Assert.That(evt.End.HasTime, Is.True);
+            Assert.That(evt.Start?.HasTime, Is.True);
+            Assert.That(evt.End?.HasTime, Is.True);
         });
     }
 
@@ -280,8 +280,8 @@ END:VCALENDAR
 
         Assert.Multiple(() =>
         {
-            Assert.That(evt.GeographicLocation.Latitude, Is.EqualTo(37.386013), "Latitude should be 37.386013; it is not.");
-            Assert.That(evt.GeographicLocation.Longitude, Is.EqualTo(-122.082932), "Longitude should be -122.082932; it is not.");
+            Assert.That(evt.GeographicLocation?.Latitude, Is.EqualTo(37.386013), "Latitude should be 37.386013; it is not.");
+            Assert.That(evt.GeographicLocation?.Longitude, Is.EqualTo(-122.082932), "Longitude should be -122.082932; it is not.");
         });
     }
 
@@ -319,15 +319,15 @@ END:VCALENDAR
     [Test, Category("Deserialization")]
     public void RequestStatus1()
     {
-        var iCal = Calendar.Load(IcsFiles.RequestStatus1);
+        var iCal = Calendar.Load(IcsFiles.RequestStatus1)!;
         Assert.That(iCal.Events, Has.Count.EqualTo(1));
         Assert.That(iCal.Events.First().RequestStatuses, Has.Count.EqualTo(4));
 
         var rs = iCal.Events.First().RequestStatuses[0];
         Assert.Multiple(() =>
         {
-            Assert.That(rs.StatusCode.Primary, Is.EqualTo(2));
-            Assert.That(rs.StatusCode.Secondary, Is.EqualTo(0));
+            Assert.That(rs.StatusCode?.Primary, Is.EqualTo(2));
+            Assert.That(rs.StatusCode?.Secondary, Is.EqualTo(0));
             Assert.That(rs.Description, Is.EqualTo("Success"));
         });
         Assert.That(rs.ExtraData, Is.Null);
@@ -335,8 +335,8 @@ END:VCALENDAR
         rs = iCal.Events.First().RequestStatuses[1];
         Assert.Multiple(() =>
         {
-            Assert.That(rs.StatusCode.Primary, Is.EqualTo(3));
-            Assert.That(rs.StatusCode.Secondary, Is.EqualTo(1));
+            Assert.That(rs.StatusCode?.Primary, Is.EqualTo(3));
+            Assert.That(rs.StatusCode?.Secondary, Is.EqualTo(1));
             Assert.That(rs.Description, Is.EqualTo("Invalid property value"));
             Assert.That(rs.ExtraData, Is.EqualTo("DTSTART:96-Apr-01"));
         });
@@ -344,8 +344,8 @@ END:VCALENDAR
         rs = iCal.Events.First().RequestStatuses[2];
         Assert.Multiple(() =>
         {
-            Assert.That(rs.StatusCode.Primary, Is.EqualTo(2));
-            Assert.That(rs.StatusCode.Secondary, Is.EqualTo(8));
+            Assert.That(rs.StatusCode?.Primary, Is.EqualTo(2));
+            Assert.That(rs.StatusCode?.Secondary, Is.EqualTo(8));
             Assert.That(rs.Description, Is.EqualTo(" Success, repeating event ignored. Scheduled as a single event."));
             Assert.That(rs.ExtraData, Is.EqualTo("RRULE:FREQ=WEEKLY;INTERVAL=2"));
         });
@@ -353,8 +353,8 @@ END:VCALENDAR
         rs = iCal.Events.First().RequestStatuses[3];
         Assert.Multiple(() =>
         {
-            Assert.That(rs.StatusCode.Primary, Is.EqualTo(4));
-            Assert.That(rs.StatusCode.Secondary, Is.EqualTo(1));
+            Assert.That(rs.StatusCode?.Primary, Is.EqualTo(4));
+            Assert.That(rs.StatusCode?.Secondary, Is.EqualTo(1));
             Assert.That(rs.Description, Is.EqualTo("Event conflict. Date/time is busy."));
         });
         Assert.That(rs.ExtraData, Is.Null);
@@ -368,16 +368,16 @@ END:VCALENDAR
     {
         var serializer = new StringSerializer();
         var value = @"test\with\;characters";
-        var unescaped = (string)serializer.Deserialize(new StringReader(value));
+        var unescaped = (string?) serializer.Deserialize(new StringReader(value));
 
         Assert.That(unescaped, Is.EqualTo(@"test\with;characters"), "String unescaping was incorrect.");
 
         value = @"C:\Path\To\My\New\Information";
-        unescaped = (string)serializer.Deserialize(new StringReader(value));
+        unescaped = (string?) serializer.Deserialize(new StringReader(value));
         Assert.That(unescaped, Is.EqualTo("C:\\Path\\To\\My\new\\Information"), "String unescaping was incorrect.");
 
         value = @"\""This\r\nis\Na\, test\""\;\\;,";
-        unescaped = (string)serializer.Deserialize(new StringReader(value));
+        unescaped = (string?) serializer.Deserialize(new StringReader(value));
 
         Assert.That(unescaped, Is.EqualTo("\"This\\r\nis\na, test\";\\;,"), "String unescaping was incorrect.");
     }
@@ -413,21 +413,21 @@ END:VCALENDAR
         {
             Assert.That(iCal.Events, Has.Count.EqualTo(4));
 
-            Assert.That(iCal.Events[0].Summary, Is.EqualTo("No status"));
-            Assert.That(iCal.Events[0].Status, Is.Null);
-            Assert.That(iCal.Events[0].IsActive, Is.True);
+            Assert.That(iCal.Events[0]!.Summary, Is.EqualTo("No status"));
+            Assert.That(iCal.Events[0]!.Status, Is.Null);
+            Assert.That(iCal.Events[0]!.IsActive, Is.True);
 
-            Assert.That(iCal.Events[1].Summary, Is.EqualTo("Confirmed"));
-            Assert.That(iCal.Events[1].Status, Is.EqualTo("CONFIRMED"));
-            Assert.That(iCal.Events[1].IsActive, Is.True);
+            Assert.That(iCal.Events[1]!.Summary, Is.EqualTo("Confirmed"));
+            Assert.That(iCal.Events[1]!.Status, Is.EqualTo("CONFIRMED"));
+            Assert.That(iCal.Events[1]!.IsActive, Is.True);
 
-            Assert.That(iCal.Events[2].Summary, Is.EqualTo("Cancelled"));
-            Assert.That(iCal.Events[2].Status, Is.EqualTo("CANCELLED"));
-            Assert.That(iCal.Events[2].IsActive, Is.False);
+            Assert.That(iCal.Events[2]!.Summary, Is.EqualTo("Cancelled"));
+            Assert.That(iCal.Events[2]!.Status, Is.EqualTo("CANCELLED"));
+            Assert.That(iCal.Events[2]!.IsActive, Is.False);
 
-            Assert.That(iCal.Events[3].Summary, Is.EqualTo("Tentative"));
-            Assert.That(iCal.Events[3].Status, Is.EqualTo("TENTATIVE"));
-            Assert.That(iCal.Events[3].IsActive, Is.True);
+            Assert.That(iCal.Events[3]!.Summary, Is.EqualTo("Tentative"));
+            Assert.That(iCal.Events[3]!.Status, Is.EqualTo("TENTATIVE"));
+            Assert.That(iCal.Events[3]!.IsActive, Is.True);
         });
     }
 
@@ -467,7 +467,7 @@ END:VCALENDAR
         var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Parameter1)).Cast<Calendar>().Single();
 
         var evt = iCal.Events.First();
-        IList<CalendarParameter> parms = evt.Properties["DTSTART"].Parameters.AllOf("VALUE").ToList();
+        IList<CalendarParameter> parms = evt.Properties["DTSTART"]!.Parameters.AllOf("VALUE").ToList();
         Assert.That(parms, Has.Count.EqualTo(2));
         Assert.Multiple(() =>
         {

--- a/Ical.Net.Tests/SimpleDeserializationTests.cs
+++ b/Ical.Net.Tests/SimpleDeserializationTests.cs
@@ -33,32 +33,32 @@ public class SimpleDeserializationTests
         var attendee1 = evt.Attendees;
         var attendee2 = evt.Attendees[1];
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // Values
             Assert.That(attendee1[0].Value, Is.EqualTo(new Uri("mailto:joecool@example.com")));
             Assert.That(attendee2.Value, Is.EqualTo(new Uri("mailto:ildoit@example.com")));
-        });
-        Assert.Multiple(() =>
+        }
+        using (Assert.EnterMultipleScope())
         {
             // MEMBERS
             Assert.That(attendee1[0].Members, Has.Count.EqualTo(1));
             Assert.That(attendee2.Members.Count, Is.EqualTo(0));
             Assert.That(attendee1[0].Members[0], Is.EqualTo(new Uri("mailto:DEV-GROUP@example.com").ToString()));
-        });
-        Assert.Multiple(() =>
+        }
+        using (Assert.EnterMultipleScope())
         {
             // DELEGATED-FROM
             Assert.That(attendee1[0].DelegatedFrom.Count, Is.EqualTo(0));
             Assert.That(attendee2.DelegatedFrom, Has.Count.EqualTo(1));
             Assert.That(attendee2.DelegatedFrom[0], Is.EqualTo(new Uri("mailto:immud@example.com").ToString()));
-        });
-        Assert.Multiple(() =>
+        }
+        using (Assert.EnterMultipleScope())
         {
             // DELEGATED-TO
             Assert.That(attendee1[0].DelegatedTo.Count, Is.EqualTo(0));
             Assert.That(attendee2.DelegatedTo.Count, Is.EqualTo(0));
-        });
+        }
     }
 
     /// <summary>
@@ -78,20 +78,20 @@ public class SimpleDeserializationTests
 
         var attendee1 = evt.Attendees;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             // Values
             Assert.That(attendee1[0].Value, Is.EqualTo(new Uri("mailto:joecool@example.com")));
 
             // MEMBERS
             Assert.That(attendee1[0].Members, Has.Count.EqualTo(3));
-        });
-        Assert.Multiple(() =>
+        }
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(attendee1[0].Members[0], Is.EqualTo(new Uri("mailto:DEV-GROUP@example.com").ToString()));
             Assert.That(attendee1[0].Members[1], Is.EqualTo(new Uri("mailto:ANOTHER-GROUP@example.com").ToString()));
             Assert.That(attendee1[0].Members[2], Is.EqualTo(new Uri("mailto:THIRD-GROUP@example.com").ToString()));
-        });
+        }
     }
 
     /// <summary>
@@ -103,11 +103,11 @@ public class SimpleDeserializationTests
     public void Bug2033495()
     {
         var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.Bug2033495)).Cast<Calendar>().Single();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(iCal.Events, Has.Count.EqualTo(1));
             Assert.That(iCal.Properties["X-LOTUS-CHILD_UID"]!.Value, Is.EqualTo("XXX"));
-        });
+        }
     }
 
     /// <summary>
@@ -121,11 +121,11 @@ public class SimpleDeserializationTests
         Assert.That(iCal.Events, Has.Count.EqualTo(1));
 
         var evt = iCal.Events.First();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(evt.Start?.HasTime, Is.True);
             Assert.That(evt.End?.HasTime, Is.True);
-        });
+        }
     }
 
     /// <summary>
@@ -166,11 +166,11 @@ public class SimpleDeserializationTests
     {
         var calendars = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.EmptyLines2)).Cast<Calendar>().ToList();
         Assert.That(calendars, Has.Count.EqualTo(2));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(calendars[0].Events, Has.Count.EqualTo(2), "iCalendar should have 2 events");
             Assert.That(calendars[1].Events, Has.Count.EqualTo(2), "iCalendar should have 2 events");
-        });
+        }
     }
 
     /// <summary>
@@ -225,11 +225,11 @@ evt.Attachments[0].ToString(),
         ProgramTest.TestCal(iCal);
         var evt = iCal.Events.First();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(evt.Uid, Is.EqualTo("uuid1153170430406"), "UID should be 'uuid1153170430406'; it is " + evt.Uid);
             Assert.That(evt.Sequence, Is.EqualTo(1), "SEQUENCE should be 1; it is " + evt.Sequence);
-        });
+        }
     }
 
     [Test, Category("Deserialization")]
@@ -278,11 +278,11 @@ END:VCALENDAR
         ProgramTest.TestCal(iCal);
         var evt = iCal.Events.First();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(evt.GeographicLocation?.Latitude, Is.EqualTo(37.386013), "Latitude should be 37.386013; it is not.");
             Assert.That(evt.GeographicLocation?.Longitude, Is.EqualTo(-122.082932), "Longitude should be -122.082932; it is not.");
-        });
+        }
     }
 
     [Test, Category("Deserialization")]
@@ -324,39 +324,39 @@ END:VCALENDAR
         Assert.That(iCal.Events.First().RequestStatuses, Has.Count.EqualTo(4));
 
         var rs = iCal.Events.First().RequestStatuses[0];
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(rs.StatusCode?.Primary, Is.EqualTo(2));
             Assert.That(rs.StatusCode?.Secondary, Is.EqualTo(0));
             Assert.That(rs.Description, Is.EqualTo("Success"));
-        });
+        }
         Assert.That(rs.ExtraData, Is.Null);
 
         rs = iCal.Events.First().RequestStatuses[1];
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(rs.StatusCode?.Primary, Is.EqualTo(3));
             Assert.That(rs.StatusCode?.Secondary, Is.EqualTo(1));
             Assert.That(rs.Description, Is.EqualTo("Invalid property value"));
             Assert.That(rs.ExtraData, Is.EqualTo("DTSTART:96-Apr-01"));
-        });
+        }
 
         rs = iCal.Events.First().RequestStatuses[2];
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(rs.StatusCode?.Primary, Is.EqualTo(2));
             Assert.That(rs.StatusCode?.Secondary, Is.EqualTo(8));
             Assert.That(rs.Description, Is.EqualTo(" Success, repeating event ignored. Scheduled as a single event."));
             Assert.That(rs.ExtraData, Is.EqualTo("RRULE:FREQ=WEEKLY;INTERVAL=2"));
-        });
+        }
 
         rs = iCal.Events.First().RequestStatuses[3];
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(rs.StatusCode?.Primary, Is.EqualTo(4));
             Assert.That(rs.StatusCode?.Secondary, Is.EqualTo(1));
             Assert.That(rs.Description, Is.EqualTo("Event conflict. Date/time is busy."));
-        });
+        }
         Assert.That(rs.ExtraData, Is.Null);
     }
 
@@ -409,7 +409,7 @@ END:VCALENDAR
     {
         var iCal = SimpleDeserializer.Default.Deserialize(new StringReader(IcsFiles.EventStatus)).Cast<Calendar>().Single();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(iCal.Events, Has.Count.EqualTo(4));
 
@@ -428,7 +428,7 @@ END:VCALENDAR
             Assert.That(iCal.Events[3]!.Summary, Is.EqualTo("Tentative"));
             Assert.That(iCal.Events[3]!.Status, Is.EqualTo("TENTATIVE"));
             Assert.That(iCal.Events[3]!.IsActive, Is.True);
-        });
+        }
     }
 
     [Test, Category("Deserialization")]
@@ -469,11 +469,11 @@ END:VCALENDAR
         var evt = iCal.Events.First();
         IList<CalendarParameter> parms = evt.Properties["DTSTART"]!.Parameters.AllOf("VALUE").ToList();
         Assert.That(parms, Has.Count.EqualTo(2));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(parms[0].Values.First(), Is.EqualTo("DATE"));
             Assert.That(parms[1].Values.First(), Is.EqualTo("OTHER"));
-        });
+        }
     }
 
     /// <summary>

--- a/Ical.Net.Tests/SymmetricSerializationTests.cs
+++ b/Ical.Net.Tests/SymmetricSerializationTests.cs
@@ -25,7 +25,7 @@ public class SymmetricSerializationTests
     private static readonly DateTime _nowTime = DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Unspecified);
     private static readonly DateTime _later = _nowTime.AddHours(1);
     private static CalendarSerializer GetNewSerializer() => new CalendarSerializer();
-    private static string SerializeToString(Calendar c) => GetNewSerializer().SerializeToString(c);
+    private static string SerializeToString(Calendar c) => GetNewSerializer().SerializeToString(c)!;
     private static CalendarEvent GetSimpleEvent(bool useDtEnd = true)
     {
         var evt = new CalendarEvent { DtStart = new CalDateTime(_nowTime) };
@@ -37,7 +37,7 @@ public class SymmetricSerializationTests
         return evt;
     }
 
-    private static Calendar UnserializeCalendar(string s) => Calendar.Load(s);
+    private static Calendar UnserializeCalendar(string s) => Calendar.Load(s)!;
     
     [Test]
     public void VTimeZoneSerialization_Test()
@@ -49,8 +49,8 @@ public class SymmetricSerializationTests
         };
         originalCalendar.AddTimeZone(tz);
         var serializer = new CalendarSerializer();
-        var serializedCalendar = serializer.SerializeToString(originalCalendar);
-        var unserializedCalendar = Calendar.Load(serializedCalendar);
+        var serializedCalendar = serializer.SerializeToString(originalCalendar)!;
+        var unserializedCalendar = Calendar.Load(serializedCalendar)!;
 
         Assert.Multiple(() =>
         {
@@ -124,7 +124,7 @@ public class SymmetricSerializationTests
             .Events
             .First()
             .Attachments
-            .Select(a => Encoding.UTF8.GetString(a.Data))
+            .Select(a => Encoding.UTF8.GetString(a.Data!))
             .First();
 
         Assert.Multiple(() =>
@@ -208,23 +208,22 @@ public class SymmetricSerializationTests
 
     private static IEnumerable CategoryTest_TestCases()
     {
-        yield return new string[] { "Foo", "Bar", "Baz" };
-        yield return new string[] { "Hello", "world" };
-        yield return new string[] { "Hello", "world", null };
+        yield return new[] { "Foo", "Bar", "Baz" };
+        yield return new[] { "Hello", "world" };
     }
 
     [Test, TestCaseSource(nameof(ResourceTest_TestCases))]
-    public void ResourceTest(string[] ressources)
+    public void ResourceTest(string[] resources)
     {
         var vEvent = GetSimpleEvent();
-        vEvent.Resources = ressources;
+        vEvent.Resources = resources;
         var c = new Calendar();
         c.Events.Add(vEvent);
 
         var serialized = SerializeToString(c);
         var categoriesCount = Regex.Matches(serialized, "RESOURCES").Count;
         Assert.That(categoriesCount, Is.EqualTo(1));
-        var resString = $"RESOURCES:{string.Join(",", ressources.OfType<string>())}";
+        var resString = $"RESOURCES:{string.Join(",", resources.OfType<string>())}";
         Assert.That(serialized, Does.Contain(resString));
 
         var deserialized = UnserializeCalendar(serialized);
@@ -233,8 +232,7 @@ public class SymmetricSerializationTests
 
     private static IEnumerable ResourceTest_TestCases()
     {
-        yield return new string[] { "Foo", "Bar", "Baz" };
-        yield return new string[] { "Hello", "world" };
-        yield return new string[] { "Hello", "world", null };
+        yield return new[] { "Foo", "Bar", "Baz" };
+        yield return new[] { "Hello", "world" };
     }
 }

--- a/Ical.Net.Tests/SymmetricSerializationTests.cs
+++ b/Ical.Net.Tests/SymmetricSerializationTests.cs
@@ -52,11 +52,11 @@ public class SymmetricSerializationTests
         var serializedCalendar = serializer.SerializeToString(originalCalendar)!;
         var unserializedCalendar = Calendar.Load(serializedCalendar)!;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(unserializedCalendar.TimeZones, Is.EqualTo(originalCalendar.TimeZones).AsCollection);
             Assert.That(unserializedCalendar, Is.EqualTo(originalCalendar));
-        });
+        }
         Assert.That(unserializedCalendar.GetHashCode(), Is.EqualTo(originalCalendar.GetHashCode()));
     }
 
@@ -72,12 +72,12 @@ public class SymmetricSerializationTests
         var serialized = SerializeToString(calendar);
         var unserialized = UnserializeCalendar(serialized);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(unserialized.GetHashCode(), Is.EqualTo(calendar.GetHashCode()));
             Assert.That(calendar.Events.SequenceEqual(unserialized.Events), Is.True);
             Assert.That(unserialized, Is.EqualTo(calendar));
-        });
+        }
     }
 
     public static IEnumerable<ITestCaseData> AttendeeSerialization_TestCases()
@@ -127,10 +127,7 @@ public class SymmetricSerializationTests
             .Select(a => Encoding.UTF8.GetString(a.Data!))
             .First();
 
-        Assert.Multiple(() =>
-        {
-            Assert.That(unserializedAttachment, Is.EqualTo(expectedAttachment));
-        });
+        Assert.That(unserializedAttachment, Is.EqualTo(expectedAttachment));
     }
 
     public static IEnumerable BinaryAttachment_TestCases()
@@ -171,12 +168,12 @@ public class SymmetricSerializationTests
             .Select(a => a.Uri)
             .Single();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(unserializedUri, Is.EqualTo(expectedUri));
             Assert.That(unserialized.GetHashCode(), Is.EqualTo(calendar.GetHashCode()));
             Assert.That(unserialized, Is.EqualTo(calendar));
-        });
+        }
     }
 
     public static IEnumerable UriAttachment_TestCases()

--- a/Ical.Net.Tests/TestExtensions.cs
+++ b/Ical.Net.Tests/TestExtensions.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 //
 
-#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using Ical.Net.CalendarComponents;

--- a/Ical.Net.Tests/TestHelpers/OccurrenceTester.cs
+++ b/Ical.Net.Tests/TestHelpers/OccurrenceTester.cs
@@ -2,11 +2,10 @@
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
-#nullable enable
+
 using System;
 using System.Linq;
 using Ical.Net.DataTypes;
-using Ical.Net.Evaluation;
 using Ical.Net.Utility;
 using NodaTime;
 using NUnit.Framework;

--- a/Ical.Net.Tests/TestHelpers/OccurrenceTester.cs
+++ b/Ical.Net.Tests/TestHelpers/OccurrenceTester.cs
@@ -33,7 +33,7 @@ internal static class OccurrenceTester
             ? evt.GetOccurrences(tz, start).ToList()
             : evt.GetOccurrences(tz, start).TakeWhileBefore(toDate.ToZonedDateTime(tz).ToInstant()).ToList();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(
                 occurrences,
@@ -45,31 +45,34 @@ internal static class OccurrenceTester
                 Assert.That(evt.RecurrenceRules, Has.Count.EqualTo(1));
             }
 
-            for (var i = 0; i < expectedPeriods.Length; i++)
+            using (Assert.EnterMultipleScope())
             {
-                var start = expectedPeriods[i].StartTime.ToZonedDateTime(tz);
-
-                ZonedDateTime end;
-
-                if (expectedPeriods[i].Duration is { } d)
+                for (var i = 0; i < expectedPeriods.Length; i++)
                 {
-                    end = start.LocalDateTime
-                        .Plus(d.GetNominalPart())
-                        .InZoneRelativeTo(start)
-                        .Plus(d.GetTimePart());
-                }
-                else if (expectedPeriods[i].EndTime is { } periodEnd)
-                {
-                    end = periodEnd.ToZonedDateTime(tz);
-                }
-                else
-                {
-                    throw new Exception("Expected test period must have a duration or an end");
-                }
+                    var start2 = expectedPeriods[i].StartTime.ToZonedDateTime(tz);
 
-                Assert.That(occurrences[i].Start, Is.EqualTo(start), "Event should start on " + start);
-                Assert.That(occurrences[i].End, Is.EqualTo(end), "Event should end on " + end);
+                    ZonedDateTime end;
+
+                    if (expectedPeriods[i].Duration is { } d)
+                    {
+                        end = start2.LocalDateTime
+                            .Plus(d.GetNominalPart())
+                            .InZoneRelativeTo(start2)
+                            .Plus(d.GetTimePart());
+                    }
+                    else if (expectedPeriods[i].EndTime is { } periodEnd)
+                    {
+                        end = periodEnd.ToZonedDateTime(tz);
+                    }
+                    else
+                    {
+                        throw new Exception("Expected test period must have a duration or an end");
+                    }
+
+                    Assert.That(occurrences[i].Start, Is.EqualTo(start2), "Event should start on " + start);
+                    Assert.That(occurrences[i].End, Is.EqualTo(end), "Event should end on " + end);
+                }
             }
-        });
+        }
     }
 }

--- a/Ical.Net.Tests/TodoTest.cs
+++ b/Ical.Net.Tests/TodoTest.cs
@@ -20,14 +20,14 @@ public class TodoTest
     [Test, TestCaseSource(nameof(ActiveTodo_TestCases)), Category("Todo")]
     public void ActiveTodo_Tests(string calendarString, IList<KeyValuePair<CalDateTime, bool>> incoming)
     {
-        var iCal = Calendar.Load(calendarString);
+        var iCal = Calendar.Load(calendarString)!;
         ProgramTest.TestCal(iCal);
         var todo = iCal.Todos;
 
         foreach (var calDateTime in incoming)
         {
             var dt = new CalDateTime(calDateTime.Key.Date, calDateTime.Key.Time, _tzid).ToZonedDateTime(_tzid);
-            Assert.That(todo[0].IsActive(dt), Is.EqualTo(calDateTime.Value));
+            Assert.That(todo[0]!.IsActive(dt), Is.EqualTo(calDateTime.Value));
         }
     }
 
@@ -169,14 +169,14 @@ public class TodoTest
     [Test, TestCaseSource(nameof(CompletedTodo_TestCases)), Category("Todo")]
     public void CompletedTodo_Tests(string calendarString, IList<KeyValuePair<CalDateTime, bool>> incoming)
     {
-        var iCal = Calendar.Load(calendarString);
+        var iCal = Calendar.Load(calendarString)!;
         ProgramTest.TestCal(iCal);
         var todo = iCal.Todos;
 
         foreach (var calDateTime in incoming)
         {
             var dt = new CalDateTime(calDateTime.Key.Date, calDateTime.Key.Time, _tzid).ToZonedDateTime(_tzid);
-            Assert.That(todo[0].IsCompleted(dt), Is.EqualTo(calDateTime.Value));
+            Assert.That(todo[0]!.IsCompleted(dt), Is.EqualTo(calDateTime.Value));
         }
     }
 
@@ -194,7 +194,7 @@ public class TodoTest
     [Test, Category("Todo")]
     public void Todo7_1()
     {
-        var iCal = Calendar.Load(IcsFiles.Todo7);
+        var iCal = Calendar.Load(IcsFiles.Todo7)!;
         var todo = iCal.Todos;
 
         var items = new List<CalDateTime>
@@ -211,7 +211,7 @@ public class TodoTest
             new CalDateTime(2007, 4, 6, 9, 0, 0, _tzid)
         }.Select(x => x.ToZonedDateTime(_tzid)).ToList();
 
-        var occurrences = todo[0].GetOccurrences(
+        var occurrences = todo[0]!.GetOccurrences(
             new CalDateTime(2006, 7, 1, 9, 0, 0).ToZonedDateTime(_tzid))
             .TakeWhileBefore(new CalDateTime(2007, 7, 1, 9, 0, 0).ToZonedDateTime(_tzid).ToInstant()).ToList();
 

--- a/Ical.Net.Tests/TodoTest.cs
+++ b/Ical.Net.Tests/TodoTest.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 //
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;

--- a/Ical.Net.Tests/VTimeZoneTest.cs
+++ b/Ical.Net.Tests/VTimeZoneTest.cs
@@ -36,11 +36,11 @@ public class VTimeZoneTest
         var serializer = new CalendarSerializer();
         var serialized = serializer.SerializeToString(iCal);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(serialized, Does.Contain("TZID:America/Phoenix"), "Time zone not found in serialization");
             Assert.That(serialized, Does.Contain("DTSTART:19670430T020000"), "Daylight savings for Phoenix was not serialized properly.");
-        });
+        }
     }
 
     [Test, Category("VTimeZone")]
@@ -50,11 +50,11 @@ public class VTimeZoneTest
         var serializer = new CalendarSerializer();
         var serialized = serializer.SerializeToString(iCal);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(serialized, Does.Contain("TZID:America/Phoenix"), "Time zone not found in serialization");
             Assert.That(serialized, Does.Not.Contain("BEGIN:DAYLIGHT"), "Daylight savings should not exist for Phoenix.");
-        });
+        }
     }
 
     [Test, Category("VTimeZone")]
@@ -64,13 +64,13 @@ public class VTimeZoneTest
         var serializer = new CalendarSerializer();
         var serialized = serializer.SerializeToString(iCal);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(serialized, Does.Contain("TZID:US Mountain Standard Time"), "Time zone not found in serialization");
             Assert.That(serialized, Does.Contain("BEGIN:STANDARD"));
             Assert.That(serialized, Does.Contain("BEGIN:DAYLIGHT"));
             Assert.That(serialized, Does.Contain("X-LIC-LOCATION"), "X-LIC-LOCATION was not serialized");
-        });
+        }
     }
 
     [Test, Category("VTimeZone")]

--- a/Ical.Net.Tests/VTimeZoneTest.cs
+++ b/Ical.Net.Tests/VTimeZoneTest.cs
@@ -107,7 +107,7 @@ public class VTimeZoneTest
         var iCal = CreateTestCalendar("Europe/Moscow");
         var serializer = new CalendarSerializer();
         // Unwrap the lines to make it easier to search for specific values
-        var serialized = TextUtil.UnwrapLines(serializer.SerializeToString(iCal));
+        var serialized = TextUtil.UnwrapLines(serializer.SerializeToString(iCal)!);
 
         using (Assert.EnterMultipleScope())
         {
@@ -201,7 +201,7 @@ public class VTimeZoneTest
         var iCal = CreateTestCalendar("America/Anchorage");
         var serializer = new CalendarSerializer();
         // Unwrap the lines to make it easier to search for specific values
-        var serialized = TextUtil.UnwrapLines(serializer.SerializeToString(iCal));
+        var serialized = TextUtil.UnwrapLines(serializer.SerializeToString(iCal)!);
 
         using (Assert.EnterMultipleScope())
         {

--- a/Ical.Net.Tests/WikiSamples/RecurrenceWikiTests.cs
+++ b/Ical.Net.Tests/WikiSamples/RecurrenceWikiTests.cs
@@ -127,12 +127,12 @@ internal class RecurrenceWikiTests
 
         // Serialize Calendar to string
         var calendarSerializer = new CalendarSerializer();
-        var generatedIcs = calendarSerializer.SerializeToString(calendar);
+        var generatedIcs = calendarSerializer.SerializeToString(calendar)!;
 
         // Calculate all occurrences
         var tz = TimeZoneResolvers.Default("Europe/Zurich");
-        IEnumerable<Occurrence> occurrences = calendar.GetOccurrences(tz);
-        Assert.That(occurrences.Count(), Is.EqualTo(2));
+        IEnumerable<Occurrence> occurrences = calendar.GetOccurrences(tz).ToList();
+        Assert.That(occurrences.Count, Is.EqualTo(2));
 
         // Wiki code end
 

--- a/Ical.Net.Tests/WikiSamples/RecurrenceWikiTests.cs
+++ b/Ical.Net.Tests/WikiSamples/RecurrenceWikiTests.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 //
 
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,7 +12,6 @@ using Ical.Net.DataTypes;
 using Ical.Net.Serialization;
 using Ical.Net.Tests.Logging;
 using Microsoft.Extensions.Logging;
-using NodaTime;
 using NUnit.Framework;
 
 namespace Ical.Net.Tests.WikiSamples;

--- a/Ical.Net.Tests/WikiSamples/RecurrenceWikiTests.cs
+++ b/Ical.Net.Tests/WikiSamples/RecurrenceWikiTests.cs
@@ -131,8 +131,8 @@ internal class RecurrenceWikiTests
 
         // Calculate all occurrences
         var tz = TimeZoneResolvers.Default("Europe/Zurich");
-        IEnumerable<Occurrence> occurrences = calendar.GetOccurrences(tz).ToList();
-        Assert.That(occurrences.Count, Is.EqualTo(2));
+        var occurrences = calendar.GetOccurrences(tz).ToList();
+        Assert.That(occurrences, Has.Count.EqualTo(2));
 
         // Wiki code end
 

--- a/Ical.Net/DataTypes/Attachment.cs
+++ b/Ical.Net/DataTypes/Attachment.cs
@@ -42,7 +42,7 @@ public class Attachment : EncodableDataType
         }
     }
 
-    public Attachment(string value) : this()
+    public Attachment(string? value) : this()
     {
         if (string.IsNullOrEmpty(value))
         {

--- a/Ical.Net/DataTypes/Organizer.cs
+++ b/Ical.Net/DataTypes/Organizer.cs
@@ -75,7 +75,7 @@ public class Organizer : EncodableDataType
 
     public Organizer() { }
 
-    public Organizer(string value) : this()
+    public Organizer(string? value) : this()
     {
         if (string.IsNullOrWhiteSpace(value))
         {


### PR DESCRIPTION
No changes in code logic, only affecting unit tests.

* Add `nullable enable` to `Ical.Net.Tests`
* Fix nullability warnings by applying nullable and null-forgiving operators in unit tests
* Replace `Assert.Multiple` with `using (Assert.EnterMultipleScope())`

Resolves #904 