### PR TITLE
Remove date and time arithmetic from CalDateTime

### DIFF
--- a/Ical.Net.Benchmarks/OccurencePerfTests.cs
+++ b/Ical.Net.Benchmarks/OccurencePerfTests.cs
@@ -166,8 +166,7 @@ public class OccurencePerfTests
         const string tzid = "America/New_York";
         const int limit = 4;
 
-        var startTime = CalDateTime.Now.AddDays(-1);
-        var interval = TimeSpan.FromDays(1);
+        var startTime = new LocalDate(2026, 02, 21).AtMidnight();
 
         var events = Enumerable
             .Range(0, limit)
@@ -175,14 +174,14 @@ public class OccurencePerfTests
             {
                 var e = new CalendarEvent
                 {
-                    Start = startTime.AddMinutes(5).ToTimeZone(tzid),
-                    End = startTime.AddMinutes(10).ToTimeZone(tzid),
+                    Start = new(startTime.PlusMinutes(5), tzid),
+                    End = new(startTime.PlusMinutes(10), tzid),
                     RecurrenceRule = new(FrequencyType.Daily, 1)
                     {
-                        Until = startTime.AddDays(10),
+                        Until = new(startTime.PlusDays(10).InUtc().ToInstant()),
                     },
                 };
-                startTime = startTime.Add(DataTypes.Duration.FromTimeSpanExact(interval));
+                startTime = startTime.PlusDays(1);
                 return e;
             });
 

--- a/Ical.Net.Tests/CalDateTimeTests.cs
+++ b/Ical.Net.Tests/CalDateTimeTests.cs
@@ -174,30 +174,6 @@ public class CalDateTimeTests
             .SetName("Date only with 'IT' CultureInfo and default format arg");
     }
 
-    [Test, TestCaseSource(nameof(DateTimeArithmeticTestCases))]
-    public DateTime DateTimeArithmeticTests(Func<CalDateTime, CalDateTime> operation)
-    {
-        var result = operation(new CalDateTime(2025, 1, 15, 10, 20, 30, tzId: CalDateTime.UtcTzId));
-        return result.Value;
-    }
-
-    public static IEnumerable DateTimeArithmeticTestCases()
-    {
-        var dateTime = new DateTime(2025, 1, 15, 10, 20, 30);
-
-        yield return new TestCaseData(new Func<CalDateTime, CalDateTime>(dt => dt.AddHours(1)))
-            .Returns(dateTime.AddHours(1))
-            .SetName($"{nameof(CalDateTime.AddHours)} 1 hour");
-
-        yield return new TestCaseData(new Func<CalDateTime, CalDateTime>(dt => dt.Add(Duration.FromSeconds(30))))
-            .Returns(dateTime.Add(TimeSpan.FromSeconds(30)))
-            .SetName($"{nameof(CalDateTime.Add)} 30 seconds");
-
-        yield return new TestCaseData(new Func<CalDateTime, CalDateTime>(dt => dt.AddMinutes(70)))
-            .Returns(dateTime.AddMinutes(70))
-            .SetName($"{nameof(CalDateTime.AddMinutes)} 70 minutes");
-    }
-
     [Test, TestCaseSource(nameof(EqualityTestCases))]
     public bool EqualityTests(Func<CalDateTime, bool> operation)
     {
@@ -254,10 +230,6 @@ public class CalDateTimeTests
     {
         var dateTime = new DateTime(2025, 1, 15);
 
-        yield return new TestCaseData(new Func<CalDateTime, CalDateTime>(dt => dt.Add(-Duration.FromDays(1))))
-            .Returns((dateTime.AddDays(-1), false))
-            .SetName($"{nameof(CalDateTime.Add)} -1 day TimeSpan");
-
         yield return new TestCaseData(new Func<CalDateTime, CalDateTime>(dt => dt.AddYears(1)))
             .Returns((dateTime.AddYears(1), false))
             .SetName($"{nameof(CalDateTime.AddYears)} 1 year");
@@ -269,28 +241,6 @@ public class CalDateTimeTests
         yield return new TestCaseData(new Func<CalDateTime, CalDateTime>(dt => dt.AddDays(7)))
             .Returns((dateTime.AddDays(7), false))
             .SetName($"{nameof(CalDateTime.AddDays)} 7 days");
-
-        yield return new TestCaseData(new Func<CalDateTime, CalDateTime>(dt => dt.Add(Duration.FromDays(1))))
-            .Returns((dateTime.Add(TimeSpan.FromDays(1)), false))
-            .SetName($"{nameof(CalDateTime.Add)} 1 day TimeSpan");
-
-        yield return new TestCaseData(new Func<CalDateTime, CalDateTime>(dt => dt.Add(Duration.Zero)))
-            .Returns((dateTime.Add(TimeSpan.Zero), false))
-            .SetName($"{nameof(CalDateTime.Add)} TimeSpan.Zero");
-    }
-
-    [Test]
-    public void DateOnlyInvalidArithmeticTests()
-    {
-        var dt = new CalDateTime(2025, 1, 15);
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(() => dt.Add(Duration.FromHours(1)), Throws.TypeOf<InvalidOperationException>());
-            Assert.That(() => dt.AddHours(2), Throws.TypeOf<InvalidOperationException>());
-            Assert.That(() => dt.AddMinutes(3), Throws.TypeOf<InvalidOperationException>());
-            Assert.That(() => dt.AddSeconds(4), Throws.TypeOf<InvalidOperationException>());
-        }
     }
 
     [Test]
