### PR TITLE
Chore: Fix unit tests with LF line ending of raw strings

### DIFF
--- a/Ical.Net.Tests/Logging/ToLogExtensions.cs
+++ b/Ical.Net.Tests/Logging/ToLogExtensions.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
@@ -37,14 +37,14 @@ internal static class ToLogExtensions
             return "No occurrences found.";
         }
 
-        sb.Append(occurrenceList.Count).AppendLine(" occurrences:");
+        sb.Append(occurrenceList.Count).Append(" occurrences:\n");
 
         foreach (var occurrence in occurrenceList)
         {
-            sb.AppendLine(occurrence.ToLog());
+            sb.Append(occurrence.ToLog()).Append('\n');
         }
 
-        return sb.ToString().TrimEnd(Environment.NewLine.ToCharArray());
+        return sb.ToString().TrimEnd('\r', '\n');
     }
 
     public static string ToLog(this Occurrence occurrence)

--- a/Ical.Net.Tests/WikiSamples/RecurrenceWikiTests.cs
+++ b/Ical.Net.Tests/WikiSamples/RecurrenceWikiTests.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
@@ -638,7 +638,7 @@ internal class RecurrenceWikiTests
             .Where(e => !e.StartsWith("DTSTAMP"))
             .Where(e => !(e.StartsWith("UID") && keep?.Contains("UID") != true))
             .Where(e => !(e.StartsWith("SEQUENCE") && keep?.Contains("SEQUENCE") != true))
-            .Aggregate(new StringBuilder(), (acc, e) => acc.AppendLine(e), e => e.ToString().TrimEnd());
+            .Aggregate(new StringBuilder(), (acc, e) => acc.Append(e).Append('\n'), e => e.ToString().TrimEnd());
 
     private static string ToWikiPeriodString(IEnumerable<Occurrence> occurrences)
         => occurrences.ToLog();


### PR DESCRIPTION
The fix was merged in `main` after creating `version/6.0`