### PR TITLE
Remove `EXRULE`, marked as obsolete in v5

### DIFF
--- a/Ical.Net.Tests/DocumentationExamples.cs
+++ b/Ical.Net.Tests/DocumentationExamples.cs
@@ -103,32 +103,4 @@ public class DocumentationExamples
             Assert.That(thanksgiving.Start.DayOfWeek == DayOfWeek.Thursday.ToIsoDayOfWeek(), Is.True);
         }
     }
-
-    [Test]
-    public void DailyExceptSunday_Test()
-    {
-        //An event that happens daily through 2016, except for Sundays
-        var vEvent = new CalendarEvent
-        {
-            DtStart = new CalDateTime(DateTime.Parse("2016-01-01T07:00", CultureInfo.InvariantCulture)),
-            DtEnd = new CalDateTime(DateTime.Parse("2016-12-31T08:00", CultureInfo.InvariantCulture)),
-            RecurrenceRules = new List<RecurrencePattern> { new RecurrencePattern(FrequencyType.Daily, 1) },
-        };
-
-        //Define the exceptions: Sunday
-        var exceptionRule = new RecurrencePattern(FrequencyType.Weekly, 1)
-        {
-            ByDay = new List<WeekDay> { new WeekDay(DayOfWeek.Sunday) }
-        };
-        vEvent.ExceptionRules = new List<RecurrencePattern> { exceptionRule };
-
-        var calendar = new Calendar();
-        calendar.Events.Add(vEvent);
-
-        // We are essentially counting all the days that aren't Sunday in 2016, so there should be 314
-        var searchStart = new CalDateTime(2015, 12, 31).ToZonedDateTime("America/New_York");
-        var searchEnd = new CalDateTime(2017, 01, 01).ToZonedDateTime("America/New_York").ToInstant();
-        var occurrences = calendar.GetOccurrences(searchStart).TakeWhileBefore(searchEnd).ToList();
-        Assert.That(occurrences, Has.Count.EqualTo(314));
-    }
 }

--- a/Ical.Net.Tests/RecurrenceTests_From_Issues.cs
+++ b/Ical.Net.Tests/RecurrenceTests_From_Issues.cs
@@ -470,46 +470,6 @@ public class RecurrenceTests_From_Issues
     #endregion
 
     [Test]
-    public void Except_Tuesday_Thursday_Saturday_Sunday()
-    {
-        // Every day for all of time, except Tuesday,Thursday,Saturday,and Sunday" Not working #298 
-
-        var vEvent = new CalendarEvent
-        {
-            Summary = "BIO CLASS",//subject
-            Description = "Details at CLASS",//description of meeting
-            Location = "Building 101",//location
-            DtStart = new CalDateTime(DateTime.Parse("2017-06-01T08:00", CultureInfo.InvariantCulture)),
-            DtEnd = new CalDateTime(DateTime.Parse("2017-06-01T09:30", CultureInfo.InvariantCulture)),
-            RecurrenceRules = new List<RecurrencePattern> { new RecurrencePattern(FrequencyType.Daily, 1) },
-        };
-
-        //Define the exceptions: Sunday
-        var exceptionRule = new RecurrencePattern(FrequencyType.Weekly, 1)
-        {
-            ByDay = new List<WeekDay> { new WeekDay(DayOfWeek.Sunday), new WeekDay(DayOfWeek.Saturday),
-                new WeekDay(DayOfWeek.Tuesday),new WeekDay(DayOfWeek.Thursday)}
-        };
-        vEvent.ExceptionRules = new List<RecurrencePattern> { exceptionRule };
-
-        var calendar = new Calendar();
-        calendar.Events.Add(vEvent);
-
-        var occurrences = vEvent.GetOccurrences(new CalDateTime(2017, 06, 01, 00, 00, 00)).TakeWhileBefore(new CalDateTime(2017, 06, 30, 23, 59, 0)).ToList();
-        var excludedDays = new List<DayOfWeek> { DayOfWeek.Sunday, DayOfWeek.Saturday, DayOfWeek.Tuesday, DayOfWeek.Thursday };
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(occurrences.Count, Is.EqualTo(13));
-            // Assert that none of the occurrences contain a weekday from the ByDay list
-            foreach (var occurrence in occurrences)
-            {
-                Assert.That(excludedDays, Does.Not.Contain(occurrence.Start.DayOfWeek.ToDayOfWeek()));
-            }
-        }
-    }
-
-    [Test]
     public void Weekly_ByDay_ByMonth()
     {
         // Bug #879

--- a/Ical.Net.Tests/WikiSamples/RecurrenceWikiTests.cs
+++ b/Ical.Net.Tests/WikiSamples/RecurrenceWikiTests.cs
@@ -623,56 +623,6 @@ internal class RecurrenceWikiTests
         _logger.LogDebug(expectedOccurrences);
     }
 