@@ -313,7 +263,6 @@ public class CalDateTimeTests
             Assert.That(CalDateTime.Today.Value.Kind, Is.EqualTo(DateTimeKind.Unspecified));
             Assert.That(c.DayOfYear, Is.EqualTo(dt.DayOfYear));
             Assert.That(c.Time, Is.EqualTo(NodaTime.LocalDateTime.FromDateTime(dt).TimeOfDay));
-            Assert.That(c.Add(-Duration.FromSeconds(dt.Second)).Value.Second, Is.EqualTo(0));
             Assert.That(c.ToString("dd.MM.yyyy", CultureInfo.InvariantCulture), Is.EqualTo("02.01.2025 Europe/Berlin"));
         }
     }

--- a/Ical.Net.Tests/CalDateTimeTests.cs
+++ b/Ical.Net.Tests/CalDateTimeTests.cs
@@ -218,31 +218,6 @@ public class CalDateTimeTests
         Assert.That(seq1.Count(), Is.EqualTo(seq2.Count()));
     }
 
-
-    [Test, TestCaseSource(nameof(DateOnlyValidArithmeticTestCases))]
-    public (DateTime Value, bool HasTime) DateOnlyValidArithmeticTests(Func<CalDateTime, CalDateTime> operation)
-    {
-        var result = operation(new CalDateTime(2025, 1, 15));
-        return (result.Value, result.HasTime);
-    }
-
-    public static IEnumerable DateOnlyValidArithmeticTestCases()
-    {
-        var dateTime = new DateTime(2025, 1, 15);
-
-        yield return new TestCaseData(new Func<CalDateTime, CalDateTime>(dt => dt.AddYears(1)))
-            .Returns((dateTime.AddYears(1), false))
-            .SetName($"{nameof(CalDateTime.AddYears)} 1 year");
-
-        yield return new TestCaseData(new Func<CalDateTime, CalDateTime>(dt => dt.AddMonths(2)))
-            .Returns((dateTime.AddMonths(2), false))
-            .SetName($"{nameof(CalDateTime.AddMonths)} 2 months");
-
-        yield return new TestCaseData(new Func<CalDateTime, CalDateTime>(dt => dt.AddDays(7)))
-            .Returns((dateTime.AddDays(7), false))
-            .SetName($"{nameof(CalDateTime.AddDays)} 7 days");
-    }
-
     [Test]
     public void Simple_PropertyAndMethod_HasTime_Tests()
     {

--- a/Ical.Net.Tests/DurationTests.cs
+++ b/Ical.Net.Tests/DurationTests.cs
@@ -1,0 +1,75 @@
+﻿//
+// Copyright ical.net project maintainers and contributors.
+// Licensed under the MIT license.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Ical.Net.DataTypes;
+using NUnit.Framework;
+
+namespace Ical.Net.Tests;
+
+[TestFixture]
+public class DurationTests
+{
+    [Test]
+    public void DurationWithMixSignsThrows()
+    {
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.Throws<ArgumentException>(() => new Duration(-3, 3));
+            Assert.Throws<ArgumentException>(() => new Duration(hours: 3, minutes: -3));
+            Assert.Throws<ArgumentException>(() => new Duration(3, seconds: -3));
+        }
+    }
+
+    [Test]
+    public void DurationFromTimeSpanOnlyHasTime()
+    {
+        var t = new TimeSpan(10, 4, 5, 6);
+        var d = Duration.FromTimeSpanExact(t);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(d.HasDate, Is.False);
+            Assert.That(d.Hours, Is.EqualTo(244));
+        }
+    }
+
+    [Test]
+    public void DurationFromAndToTimeSpanIsEqual()
+    {
+        var a = new TimeSpan(10, 4, 5, 6);
+        var b = Duration.FromTimeSpanExact(a).ToTimeSpanUnspecified();
+
+        Assert.That(a, Is.EqualTo(b));
+    }
+
+    [Test]
+    public void DurationNegatesValues()
+    {
+        var a = new Duration(1, 2, 3, 4, 5);
+
+        var b = -a;
+
+        Assert.That(b.ToString(), Is.EqualTo("-P1W2DT3H4M5S"));
+    }
+
+    [Test]
+    public void DurationNegatesNullValues()
+    {
+        var a = new Duration(1, 2, seconds: 3);
+
+        var b = -a;
+
+        Assert.That(b.ToString(), Is.EqualTo("-P1W2DT3S"));
+    }
+
+    [Test]
+    public void DurationZeroAndNullAreEqual()
+    {
+        Assert.That(Duration.FromSeconds(0), Is.EqualTo(Duration.Zero));
+    }
+}

--- a/Ical.Net.Tests/PeriodListWrapperTests.cs
+++ b/Ical.Net.Tests/PeriodListWrapperTests.cs
@@ -82,7 +82,7 @@ public class PeriodListWrapperTests
         var dateTime = new CalDateTime(2025, 1, 1, 10, 11, 12, "Europe/Berlin");
 
         exDates.Add(dateOnly);
-        exDates.Add(dateOnly.AddDays(1));
+        exDates.Add(dateOnly.Date.PlusDays(1).ToCalDateTime());
         exDates.Add(dateTime);
 
         var dateTimeSuccess = exDates.Remove(dateTime);
@@ -234,7 +234,7 @@ public class PeriodListWrapperTests
         var period2 = new Period(new CalDateTime(2025, 1, 1, 10, 0, 0, "Europe/Berlin"), Duration.FromHours(6));
 
         recDates.Add(period1).Add(period2);
-        recDates.Add(new Period(period1.StartTime.AddDays(1), Duration.FromDays(5)));
+        recDates.Add(new Period(period1.StartTime.Date.PlusDays(1).ToCalDateTime(), Duration.FromDays(5)));
 
         var period1Success = recDates.Remove(period1);
         var period2Success = recDates.Remove(period2);
