### PR TITLE
Stop todo evaluation at given datetime

### DIFF
--- a/Ical.Net/Evaluation/TodoEvaluator.cs
+++ b/Ical.Net/Evaluation/TodoEvaluator.cs
@@ -50,7 +50,7 @@ public class TodoEvaluator : RecurringEvaluator
         }
 
         return Evaluate(Todo.Start, beginningDate, options)
-            .Where(p => p.Start.ToInstant() <= currDt.ToInstant());
+            .TakeWhile(p => p.Start.ToInstant() <= currDt.ToInstant());
     }
 
     private static void DetermineStartingRecurrence(IEnumerable<EvaluationPeriod> rdate, ref ZonedDateTime referenceDateTime)


### PR DESCRIPTION
This is a v6 fix for #913. Should probably be fixed for v5 too. I am still trying to make sense of the TODO stuff, but I think `TakeWhile` was the original intention here.