-    [Test]
-    public void MoreRecurrenceRuleExamples()
-    {
-        // Every other Tuesday until the end of the year
-        var rrule1 = new RecurrencePattern(FrequencyType.Weekly, 2)
-        {
-            Until = new CalDateTime(2026, 1, 1)
-        };
-
-        // The 2nd day of every month for 5 occurrences
-        var rrule2 = new RecurrencePattern(FrequencyType.Monthly)
-        {
-            ByMonthDay = [2],  // Your day of the month goes here
-            Count = 5
-        };
-
-        // The 4th Thursday of November every year
-        var rrule3 = new RecurrencePattern(FrequencyType.Yearly, 1)
-        {
-            Frequency = FrequencyType.Yearly,
-            Interval = 1,
-            ByMonth = [11],
-            ByDay = [new WeekDay { DayOfWeek = DayOfWeek.Thursday, Offset = 4 }],
-        };
-
-        // Every day in 2025, except Sundays
-        var rrule4 = new RecurrencePattern(FrequencyType.Daily)
-        {
-            // Start: 2025-01-01, End: 2025-12-31
-            Until = new CalDateTime(2025, 12, 31),
-            // Exclude Sundays
-            ByDay = [
-                new WeekDay(DayOfWeek.Monday),
-                new WeekDay(DayOfWeek.Tuesday),
-                new WeekDay(DayOfWeek.Wednesday),
-                new WeekDay(DayOfWeek.Thursday),
-                new WeekDay(DayOfWeek.Friday),
-                new WeekDay(DayOfWeek.Saturday)
-            ]
-        };
-
-        Assert.That(() =>
-        {
-            _ = new CalendarEvent
-            {
-                ExceptionRules = [rrule1, rrule2, rrule3, rrule4]
-            };
-        }, Throws.Nothing);
-    }
-
     private static string RemoveIrrelevantProperties(string generatedIcs, string[]? keep = null)
         => generatedIcs
             .Split('\n')

--- a/Ical.Net/CalendarComponents/CalendarEvent.cs
+++ b/Ical.Net/CalendarComponents/CalendarEvent.cs
@@ -209,7 +209,6 @@ public class CalendarEvent : RecurringComponent, IAlarmContainer
             && IsActive == other.IsActive
             && string.Equals(Transparency, other.Transparency, TransparencyType.Comparison)
             && Attachments.SequenceEqual(other.Attachments)
-            && CollectionHelpers.Equals(ExceptionRules, other.ExceptionRules)
             && CollectionHelpers.Equals(RecurrenceRules, other.RecurrenceRules);
 
         if (!result)

--- a/Ical.Net/CalendarComponents/IRecurrable.cs
+++ b/Ical.Net/CalendarComponents/IRecurrable.cs
@@ -19,9 +19,6 @@ public interface IRecurrable : IGetOccurrences
 
     ExceptionDates ExceptionDates { get; }
 
-    [Obsolete("EXRULE is marked as deprecated in RFC 5545 and will be removed in a future version")]
-    IList<RecurrencePattern> ExceptionRules { get; set; }
-
     RecurrenceDates RecurrenceDates { get; }
     IList<RecurrencePattern> RecurrenceRules { get; set; }
     CalDateTime? RecurrenceId { get; set; }