@@ -281,8 +281,11 @@ public class PeriodListWrapperTests
         
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(recDates.Contains(new Period(period1.StartTime.AddDays(1), Duration.FromDays(5))), Is.False);
-            Assert.That(recDates.Contains(new Period(period2.StartTime.AddDays(1), Duration.FromHours(6))), Is.False);
+            var start1 = period1.StartTime.Date.PlusDays(1).ToCalDateTime();
+            Assert.That(recDates.Contains(new Period(start1, Duration.FromDays(5))), Is.False);
+
+            var start2 = period2.StartTime.ToLocalDateTime().PlusDays(1).ToCalDateTime("Europe/Berlin");
+            Assert.That(recDates.Contains(new Period(start2, Duration.FromHours(6))), Is.False);
         }
     }
 
@@ -336,8 +339,8 @@ public class PeriodListWrapperTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(exDates.Contains(dateOnly.AddDays(1)), Is.False);
-            Assert.That(exDates.Contains(dateTime.AddDays(1)), Is.False);
+            Assert.That(exDates.Contains(new CalDateTime(2025, 1, 2)), Is.False);
+            Assert.That(exDates.Contains(new CalDateTime(2025, 1, 2, 10, 11, 12, "Europe/Berlin")), Is.False);
         }
     }
 

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -3026,8 +3026,8 @@ END:VCALENDAR";
         Assert.That(occurrences, Has.Count.EqualTo(3));
     }
 
-    private static readonly CalDateTime _now = CalDateTime.Now;
-    private static readonly CalDateTime _later = _now.AddHours(1);
+    private static readonly CalDateTime _now = new(2026, 2, 24, 11, 30, 21);
+    private static readonly CalDateTime _later = _now.ToLocalDateTime().PlusHours(1).ToCalDateTime();
 
     private static CalendarEvent GetEventWithRecurrenceRule()
     {
@@ -3048,7 +3048,7 @@ END:VCALENDAR";
     public void ExDatesShouldGetMergedInOutput()
     {
         var start = _now.AddYears(-1);
-        var end = start.AddHours(1);
+        var end = start.ToLocalDateTime().PlusHours(1).ToCalDateTime();
         var e = new CalendarEvent
         {
             DtStart = start,
@@ -3491,8 +3491,13 @@ END:VCALENDAR";
         var evt = cal.Events.First();
         var ev = new EventEvaluator(evt);
 
+        var end = evt.DtStart!
+            .ToZonedDateTime()
+            .PlusMinutes(61)
+            .ToInstant();
+
         var occurrences = ev.Evaluate(evt.DtStart!, evt.DtStart!.ToZonedDateTime(tzId), null)
-            .TakeWhileBefore(evt.DtStart.AddMinutes(61).ToZonedDateTime(tzId).ToInstant());
+            .TakeWhileBefore(end);
 
         var occurrencesStartTimes = occurrences.Select(x => x.Start).Take(2).ToList();
 

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -2441,7 +2441,7 @@ public class RecurrenceTests
             Start = new CalDateTime(2019, 1, 4, 8, 0, 0, "UTC"),
             RecurrenceRule = new(FrequencyType.Daily)
             {
-                Until = CalDateTime.Today.AddMonths(4)
+                Until = new(2019, 5, 4, 8, 0, 0, "UTC")
             }
         };
 
@@ -2569,7 +2569,7 @@ public class RecurrenceTests
         evt.RecurrenceRule = new($"FREQ={freq};INTERVAL=10;COUNT=5");
 
         var occurrences = evt.GetOccurrences(evt.Start.ToZonedDateTime().PlusHours(-24))
-            .TakeWhileBefore(evt.Start.AddDays(100))
+            .TakeWhileBefore(evt.Start.Date.PlusDays(100).AtMidnight().InUtc().ToInstant())
             .ToList();
 
         var startDates = occurrences.Select(x => x.Start.ToInstant()).ToList();
@@ -3008,19 +3008,19 @@ END:VCALENDAR";
     [Test]
     public void AddExDateToEventAfterGetOccurrencesShouldRecomputeResult()
     {
-        var searchStart = _now.AddDays(-1);
-        var searchEnd = _now.AddDays(7);
+        var searchStart = _now.ToLocalDateTime().PlusDays(-1).ToCalDateTime();
+        var searchEnd = _now.ToLocalDateTime().PlusDays(7).ToCalDateTime();
         var e = GetEventWithRecurrenceRule();
         var occurrences = e.GetOccurrences(searchStart).TakeWhileBefore(searchEnd).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(5));
 
-        var exDate = _now.AddDays(1);
+        var exDate = _now.ToLocalDateTime().PlusDays(1).ToCalDateTime();
         e.ExceptionDates.Add(exDate);
         occurrences = e.GetOccurrences(searchStart).TakeWhileBefore(searchEnd).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(4));
 
         //Specifying just a date should "black out" that date
-        var excludeTwoDaysFromNow = new CalDateTime(_now.Date).AddDays(2);
+        var excludeTwoDaysFromNow = new CalDateTime(_now.Date.PlusDays(2));
         e.ExceptionDates.Add(excludeTwoDaysFromNow);
         occurrences = e.GetOccurrences(searchStart).TakeWhileBefore(searchEnd).ToList();
         Assert.That(occurrences, Has.Count.EqualTo(3));
@@ -3047,7 +3047,7 @@ END:VCALENDAR";
     [Test]
     public void ExDatesShouldGetMergedInOutput()
     {
-        var start = _now.AddYears(-1);
+        var start = _now.ToLocalDateTime().PlusYears(-1).ToCalDateTime();
         var end = start.ToLocalDateTime().PlusHours(1).ToCalDateTime();
         var e = new CalendarEvent
         {
@@ -3055,16 +3055,16 @@ END:VCALENDAR";
             DtEnd = end,
             RecurrenceRule = new RecurrenceRule(FrequencyType.Daily)
             {
-                Until = start.AddYears(2)
+                Until = start.ToLocalDateTime().PlusYears(2).ToCalDateTime()
             }
         };
 
-        var firstExclusion = start.AddDays(4);
+        var firstExclusion = start.ToLocalDateTime().PlusDays(4).ToCalDateTime();
         e.ExceptionDates.Add(firstExclusion);
         var serialized = SerializationHelpers.SerializeToString(e);
         Assert.That(Regex.Matches(serialized, "EXDATE:"), Has.Count.EqualTo(1));
 
-        var secondExclusion = start.AddDays(5);
+        var secondExclusion = start.ToLocalDateTime().PlusDays(5).ToCalDateTime();
         e.ExceptionDates.Add(secondExclusion);
         serialized = SerializationHelpers.SerializeToString(e);
         Assert.That(Regex.Matches(serialized, "EXDATE:"), Has.Count.EqualTo(1));
@@ -3085,13 +3085,13 @@ END:VCALENDAR";
             }
         };
 
