### PR TITLE
Update encoding and line endings for consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,10 @@
 # Remove the line below if you want to inherit .editorconfig settings from higher directories
 root = true
 
+[*]
+# editors create UTF-8 only
+charset = utf-8
+
 [*.{cs,xml,csproj,sln}]
 
 #Core editorconfig formatting - indentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,7 +9,7 @@
 *.msg text
 *.txt text
 *.yml text
-*.cs text diff=csharp
+*.cs text=auto eol=lf diff=csharp
 *.md text diff=markdown
 *.editorconfig text
 *.json text


### PR DESCRIPTION
`.editorconfig` now enforces UTF-8 encoding for all files. 
`.gitattributes` sets LF line endings and auto text normalization for C# files