--- a/Ical.Net/CalendarComponents/RecurringComponent.cs
+++ b/Ical.Net/CalendarComponents/RecurringComponent.cs
@@ -19,7 +19,7 @@ namespace Ical.Net.CalendarComponents;
 /// </summary>
 /// <remarks>
 /// This component automatically handles
-/// RRULEs, RDATE, EXRULEs, and EXDATEs, as well as the DTSTART
+/// RRULEs, RDATE, and EXDATEs, as well as the DTSTART
 /// for the recurring item (all recurring items must have a DTSTART).
 /// </remarks>
 public abstract class RecurringComponent : UniqueComponent, IRecurringComponent
@@ -80,13 +80,6 @@ public abstract class RecurringComponent : UniqueComponent, IRecurringComponent
     }
 
     public virtual ExceptionDates ExceptionDates { get; internal set; } = null!;
-
-    [Obsolete("EXRULE is marked as deprecated in RFC 5545 and will be removed in a future version")]
-    public virtual IList<RecurrencePattern> ExceptionRules
-    {
-        get => Properties.GetMany<RecurrencePattern>("EXRULE");
-        set => Properties.Set("EXRULE", value);
-    }
 
     public virtual CalDateTime? LastModified
     {

--- a/Ical.Net/Evaluation/TodoEvaluator.cs
+++ b/Ical.Net/Evaluation/TodoEvaluator.cs
@@ -36,11 +36,6 @@ public class TodoEvaluator : RecurringEvaluator
         DetermineStartingRecurrence(Todo.RecurrenceDates.GetAllDates()
             .Select(x => x.ToZonedDateTime(completedDate.Zone)), ref beginningDate);
 
-        foreach (var exrule in Todo.ExceptionRules)
-        {
-            DetermineStartingRecurrence(exrule, ref beginningDate);
-        }
-
         DetermineStartingRecurrence(Todo.ExceptionDates.GetAllDates()
             .Select(x => x.ToZonedDateTime(completedDate.Zone)), ref beginningDate);
 

--- a/Ical.Net/Serialization/DataTypeMapper.cs
+++ b/Ical.Net/Serialization/DataTypeMapper.cs
@@ -39,7 +39,6 @@ internal class DataTypeMapper
         AddPropertyMapping("DUE", typeof(CalDateTime), false);
         AddPropertyMapping("DURATION", typeof(Duration), false);
         AddPropertyMapping("EXDATE", typeof(PeriodList), false);
-        AddPropertyMapping("EXRULE", typeof(RecurrencePattern), false);
         AddPropertyMapping("FREEBUSY", typeof(FreeBusyEntry), true);
         AddPropertyMapping("GEO", typeof(GeographicLocation), false);
         AddPropertyMapping("LAST-MODIFIED", typeof(CalDateTime), false);

--- a/Ical.Net/VTimeZoneInfo.cs
+++ b/Ical.Net/VTimeZoneInfo.cs
@@ -111,13 +111,6 @@ public class VTimeZoneInfo : CalendarComponent, IRecurrable
 
     public virtual ExceptionDates ExceptionDates { get; private set; } = null!;
 
-    [Obsolete("EXRULE is marked as deprecated in RFC 5545 and will be removed in a future version")]
-    public virtual IList<RecurrencePattern> ExceptionRules
-    {
-        get => Properties.GetMany<RecurrencePattern>("EXRULE");
-        set => Properties.Set("EXRULE", value);
-    }
-
     internal IList<PeriodList> RecurrenceDatesPeriodLists
     {
         get => Properties.GetMany<PeriodList>("RDATE");


### PR DESCRIPTION
**`EXRULE`** support has been fully removed from the codebase, including:
- Deletion of ExceptionRules properties from interfaces and classes
- Removal of EXRULE evaluation logic in RecurringEvaluator and TodoEvaluator
- Deletion of all tests and documentation referencing EXRULE
- CalendarEvent equality no longer compares ExceptionRules

This aligns with RFC 5545, which deprecates EXRULE, and simplifies the code by removing obsolete functionality.

See #909 