-        e.ExceptionDates.Add(new CalDateTime(_now.Date, _now.Time, tzid).AddDays(1));
+        e.ExceptionDates.Add(new CalDateTime(_now.Date.PlusDays(1), _now.Time, tzid));
 
         var serialized = SerializationHelpers.SerializeToString(e);
         const string expected = "TZID=Europe/Stockholm";
         Assert.That(Regex.Matches(serialized, expected), Has.Count.EqualTo(3));
 
-        e.ExceptionDates.Add(new CalDateTime(_now.Date, _now.Time, tzid).AddDays(2));
+        e.ExceptionDates.Add(new CalDateTime(_now.Date.PlusDays(2), _now.Time, tzid));
         serialized = SerializationHelpers.SerializeToString(e);
         Assert.That(Regex.Matches(serialized, expected), Has.Count.EqualTo(3));
     }
@@ -3105,14 +3105,20 @@ END:VCALENDAR";
             End = new CalDateTime(DateTime.Parse("2019-06-08 00:00:00", CultureInfo.InvariantCulture))
         };
 
+        var tz = DateUtil.GetZone("America/New_York");
+
         //Testing on both the first day and the next, results used to be different
         for (var i = 0; i <= 1; i++)
         {
-            var checkTime = new CalDateTime(2019, 06, 07, 00, 00, 00);
-            checkTime = checkTime.AddDays(i);
+            var checkTime = new LocalDate(2019, 6, 7)
+                .PlusDays(i)
+                .AtStartOfDayInZone(tz);
 
             //Valid if asking for a range starting at the same moment
-            var occurrences = vEvent.GetOccurrences(checkTime).TakeWhileBefore(checkTime.AddDays(1)).ToList();
+            var occurrences = vEvent.GetOccurrences(checkTime)
+                .TakeWhileBefore(checkTime.PlusHours(24).ToInstant())
+                .ToList();
+
             Assert.That(occurrences, Has.Count.EqualTo(i == 0 ? 1 : 0));
         }
     }

--- a/Ical.Net.Tests/SerializationTests.cs
+++ b/Ical.Net.Tests/SerializationTests.cs
@@ -23,12 +23,21 @@ namespace Ical.Net.Tests;
 [TestFixture]
 public class SerializationTests
 {
-    private static readonly CalDateTime _nowTime = CalDateTime.Now;
-    private static readonly CalDateTime _later = _nowTime.AddHours(1);
-    private static CalendarSerializer GetNewSerializer() => new CalendarSerializer();
+    private static readonly CalDateTime _nowTime = new(2026, 2, 24, 11, 30, 21);
+
+    private static readonly CalDateTime _later = _nowTime.ToLocalDateTime().PlusHours(1).ToCalDateTime();
+    private static CalendarSerializer GetNewSerializer() => new();
+
     private static string SerializeToString(Calendar c) => GetNewSerializer().SerializeToString(c)!;
+
     private static string SerializeToString(CalendarEvent e) => SerializeToString(new Calendar { Events = { e } });
-    private static CalendarEvent GetSimpleEvent() => new CalendarEvent { DtStart = _nowTime, Duration = (_later.Value - _nowTime.Value).ToDurationExact() };
+
+    private static CalendarEvent GetSimpleEvent() => new()
+    {
+        DtStart = _nowTime,
+        Duration = Duration.FromPeriod(_later.ToLocalDateTime() - _nowTime.ToLocalDateTime())
+    };
+
     private static Calendar DeserializeCalendar(string s) => Calendar.Load(s)!;
 
     internal static void CompareComponents(ICalendarComponent cb1, ICalendarComponent cb2)
@@ -457,11 +466,11 @@ public class SerializationTests
         var e = new CalendarEvent
         {
             Start = _nowTime.ToTimeZone(someTz),
-            End = _nowTime.AddHours(1).ToTimeZone(someTz),
+            End = _nowTime.ToLocalDateTime().PlusHours(1).ToCalDateTime().ToTimeZone(someTz),
             RecurrenceRule = new(FrequencyType.Daily)
             {
-                Until = _nowTime.AddDays(7),
-            },
+                Until = _nowTime.ToLocalDateTime().PlusDays(7).ToCalDateTime(),
+            }
         };
         var c = new Calendar
         {

--- a/Ical.Net.Tests/SymmetricSerializationTests.cs
+++ b/Ical.Net.Tests/SymmetricSerializationTests.cs
@@ -32,7 +32,7 @@ public class SymmetricSerializationTests
         if (useDtEnd)
             evt.DtEnd = new CalDateTime(_later);
         else
-            evt.Duration = (_later - _nowTime).ToDurationExact();
+            evt.Duration = Duration.FromTimeSpanExact(_later - _nowTime);
 
         return evt;
     }

--- a/Ical.Net.Tests/TodoTest.cs
+++ b/Ical.Net.Tests/TodoTest.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
+using Ical.Net.Utility;
 using NUnit.Framework;
 
 namespace Ical.Net.Tests;
@@ -95,7 +96,9 @@ public class TodoTest
 
         // periodStart is in the future, so filtering the first occurrence will also require
         // looking at the todo's duration, which is unset/null. It must therefore be ignored.
-        var firstOccurrence = todo.GetOccurrences(today.AddDays(2).ToZonedDateTime("America/New_York")).FirstOrDefault();
+        var tz = DateUtil.GetZone("America/New_York");
+        var start = today.Date.PlusDays(2).AtStartOfDayInZone(tz);
+        var firstOccurrence = todo.GetOccurrences(start).FirstOrDefault();
 
         Assert.That(firstOccurrence, Is.Not.Null);
         Assert.That(firstOccurrence.Start, Is.EqualTo(firstOccurrence.End));

--- a/Ical.Net.Tests/VTimeZoneTest.cs
+++ b/Ical.Net.Tests/VTimeZoneTest.cs
@@ -277,7 +277,7 @@ public class VTimeZoneTest
 
         iCal = CreateTestCalendar("America/Detroit");
         var tzInfo2 = iCal.TimeZones.First().TimeZoneInfos.First();
-        tzInfo2.RecurrenceId = dt.AddDays(1);
+        tzInfo2.RecurrenceId = dt.Date.PlusDays(1).ToCalDateTime();
 
         iCal = CreateTestCalendar("America/Detroit");
         var tzInfo3 = iCal.TimeZones.First().TimeZoneInfos.First();
@@ -290,8 +290,8 @@ public class VTimeZoneTest
 
             Assert.That(tzInfo1.TzId, Is.EqualTo("America/Detroit"));
 
-            Assert.That(tzInfo2.RecurrenceIdentifier!.StartTime, Is.EqualTo(dt.AddDays(1)));
-            Assert.That(tzInfo2.RecurrenceId, Is.EqualTo(dt.AddDays(1)));
+            Assert.That(tzInfo2.RecurrenceIdentifier!.StartTime, Is.EqualTo(dt.Date.PlusDays(1).ToCalDateTime()));
+            Assert.That(tzInfo2.RecurrenceId, Is.EqualTo(dt.Date.PlusDays(1).ToCalDateTime()));
             Assert.That(tzInfo2.RecurrenceIdentifier.Range, Is.EqualTo(RecurrenceRange.ThisInstance));
 
             // RecurrenceId only supports ThisInstance implicitly,

--- a/Ical.Net.Tests/WikiSamples/RecurrenceWikiTests.cs
+++ b/Ical.Net.Tests/WikiSamples/RecurrenceWikiTests.cs
@@ -183,8 +183,11 @@ internal class RecurrenceWikiTests
         {
             Frequency = FrequencyType.Yearly,
             ByMonthDay = [10, 12],
-            // 2027-07-10 09:00:00 Europe/Zurich (07:00:00 UTC)
-            Until = start.AddYears(2).ToTimeZone("UTC")
+            Until = start.ToLocalDateTime()
+                .PlusYears(2)
+                .InZoneLeniently("Europe/Zurich")
+                .ToInstant()
+                .ToCalDateTime()
         };
 
         var calendarEvent = new CalendarEvent
@@ -439,7 +442,7 @@ internal class RecurrenceWikiTests
             DtStart = startMoved,
             DtEnd = new(startMoved.ToZonedDateTime().PlusMinutes(13)),
             // Set the original date of the occurrence (2025-07-14 09:00:00).
-            RecurrenceId = start.AddDays(4),
+            RecurrenceId = new(2025, 07, 14, 09, 00, 00, timeZoneId),
             // The first change for this RecurrenceId
             Sequence = 1
         };

--- a/Ical.Net.Tests/WikiSamples/RecurrenceWikiTests.cs
+++ b/Ical.Net.Tests/WikiSamples/RecurrenceWikiTests.cs
@@ -12,6 +12,7 @@ using Ical.Net.DataTypes;
 using Ical.Net.Serialization;
 using Ical.Net.Tests.Logging;
 using Microsoft.Extensions.Logging;
+using NodaTime;
 using NUnit.Framework;
 
 namespace Ical.Net.Tests.WikiSamples;
@@ -117,7 +118,7 @@ internal class RecurrenceWikiTests
         var calendarEvent = new CalendarEvent
         {
             DtStart = start,
-            DtEnd = start.AddHours(1),
+            DtEnd = start.ToZonedDateTime().PlusHours(1).ToCalDateTime(),
             RecurrenceRule = recurrence
         };
 
@@ -189,7 +190,7 @@ internal class RecurrenceWikiTests
         var calendarEvent = new CalendarEvent
         {
             DtStart = start,
-            DtEnd = start.AddHours(1),
+            DtEnd = start.ToZonedDateTime().PlusHours(1).ToCalDateTime(),
             RecurrenceRule = recurrence
         };
 
@@ -265,8 +266,8 @@ internal class RecurrenceWikiTests
         var calendarEvent = new CalendarEvent
         {
             DtStart = start,
-            DtEnd = start.AddHours(4),
-            RecurrenceRule = recurrence,
+            DtEnd = start.ToZonedDateTime().PlusHours(4).ToCalDateTime(),
+            RecurrenceRule = recurrence
         };
         // Add additional an occurrence to the series.
         calendarEvent.RecurrenceDates
@@ -334,14 +335,14 @@ internal class RecurrenceWikiTests
         var recurrence = new RecurrenceRule
         {
             Frequency = FrequencyType.Hourly,
-            Until = start.AddHours(4)
+            Until = start.ToZonedDateTime().PlusHours(4).ToCalDateTime()
         };
 
         var calendarEvent = new CalendarEvent
         {
             DtStart = start,
-            DtEnd = start.AddMinutes(15),
-            RecurrenceRule = recurrence,
+            DtEnd = new(start.ToZonedDateTime().PlusMinutes(15)),
+            RecurrenceRule = recurrence
         };
         // Add the exception date to the series.
         calendarEvent.ExceptionDates
@@ -407,7 +408,8 @@ internal class RecurrenceWikiTests
         // Wiki code start
 
         // Create the CalendarEvent
-        var start = new CalDateTime(2025, 07, 10, 09, 00, 00, "Europe/Zurich");
+        var timeZoneId = "Europe/Zurich";
+        var start = new CalDateTime(2025, 07, 10, 09, 00, 00, timeZoneId);
         var recurrence = new RecurrenceRule
         {
             Frequency = FrequencyType.Daily,
@@ -421,12 +423,12 @@ internal class RecurrenceWikiTests
             Uid = "my-custom-id",
             Summary = "Walking",
             DtStart = start,
-            DtEnd = start.AddHours(1),
+            DtEnd = start.ToZonedDateTime().PlusHours(1).ToCalDateTime(),
             RecurrenceRule = recurrence,
             Sequence = 0 // default value
         };
 
-        var startMoved = new CalDateTime(2025, 07, 13, 13, 00, 00, "Europe/Zurich");
+        var startMoved = new CalDateTime(2025, 07, 13, 13, 00, 00, timeZoneId);
         var movedEvent = new CalendarEvent
         {
             // UID links master with child.
@@ -435,7 +437,7 @@ internal class RecurrenceWikiTests
             Summary = "Short after lunch walk",
             // Set new start and end time.
             DtStart = startMoved,
-            DtEnd = startMoved.AddMinutes(13),
+            DtEnd = new(startMoved.ToZonedDateTime().PlusMinutes(13)),
             // Set the original date of the occurrence (2025-07-14 09:00:00).
             RecurrenceId = start.AddDays(4),
             // The first change for this RecurrenceId
@@ -521,7 +523,7 @@ internal class RecurrenceWikiTests
         var calendarEvent = new CalendarEvent
         {
             DtStart = start,
-            DtEnd = start.AddHours(1),
+            DtEnd = start.ToZonedDateTime().PlusHours(1).ToCalDateTime(),
             RecurrenceRule = recurrence
         };
 
@@ -578,14 +580,15 @@ internal class RecurrenceWikiTests
         // Wiki code start
 
         var calendar = new Calendar();
-        var start = new CalDateTime(2025, 9, 1, 10, 0, 0, CalDateTime.UtcTzId);
+
+        var start = new LocalDateTime(2025, 9, 1, 10, 0, 0);
 
         // Event that recurs daily
         calendar.Events.Add(new CalendarEvent
         {
             Summary = "Daily event",
-            Start = start,
-            End = start.AddHours(1),
+            Start = start.ToCalDateTime(CalDateTime.UtcTzId),
+            End = start.InUtc().PlusHours(1).ToCalDateTime(),
             RecurrenceRule = new RecurrenceRule(FrequencyType.Daily, interval: 1)
         });
 
@@ -593,8 +596,8 @@ internal class RecurrenceWikiTests
         calendar.Events.Add(new CalendarEvent
         {
             Summary = "Far future event",
-            Start = start.AddYears(10),
-            End = start.AddYears(10).AddHours(1)
+            Start = start.PlusYears(10).ToCalDateTime(CalDateTime.UtcTzId),
+            End = start.PlusYears(10).InUtc().PlusHours(1).ToCalDateTime()
         });
         
         var tz = TimeZoneResolvers.Default("UTC");

--- a/Ical.Net/CalendarComponents/VTimeZone.cs
+++ b/Ical.Net/CalendarComponents/VTimeZone.cs
@@ -250,8 +250,8 @@ public class VTimeZone : CalendarComponent
     {
         foreach (var interval in intervals)
         {
-            var time = interval.IsoLocalStart.ToDateTimeUnspecified();
-            var date = new CalDateTime(time, true).Add(delta.ToDurationExact());
+            var time = interval.IsoLocalStart.PlusSeconds((long)delta.TotalSeconds);
+            var date = new CalDateTime(time);
 
             tzi.RecurrenceDates.Add(date);
         }

--- a/Ical.Net/DataTypes/CalDateTime.cs
+++ b/Ical.Net/DataTypes/CalDateTime.cs
@@ -464,24 +464,6 @@ public sealed class CalDateTime : IFormattable, IEquatable<CalDateTime>
         return new(ToZonedDateTime(otherTzId));
     }
 
-    /// <inheritdoc cref="DateTime.AddYears"/>
-    public CalDateTime AddYears(int years)
-    {
-        return new(_localDate.PlusYears(years), _localTime, _tzId);
-    }
-
-    /// <inheritdoc cref="DateTime.AddMonths"/>
-    public CalDateTime AddMonths(int months)
-    {
-        return new(_localDate.PlusMonths(months), _localTime, _tzId);
-    }
-
-    /// <inheritdoc cref="DateTime.AddDays"/>
-    public CalDateTime AddDays(int days)
-    {
-        return new(_localDate.PlusDays(days), _localTime, _tzId);
-    }
-
     /// <inheritdoc />
     public override string ToString() => ToString(null, null);
 

--- a/Ical.Net/DataTypes/CalDateTime.cs
+++ b/Ical.Net/DataTypes/CalDateTime.cs
@@ -464,64 +464,6 @@ public sealed class CalDateTime : IFormattable, IEquatable<CalDateTime>
         return new(ToZonedDateTime(otherTzId));
     }
 
-    /// <summary>
-    /// Add the specified <see cref="Duration"/> to this instance/>.
-    /// </summary>
-    /// <remarks>
-    /// In correspondence to RFC5545, the weeks and day fields of a duration are considered nominal durations while the time fields are considered exact values.
-    /// </remarks>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown when attempting to add a time span to a date-only instance, 
-    /// and the time span is not a multiple of full days.
-    /// </exception>
-    public CalDateTime Add(Duration d)
-    {
-        // If NOOP
-        if (d.IsEmpty) return this;
-
-        if (!HasTime && d.HasTime)
-        {
-            throw new InvalidOperationException($"This instance represents a 'date-only' value '{ToString()}'. Only multiples of full days can be added to a 'date-only' instance, not '{d}'");
-        }
-
-        // RFC 5545 3.3.6:
-        // If the property permits, multiple "duration" values are specified by a COMMA-separated
-        // list of values.The format is based on the[ISO.8601.2004] complete representation basic
-        // format with designators for the duration of time.The format can represent nominal
-        // durations(weeks and days) and accurate durations(hours, minutes, and seconds).
-        // Note that unlike[ISO.8601.2004], this value type doesn't support the "Y" and "M"
-        // designators to specify durations in terms of years and months.
-        //
-        // The duration of a week or a day depends on its position in the calendar. In the case
-        // of discontinuities in the time scale, such as the change from standard time to daylight
-        // time and back, the computation of the exact duration requires the subtraction or
-        // addition of the change of duration of the discontinuity.Leap seconds MUST NOT be
-        // considered when computing an exact duration.When computing an exact duration, the
-        // greatest order time components MUST be added first, that is, the number of days MUST be
-        // added first, followed by the number of hours, number of minutes, and number of seconds.
-
-        if (_localTime is null)
-        {
-            // The value is date only and the duration has no time,
-            // so just add to the date.
-            var date = ToLocalDateTime().Date.Plus(d.GetNominalPart());
-            return new(date, _tzId);
-        }
-        else
-        {
-            // Treat floating values as UTC, and add date and time
-            var zoned = ToZonedDateTime();
-            var result = zoned
-                .LocalDateTime
-                .Plus(d.GetNominalPart())
-                .InZoneLeniently(zoned.Zone)
-                .Plus(d.GetTimePart());
-
-            // Use the original time zone (which may be null)
-            return new(result.LocalDateTime, _tzId);
-        }
-    }
-
     /// <inheritdoc cref="DateTime.AddYears"/>
     public CalDateTime AddYears(int years)
     {
@@ -539,27 +481,6 @@ public sealed class CalDateTime : IFormattable, IEquatable<CalDateTime>
     {
         return new(_localDate.PlusDays(days), _localTime, _tzId);
     }
-
-    /// <inheritdoc cref="DateTime.AddHours"/>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown when attempting to add a time span to a date-only instance, 
-    /// and the time span is not a multiple of full days.
-    /// </exception>
-    public CalDateTime AddHours(int hours) => Add(Duration.FromHours(hours));
-
-    /// <inheritdoc cref="DateTime.AddMinutes"/>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown when attempting to add a time span to a date-only instance, 
-    /// and the time span is not a multiple of full days.
-    /// </exception>
-    public CalDateTime AddMinutes(int minutes) => Add(Duration.FromMinutes(minutes));
-
-    /// <inheritdoc cref="DateTime.AddSeconds"/>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown when attempting to add a time span to a date-only instance, 
-    /// and the time span is not a multiple of full days.
-    /// </exception>
-    public CalDateTime AddSeconds(int seconds) => Add(Duration.FromSeconds(seconds));
 
     /// <inheritdoc />
     public override string ToString() => ToString(null, null);

--- a/Ical.Net/DataTypes/Duration.cs
+++ b/Ical.Net/DataTypes/Duration.cs
@@ -179,25 +179,6 @@ public struct Duration
         => new Duration(hours: NullIfZero(t.Days * 24 + t.Hours), minutes: NullIfZero(t.Minutes), seconds: NullIfZero(t.Seconds));
 
     /// <summary>
-    /// Creates an instance that represents the given time span, treating the days as nominal duration and the time part as exact.
-    /// </summary>
-    /// <remarks>
-    /// According to RFC5545 the weeks and day fields of a duration are considered nominal durations while the time fields are considered exact values.
-    /// </remarks>
-    internal static Duration FromTimeSpan(TimeSpan t)
-        => new Duration(days: NullIfZero(t.Days), hours: NullIfZero(t.Hours), minutes: NullIfZero(t.Minutes), seconds: NullIfZero(t.Seconds));
-
-    /// <summary>
-    /// Gets a value representing the time parts of the given instance.
-    /// </summary>
-    internal TimeSpan TimeAsTimeSpan => new(0, Hours ?? 0, Minutes ?? 0, Seconds ?? 0);
-
-    /// <summary>
-    /// Gets a value representing the date parts (days and weeks) of the given instance.
-    /// </summary>
-    internal TimeSpan DateAsTimeSpan => new((Weeks ?? 0) * 7 + (Days ?? 0), 0, 0, 0);
-
-    /// <summary>
     /// Convert the instance to a <see cref="TimeSpan"/>, ignoring potential
     /// DST changes.
     /// </summary>
@@ -209,16 +190,6 @@ public struct Duration
     /// </remarks>
     public TimeSpan ToTimeSpanUnspecified()
         => new TimeSpan((Weeks ?? 0) * 7 + (Days ?? 0), Hours ?? 0, Minutes ?? 0, Seconds ?? 0);
-
-    /// <summary>
-    /// Gets a value indicating whether the duration is zero, that is, all fields are null or 0.
-    /// </summary>
-    internal bool IsZero
-        => ((Weeks ?? 0) == 0)
-            && ((Days ?? 0) == 0)
-            && ((Hours ?? 0) == 0)
-            && ((Minutes ?? 0) == 0)
-            && ((Seconds ?? 0) == 0);
 
     /// <summary>
     /// Gets a value indicating whether the duration is empty, that is, all fields are null.

--- a/Ical.Net/DataTypes/Duration.cs
+++ b/Ical.Net/DataTypes/Duration.cs
@@ -45,7 +45,10 @@ public struct Duration
         Seconds = seconds;
     }
 
-    public NodaTime.Period ToPeriod()
+    public static Duration FromPeriod(NodaTime.Period p)
+        => new(p.Weeks, p.Days, (int) p.Hours, (int) p.Minutes, (int) p.Seconds);
+
+    public readonly NodaTime.Period ToPeriod()
     {
         var b = new NodaTime.PeriodBuilder
         {
@@ -59,7 +62,7 @@ public struct Duration
         return b.Build();
     }
 
-    public NodaTime.Period GetNominalPart()
+    public readonly NodaTime.Period GetNominalPart()
     {
         var b = new NodaTime.PeriodBuilder
         {
@@ -70,7 +73,7 @@ public struct Duration
         return b.Build();
     }
 
-    public NodaTime.Duration GetTimePart()
+    public readonly NodaTime.Duration GetTimePart()
     {
         var b = new NodaTime.PeriodBuilder
         {

--- a/Ical.Net/NodaTimeExtensions.cs
+++ b/Ical.Net/NodaTimeExtensions.cs
@@ -4,13 +4,18 @@
 //
 
 using System;
+using Ical.Net.DataTypes;
 using NodaTime;
 using NodaTime.TimeZones;
 
 namespace Ical.Net;
 
-internal static class NodaTimeExtensions
+public static class NodaTimeExtensions
 {
+    public static CalDateTime ToCalDateTime(this ZonedDateTime value) => new(value);
+
+    public static CalDateTime ToCalDateTime(this LocalDateTime value, string? timeZone = null) => new(value, timeZone);
+
     /// <summary>
     /// Returns a ZonedDateTime that matches the time zone and
     /// offset of the start value, or shifts forward if the local

--- a/Ical.Net/NodaTimeExtensions.cs
+++ b/Ical.Net/NodaTimeExtensions.cs
@@ -16,6 +16,10 @@ public static class NodaTimeExtensions
 
     public static CalDateTime ToCalDateTime(this LocalDateTime value, string? timeZone = null) => new(value, timeZone);
 
+    public static CalDateTime ToCalDateTime(this LocalDate value, string? timeZone = null) => new(value, timeZone);
+
+    public static CalDateTime ToCalDateTime(this Instant value) => new(value);
+
     /// <summary>
     /// Returns a ZonedDateTime that matches the time zone and
     /// offset of the start value, or shifts forward if the local

--- a/Ical.Net/Utility/DateUtil.cs
+++ b/Ical.Net/Utility/DateUtil.cs
@@ -4,7 +4,6 @@
 //
 
 using System;
-using Ical.Net.DataTypes;
 using NodaTime;
 
 namespace Ical.Net.Utility;
@@ -28,13 +27,4 @@ internal static class DateUtil
             : 1;
         return (int) Math.Floor(d.Day / 7.0) + offset;
     }
-
-    /// <summary>
-    /// Creates an instance that represents the given time span as exact value, that is, time-only.
-    /// </summary>
-    /// <remarks>
-    /// According to RFC5545 the weeks and day fields of a duration are considered nominal durations while the time fields are considered exact values.
-    /// </remarks>
-    internal static DataTypes.Duration ToDurationExact(this TimeSpan timeSpan)
-        => DataTypes.Duration.FromTimeSpanExact(timeSpan);
 }


### PR DESCRIPTION
From discussion in #849 and #854, one way to resolve math issues is to leave math to `NodaTime` (or `System.DateTime`). This removes all `Add*()` methods from `CalDateTime` and replaces usage by converting to `NodaTime` and back.

Doing this adds more support towards having `NodaTime` in the public API. Making it easy to convert to and from `NodaTime` types is important.

While this change does make sense, it does complicate things significantly for users who use `Add*()`. For those unfamiliar with `NodaTime`, they would have to learn `NodaTime` while also understanding that `CalDateTime` can hold date, datetime, or datetime with time zone without offset. `CalDateTime` will need to be converted to the correct `NodaTime` type based on the data it holds and what date/time units are being added. This will need to be well documented.

Fixes #849