### PR TITLE
feat(alarms)!: Introduce streaming for alarm occurrences

### DIFF
--- a/Ical.Net.Tests/AlarmTests.cs
+++ b/Ical.Net.Tests/AlarmTests.cs
@@ -311,6 +311,37 @@ public class AlarmTests
     }
 
     [Test]
+    public void RecurringAlarm_RelatedEnd_Indefinite()
+    {
+        CalendarEvent e = new()
+        {
+            Start = new CalDateTime(2026, 4, 7, 9, 0, 0, CalDateTime.UtcTzId),
+            Duration = new Duration(hours: 1),
+            RecurrenceRule = new RecurrenceRule(FrequencyType.Daily)
+        };
+
+        e.Alarms.Add(new Alarm
+        {
+            Trigger = new Trigger(new Duration(minutes: -30))
+            {
+                Related = TriggerRelation.End
+            }
+        });
+
+        var results = e.GetAlarmOccurrences(DateTimeZone.Utc)
+            .Select(x => x.Start.ToInstant())
+            .Take(3)
+            .ToList();
+
+        Assert.That(results, Is.EqualTo(new[]
+        {
+            Instant.FromUtc(2026, 4,  7, 9, 30, 0),
+            Instant.FromUtc(2026, 4, 14, 9, 30, 0),
+            Instant.FromUtc(2026, 4, 21, 9, 30, 0),
+        }));
+    }
+
+    [Test]
     public void AlarmWithRepeatButNoDuration_ShouldNotProduceDuplicates()
     {
         // RFC 5545 §3.8.6.2: REPEAT and DURATION must appear together.

--- a/Ical.Net.Tests/AlarmTests.cs
+++ b/Ical.Net.Tests/AlarmTests.cs
@@ -1,0 +1,421 @@
+//
+// Copyright ical.net project maintainers and contributors.
+// Licensed under the MIT license.
+//
+
+using System.IO;
+using System.Linq;
+using Ical.Net.CalendarComponents;
+using Ical.Net.DataTypes;
+using Ical.Net.Serialization;
+using NodaTime;
+using NUnit.Framework;
+using Duration = Ical.Net.DataTypes.Duration;
+using Period = Ical.Net.DataTypes.Period;
+
+namespace Ical.Net.Tests;
+
+[TestFixture]
+public class AlarmTests
+{
+    #region Examples from RFC 5545
+
+    [Test]
+    public void ExactTimeAlarmWithRepeat()
+    {
+        CalendarEvent e = new()
+        {
+            Start = new CalDateTime(1997, 3, 18)
+        };
+
+        var valarm = """
+            BEGIN:VALARM
+            TRIGGER;VALUE=DATE-TIME:19970317T133000Z
+            REPEAT:4
+            DURATION:PT15M
+            ACTION:AUDIO
+            ATTACH;FMTTYPE=audio/basic:ftp://example.com/pub/
+                sounds/bell-01.aud
+            END:VALARM
+            """;
+
+        var alarm = SimpleDeserializer.Default
+            .Deserialize(new StringReader(valarm))
+            .Cast<Alarm>()
+            .Single();
+
+        e.Alarms.Add(alarm);
+
+        var results = e.GetAlarmOccurrences(DateTimeZone.Utc)
+            .Select(x => x.Start.ToInstant())
+            .ToList();
+
+        Assert.That(results, Is.EqualTo(new[]
+        {
+            Instant.FromUtc(1997, 3, 17, 13, 30, 0),
+            Instant.FromUtc(1997, 3, 17, 13, 45, 0),
+            Instant.FromUtc(1997, 3, 17, 14,  0, 0),
+            Instant.FromUtc(1997, 3, 17, 14, 15, 0),
+            Instant.FromUtc(1997, 3, 17, 14, 30, 0),
+        }));
+    }
+
+    [Test]
+    public void RelativeAlarmBeforeStart()
+    {
+        CalendarEvent e = new()
+        {
+            Start = new CalDateTime(1997, 3, 17, 13, 30, 0, CalDateTime.UtcTzId),
+            Duration = new Duration(hours: 1)
+        };
+
+        var valarm = """
+            BEGIN:VALARM
+            TRIGGER:-PT30M
+            REPEAT:2
+            DURATION:PT15M
+            ACTION:AUDIO
+            ATTACH;FMTTYPE=audio/basic:ftp://example.com/pub/
+                sounds/bell-01.aud
+            END:VALARM
+            """;
+
+        var alarm = SimpleDeserializer.Default
+            .Deserialize(new StringReader(valarm))
+            .Cast<Alarm>()
+            .Single();
+
+        e.Alarms.Add(alarm);
+
+        var results = e.GetAlarmOccurrences(DateTimeZone.Utc)
+            .Select(x => x.Start.ToInstant())
+            .ToList();
+
+        Assert.That(results, Is.EqualTo(new[]
+        {
+            Instant.FromUtc(1997, 3, 17, 13,  0, 0),
+            Instant.FromUtc(1997, 3, 17, 13, 15, 0),
+            Instant.FromUtc(1997, 3, 17, 13, 30, 0),
+        }));
+    }
+
+    [Test]
+    public void RelativeAlarmAfterEnd()
+    {
+        CalendarEvent e = new()
+        {
+            Start    = new CalDateTime(1997, 3, 17, 13, 30, 0, CalDateTime.UtcTzId),
+            Duration = new Duration(hours: 1)
+        };
+
+        var valarm = """
+            BEGIN:VALARM
+            TRIGGER;RELATED=END:PT5M
+            REPEAT:2
+            DURATION:PT5M
+            ACTION:AUDIO
+            ATTACH;FMTTYPE=audio/basic:ftp://example.com/pub/
+                sounds/bell-01.aud
+            END:VALARM
+            """;
+
+        var alarm = SimpleDeserializer.Default
+            .Deserialize(new StringReader(valarm))
+            .Cast<Alarm>()
+            .Single();
+
+        e.Alarms.Add(alarm);
+
+        var results = e.GetAlarmOccurrences(DateTimeZone.Utc)
+            .Select(x => x.Start.ToInstant())
+            .ToList();
+
+        Assert.That(results, Is.EqualTo(new[]
+        {
+            Instant.FromUtc(1997, 3, 17, 14, 35, 0),
+            Instant.FromUtc(1997, 3, 17, 14, 40, 0),
+            Instant.FromUtc(1997, 3, 17, 14, 45, 0),
+        }));
+    }
+
+    [Test]
+    public void EmailAlarmBeforeEnd()
+    {
+        var valarm = """
+            BEGIN:VALARM
+            TRIGGER;RELATED=END:-P2D
+            ACTION:EMAIL
+            END:VALARM
+            """;
+
+        var alarm = SimpleDeserializer.Default
+            .Deserialize(new StringReader(valarm))
+            .Cast<Alarm>()
+            .Single();
+
+        CalendarEvent e = new()
+        {
+            Start    = new CalDateTime(1998, 1,  1, 0, 0, 0, CalDateTime.UtcTzId),
+            Duration = new Duration(days: 5)
+        };
+        e.Alarms.Add(alarm);
+
+        var results = e.GetAlarmOccurrences(DateTimeZone.Utc)
+            .Select(x => x.Start.ToInstant())
+            .ToList();
+
+        // end = Jan 6, trigger = end - 2 days = Jan 4
+        Assert.That(results, Is.EqualTo(new[]
+        {
+            Instant.FromUtc(1998, 1, 4, 0, 0, 0)
+        }));
+    }
+
+    #endregion
+
+    #region Recurring component alarms
+
+    [Test]
+    public void RecurringAlarm_RelativeStart_ReturnsAlarmsForEachOccurrence()
+    {
+        CalendarEvent e = new()
+        {
+            Start = new CalDateTime(2026, 4, 7, 9, 0, 0, CalDateTime.UtcTzId),
+            RecurrenceRule = new RecurrenceRule(FrequencyType.Weekly, 1) { Count = 4 }
+        };
+
+        e.Alarms.Add(new Alarm
+        {
+            Trigger = new Trigger(new Duration(minutes: -15))
+        });
+
+        var results = e.GetAlarmOccurrences(DateTimeZone.Utc)
+            .Select(x => x.Start.ToInstant())
+            .ToList();
+
+        Assert.That(results, Is.EqualTo(new[]
+        {
+            Instant.FromUtc(2026, 4,  7, 8, 45, 0),
+            Instant.FromUtc(2026, 4, 14, 8, 45, 0),
+            Instant.FromUtc(2026, 4, 21, 8, 45, 0),
+            Instant.FromUtc(2026, 4, 28, 8, 45, 0),
+        }));
+    }
+
+    [Test]
+    public void RecurringAlarm_WithRepeatDuration_ProducesRepetitions()
+    {
+        CalendarEvent e = new()
+        {
+            Start = new CalDateTime(2026, 4, 7, 9, 0, 0, CalDateTime.UtcTzId),
+            RecurrenceRule = new RecurrenceRule(FrequencyType.Weekly, 1) { Count = 2 }
+        };
+
+        e.Alarms.Add(new Alarm
+        {
+            Trigger  = new Trigger(new Duration(minutes: -15)),
+            Repeat   = 1,
+            Duration = new Duration(minutes: 5)
+        });
+
+        var results = e.GetAlarmOccurrences(DateTimeZone.Utc)
+            .Select(x => x.Start.ToInstant())
+            .ToList();
+
+        Assert.That(results, Is.EqualTo(new[]
+        {
+            Instant.FromUtc(2026, 4,  7, 8, 45, 0),
+            Instant.FromUtc(2026, 4,  7, 8, 50, 0),
+            Instant.FromUtc(2026, 4, 14, 8, 45, 0),
+            Instant.FromUtc(2026, 4, 14, 8, 50, 0),
+        }));
+    }
+
+    [Test]
+    public void RecurringAlarm_MultipleAlarms_ReturnsMergedOrdered()
+    {
+        CalendarEvent e = new()
+        {
+            Start = new CalDateTime(2026, 4, 7, 9, 0, 0, CalDateTime.UtcTzId),
+            RecurrenceRule = new RecurrenceRule(FrequencyType.Weekly, 1) { Count = 2 }
+        };
+
+        e.Alarms.Add(new Alarm { Trigger = new Trigger(new Duration(minutes: -30)) });
+        e.Alarms.Add(new Alarm { Trigger = new Trigger(new Duration(minutes: -10)) });
+
+        var results = e.GetAlarmOccurrences(DateTimeZone.Utc)
+            .Select(x => x.Start.ToInstant())
+            .ToList();
+
+        Assert.That(results, Is.EqualTo(new[]
+        {
+            Instant.FromUtc(2026, 4,  7, 8, 30, 0),
+            Instant.FromUtc(2026, 4,  7, 8, 50, 0),
+            Instant.FromUtc(2026, 4, 14, 8, 30, 0),
+            Instant.FromUtc(2026, 4, 14, 8, 50, 0),
+        }));
+    }
+
+    [Test]
+    public void GetAlarmOccurrences_EndTime_BoundsResults()
+    {
+        CalendarEvent e = new()
+        {
+            Start = new CalDateTime(2026, 4, 7, 9, 0, 0, CalDateTime.UtcTzId),
+            RecurrenceRule = new RecurrenceRule(FrequencyType.Weekly, 1)
+        };
+
+        e.Alarms.Add(new Alarm { Trigger = new Trigger(new Duration(minutes: -15)) });
+
+        var results = e.GetAlarmOccurrences(DateTimeZone.Utc,
+                endTime: Instant.FromUtc(2026, 4, 22, 0, 0, 0))
+            .Select(x => x.Start.ToInstant())
+            .ToList();
+
+        Assert.That(results, Is.EqualTo(new[]
+        {
+            Instant.FromUtc(2026, 4,  7, 8, 45, 0),
+            Instant.FromUtc(2026, 4, 14, 8, 45, 0),
+            Instant.FromUtc(2026, 4, 21, 8, 45, 0),
+        }));
+    }
+
+    [Test]
+    public void RecurringAlarm_RelatedEnd_ReturnsAlarmsRelativeToOccurrenceEnd()
+    {
+        CalendarEvent e = new()
+        {
+            Start    = new CalDateTime(2026, 4, 7, 9, 0, 0, CalDateTime.UtcTzId),
+            Duration = new Duration(hours: 1),
+            RecurrenceRule = new RecurrenceRule(FrequencyType.Weekly, 1) { Count = 3 }
+        };
+
+        e.Alarms.Add(new Alarm
+        {
+            Trigger = new Trigger(new Duration(minutes: -30))
+            {
+                Related = TriggerRelation.End
+            }
+        });
+
+        var results = e.GetAlarmOccurrences(DateTimeZone.Utc)
+            .Select(x => x.Start.ToInstant())
+            .ToList();
+
+        Assert.That(results, Is.EqualTo(new[]
+        {
+            Instant.FromUtc(2026, 4,  7, 9, 30, 0),
+            Instant.FromUtc(2026, 4, 14, 9, 30, 0),
+            Instant.FromUtc(2026, 4, 21, 9, 30, 0),
+        }));
+    }
+
+    [Test]
+    public void AlarmWithRepeatButNoDuration_ShouldNotProduceDuplicates()
+    {
+        // RFC 5545 §3.8.6.2: REPEAT and DURATION must appear together.
+        // When Duration is absent, GetFireTimes yields only the base fire time.
+        CalendarEvent e = new()
+        {
+            Start = new CalDateTime(2026, 4, 7, 9, 0, 0, CalDateTime.UtcTzId)
+        };
+
+        e.Alarms.Add(new Alarm
+        {
+            Trigger = new Trigger(new Duration(minutes: -15)),
+            Repeat  = 3
+            // Duration intentionally omitted
+        });
+
+        var results = e.GetAlarmOccurrences(DateTimeZone.Utc)
+            .Select(x => x.Start.ToInstant())
+            .ToList();
+
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.That(results[0], Is.EqualTo(Instant.FromUtc(2026, 4, 7, 8, 45, 0)));
+    }
+
+    [Test]
+    public void ComponentWithNoAlarms_GetAlarmOccurrences_IsEmpty()
+    {
+        CalendarEvent e = new()
+        {
+            Start = new CalDateTime(2026, 4, 7, 9, 0, 0, CalDateTime.UtcTzId)
+        };
+
+        var results = e.GetAlarmOccurrences(DateTimeZone.Utc).ToList();
+
+        Assert.That(results, Is.Empty);
+    }
+
+    [Test]
+    public void GetAlarmOccurrences_StartTime_FiltersAlarmFireTimes()
+    {
+        // startTime is a lower bound on alarm FIRE TIMES, not component start times.
+        CalendarEvent e = new()
+        {
+            Start = new CalDateTime(2026, 4, 7, 9, 0, 0, CalDateTime.UtcTzId)
+        };
+
+        e.Alarms.Add(new Alarm
+        {
+            Trigger = new Trigger(new Duration(days: -1)) // fires Apr 6 for Apr 7 occurrence
+        });
+
+        var results = e.GetAlarmOccurrences(DateTimeZone.Utc,
+                startTime: Instant.FromUtc(2026, 4, 7, 9, 0, 0),  // Apr 7 09:00 – after alarm fire time
+                endTime:   Instant.FromUtc(2026, 4, 8, 9, 0, 0))
+            .Select(x => x.Start.ToInstant())
+            .ToList();
+
+        Assert.That(results, Is.Empty);
+    }
+
+    [Test]
+    public void RDatePeriods_TriggerRelatedEnd_AlarmsOrderedByEndNotStart()
+    {
+        // Three occurrences (DTSTART + 2 RDATEs). Ordered by start: DTSTART, A, B.
+        // RDATE A has a longer duration than RDATE B, so A ends after B despite starting before it.
+        // With TRIGGER;RELATED=END:-PT2H the alarm order follows end times, not start times.
+        CalendarEvent e = new()
+        {
+            Start    = new CalDateTime(2026, 4, 1, 9, 0, 0, CalDateTime.UtcTzId),
+            Duration = new Duration(hours: 1)   // DTSTART ends Apr 1 10:00
+        };
+
+        // RDATE A: starts Apr 2, ends Apr 10 (8 days)
+        e.RecurrenceDates.Add(new Period(
+            new CalDateTime(2026, 4, 2, 9, 0, 0, CalDateTime.UtcTzId),
+            new CalDateTime(2026, 4, 10, 9, 0, 0, CalDateTime.UtcTzId)));
+
+        // RDATE B: starts Apr 5, ends Apr 7 (2 days) — starts after A but ends before A
+        e.RecurrenceDates.Add(new Period(
+            new CalDateTime(2026, 4, 5, 9, 0, 0, CalDateTime.UtcTzId),
+            new CalDateTime(2026, 4, 7, 9, 0, 0, CalDateTime.UtcTzId)));
+
+        e.Alarms.Add(new Alarm
+        {
+            Trigger = new Trigger(new Duration(hours: -2))
+            {
+                Related = TriggerRelation.End
+            }
+        });
+
+        var results = e.GetAlarmOccurrences(DateTimeZone.Utc)
+            .Select(x => x.Start.ToInstant())
+            .ToList();
+
+        // Alarm fires 2 hours before each occurrence END:
+        //   DTSTART => end Apr 1  10:00 → alarm Apr 1  08:00
+        //   RDATE B => end Apr 7  09:00 → alarm Apr 7  07:00  (starts later than A, fires earlier)
+        //   RDATE A => end Apr 10 09:00 → alarm Apr 10 07:00  (starts earlier than B, fires later)
+        Assert.That(results, Is.EqualTo(new[]
+        {
+            Instant.FromUtc(2026, 4,  1, 8, 0, 0),
+            Instant.FromUtc(2026, 4,  7, 7, 0, 0),
+            Instant.FromUtc(2026, 4, 10, 7, 0, 0),
+        }));
+    }
+
+    #endregion
+}

--- a/Ical.Net.Tests/CollectionHelpersTests.cs
+++ b/Ical.Net.Tests/CollectionHelpersTests.cs
@@ -175,4 +175,71 @@ internal class CollectionHelpersTests
 
         Assert.That(result, Is.EqualTo(expected));
     }
+
+    [Test]
+    public void TestOrderedNestedMergeMany_PrefersVerticalOverHorizontalEnumeration()
+    {
+        IEnumerable<int> Seq1()
+        {
+            yield return 0;
+            while (true) yield return 1;
+        }
+
+        IEnumerable<int> Seq2()
+        {
+            // This will be returned in the final sequence, as it is less than the indefinite sequence of 1s.
+            yield return 0;
+
+            // This value will be returned by this sequence but not to the final sequence, as
+            // iteration of should go into the depth first, so returning all the (indefinite) 1s from
+            // the first sequence first before continuing there.
+            // It is relevant that the iteration first happens into the depth and only then into the breadth,
+            // because otherwise the operator would have to maintain more IEnumerators than needed,
+            // which would increase memory pressure.
+            yield return 1;
+            Assert.Fail();
+        }
+
+        IEnumerable<int> Seq3()
+        {
+            // This item will be queried but the sequence will not be considered active as long as the first
+            // value is not returned in the final sequence, which will never happen.
+            yield return 1;
+            Assert.Fail();
+        }
+
+        IEnumerable<int> Seq4()
+        {
+            // The final sequence shouldn't be queried at all, because no values are
+            // being returned from the previous.
+            Assert.Fail();
+            yield break;
+        }
+
+        var result =
+            new[] { Seq1(), Seq2(), Seq3(), Seq4() }
+            .OrderedNestedMergeMany()
+            .Take(10)
+            .ToList();
+
+        Assert.That(result, Is.EqualTo(new[] { 0, 0, 1, 1, 1, 1, 1, 1, 1, 1 }));
+    }
+
+    [Test]
+    public void TestOrderedNestedMergeMany_SubsequenceOnlyEnumeratedWhenNeeded()
+    {
+        IEnumerable<int> FailingSeq()
+        {
+            Assert.Fail();
+            yield break;
+        }
+
+        var result =
+            new[] { [1], FailingSeq() }
+            .OrderedNestedMergeMany()
+            .Take(1)
+            .ToList();
+
+        Assert.That(result, Is.EqualTo(new[] { 1 }));
+    }
 }

--- a/Ical.Net.Tests/CollectionHelpersTests.cs
+++ b/Ical.Net.Tests/CollectionHelpersTests.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
@@ -93,5 +93,86 @@ internal class CollectionHelpersTests
     {
         var result = new[] { 1, 2, 2, 3 }.OrderedDistinct();
         Assert.That(result, Is.EqualTo(new[] { 1, 2, 3 }));
+    }
+
+    [Test]
+    public void TestOrderedNestedMergeMany()
+    {
+        var result = new[]
+        {
+            new[] { 1, 4, 7 },
+            new[] { 2, 5, 8 },
+            new[] { 3, 6, 9 },
+        }.OrderedNestedMergeMany(Comparer<int>.Default);
+
+        Assert.That(result, Is.EqualTo(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 }));
+    }
+
+    [Test]
+    public void TestOrderedNestedMergeMany_AllowsDuplicates()
+    {
+        var result = new[]
+        {
+            new[] { 1, 2, 2, 4 },
+            new[] { 1, 2, 3, 4 },
+        }.OrderedNestedMergeMany(Comparer<int>.Default);
+
+        Assert.That(result, Is.EqualTo(new[] { 1, 1, 2, 2, 2, 3, 4, 4 }));
+    }
+
+    [Test]
+    public void TestOrderedNestedMergeMany_HandlesEmptyInnerSequences()
+    {
+        IEnumerable<IEnumerable<int>> withEmpty =
+        [
+            [],
+            [1, 3],
+            [2],
+        ];
+
+        var result = withEmpty
+            .OrderedNestedMergeMany(Comparer<int>.Default)
+            .ToList();
+
+        Assert.That(result, Is.EqualTo(new[] { 1, 2, 3 }));
+    }
+
+    [Test]
+    [TestCase(false, false)]
+    [TestCase(true, false)]
+    [TestCase(false, true)]
+    [TestCase(true, true)]
+    public void TestOrderedNestedMergeMany_StreamsOuterSequence(bool increasingOuter, bool increasingInner)
+    {
+        IEnumerable<int> GetIndefiniteSequence(int start)
+        {
+            var i = start;
+            while (true)
+            {
+                yield return i;
+                i += increasingInner ? 1 : 0;
+            }
+        }
+
+        IEnumerable<IEnumerable<int>> GetOrderedInnerSequences()
+        {
+            var i = 0;
+            while (true)
+            {
+                yield return GetIndefiniteSequence(i);
+                i += increasingOuter ? 1 : 0;
+            }
+        }
+
+        var result = GetOrderedInnerSequences()
+            .OrderedNestedMergeMany(Comparer<int>.Default)
+            .Take(10)
+            .ToList();
+
+        var expected = increasingOuter && increasingInner
+            ? new[] { 0, 1, 1, 2, 2, 2, 3, 3, 3, 3 }
+            : new[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+
+        Assert.That(result, Is.EqualTo(expected));
     }
 }

--- a/Ical.Net.Tests/TestExtensions.cs
+++ b/Ical.Net.Tests/TestExtensions.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //

--- a/Ical.Net/CalendarComponents/Alarm.cs
+++ b/Ical.Net/CalendarComponents/Alarm.cs
@@ -1,18 +1,16 @@
-﻿//
+//
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
 
 using System.Collections.Generic;
 using Ical.Net.DataTypes;
-using Ical.Net.Evaluation;
 using NodaTime;
 
 namespace Ical.Net.CalendarComponents;
 
 /// <summary>
 /// A class that represents an RFC 2445 VALARM component.
-/// FIXME: move GetOccurrences() logic into an AlarmEvaluator.
 /// </summary>
 public class Alarm : CalendarComponent
 {
@@ -70,114 +68,19 @@ public class Alarm : CalendarComponent
     }
 
     /// <summary>
-    /// Gets a list of alarm occurrences for the given recurring component, <paramref name="rc"/>
-    /// that occur at or after <paramref name="fromDate"/>.
+    /// Yields the base fire time followed by any additional fire times produced by
+    /// <c>REPEAT</c> and <c>DURATION</c>.
     /// </summary>
-    public virtual IList<AlarmOccurrence> GetOccurrences(IRecurringComponent rc, DateTimeZone timeZone, Instant? fromDate, EvaluationOptions? options)
+    internal IEnumerable<ZonedDateTime> GetFireTimes(ZonedDateTime baseFireTime)
     {
-        if (Trigger == null)
+        yield return baseFireTime;
+        if (Repeat <= 0 || !Properties.ContainsKey("DURATION")) yield break;
+        var period = Duration!.Value.ToPeriod();
+        var t = baseFireTime;
+        for (var i = 0; i < Repeat; i++)
         {
-            return [];
-        }
-
-        var occurrences = new List<AlarmOccurrence>();
-
-        // If the trigger is relative, it can recur right along with
-        // the recurring items, otherwise, it happens once and
-        // only once (at a precise time).
-        if (Trigger.IsRelative)
-        {
-            // Ensure that "FromDate" has already been set
-            if (fromDate == null)
-            {
-                fromDate = rc.Start?.ToZonedDateTime(timeZone).ToInstant();
-            }
-
-            var triggerDuration = Trigger.Duration!.Value.ToPeriod();
-
-            foreach (var o in rc.GetOccurrences(timeZone, fromDate, options))
-            {
-                var dt = o.Start;
-                if (string.Equals(Trigger.Related, TriggerRelation.End, TriggerRelation.Comparison))
-                {
-                    dt = o.End;
-                }
-
-                var triggerStart = dt.LocalDateTime
-                    .Plus(triggerDuration)
-                    .InZoneLeniently(dt.Zone);
-
-                occurrences.Add(new AlarmOccurrence(this, triggerStart, rc));
-            }
-        }
-        else
-        {
-            var dt = Trigger?.DateTime?.ToZonedDateTime();
-            if (dt != null)
-            {
-                occurrences.Add(new AlarmOccurrence(this, dt.Value, rc));
-            }
-        }
-
-        // If a REPEAT and DURATION value were specified,
-        // then handle those repetitions here.
-        AddRepeatedItems(occurrences);
-
-        return occurrences;
-    }
-
-    /// <summary>
-    /// Polls the <see cref="Alarm"/> component for alarms that have been triggered
-    /// since the provided <paramref name="start"/> date/time.  If <paramref name="start"/>
-    /// is null, all triggered alarms will be returned.
-    /// </summary>
-    /// <param name="start">The earliest date/time to poll triggered alarms for.</param>
-    /// <param name="options"></param>
-    /// <returns>A list of <see cref="AlarmOccurrence"/> objects, each containing a triggered alarm.</returns>
-    public virtual IList<AlarmOccurrence> Poll(DateTimeZone timeZone, Instant? start, EvaluationOptions? options = null)
-    {
-        var results = new List<AlarmOccurrence>();
-
-        // Evaluate the alarms to determine the recurrences
-        if (Parent is not RecurringComponent rc)
-        {
-            return results;
-        }
-
-        results.AddRange(GetOccurrences(rc, timeZone, start, options));
-        return results;
-    }
-
-    /// <summary>
-    /// Handles the repetitions that occur from the <c>REPEAT</c> and
-    /// <c>DURATION</c> properties.  Each recurrence of the alarm will
-    /// have its own set of generated repetitions.
-    /// </summary>
-    private void AddRepeatedItems(List<AlarmOccurrence> occurrences)
-    {
-        var len = occurrences.Count;
-        for (var i = 0; i < len; i++)
-        {
-            var ao = occurrences[i];
-            if (ao.Component == null)
-            {
-                continue;
-            }
-
-            var alarmTime = ao.Start;
-            var duration = Duration?.ToPeriod();
-
-            for (var j = 0; j < Repeat; j++)
-            {
-                if (duration != null)
-                {
-                    alarmTime = alarmTime.LocalDateTime
-                        .Plus(duration)
-                        .InZoneLeniently(alarmTime.Zone);
-                }
-
-                occurrences.Add(new AlarmOccurrence(this, alarmTime, ao.Component));
-            }
+            t = t.LocalDateTime.Plus(period).InZoneLeniently(t.Zone);
+            yield return t;
         }
     }
 }

--- a/Ical.Net/CalendarComponents/IAlarmContainer.cs
+++ b/Ical.Net/CalendarComponents/IAlarmContainer.cs
@@ -1,10 +1,11 @@
-﻿//
+//
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
 
 using System.Collections.Generic;
 using Ical.Net.DataTypes;
+using Ical.Net.Evaluation;
 using NodaTime;
 
 namespace Ical.Net.CalendarComponents;
@@ -16,14 +17,14 @@ public interface IAlarmContainer
     /// </summary>
     ICalendarObjectList<Alarm> Alarms { get; }
 
-    ///  <summary>
-    ///  Polls <see cref="Alarm"/>s for occurrences within the <see cref="RecurringComponent.GetOccurrences"/>d
-    ///  time frame of this <see cref="RecurringComponent"/>.  For each evaluated
-    ///  occurrence if this component, each <see cref="Alarm"/> is polled for its
-    ///  corresponding alarm occurrences.
-    ///  </summary>
-    /// <param name="startTime">The earliest allowable alarm occurrence to poll, or <c>null</c>.</param>
-    /// <param name="endTime"></param>
-    /// <returns>A List of <see cref="AlarmOccurrence"/> objects, one for each occurrence of the <see cref="Alarm"/>.</returns>
-    IList<AlarmOccurrence> PollAlarms(DateTimeZone timeZone, Instant? startTime, Instant? endTime);
+    /// <summary>
+    /// Gets a streaming sequence of <see cref="AlarmOccurrence"/>s for all <see cref="Alarms"/>
+    /// on this component, with fire times in the range [<paramref name="startTime"/>, <paramref name="endTime"/>).
+    /// </summary>
+    /// <param name="timeZone">The time zone used to evaluate component occurrences.</param>
+    /// <param name="startTime">Lower bound (inclusive) on alarm fire times, or <c>null</c> for no lower bound.</param>
+    /// <param name="endTime">Upper bound (exclusive) on alarm fire times, or <c>null</c> for no upper bound.</param>
+    /// <param name="options">Evaluation options, or <c>null</c> for defaults.</param>
+    /// <returns>A streaming sequence of <see cref="AlarmOccurrence"/> objects.</returns>
+    IEnumerable<AlarmOccurrence> GetAlarmOccurrences(DateTimeZone timeZone, Instant? startTime = null, Instant? endTime = null, EvaluationOptions? options = null);
 }

--- a/Ical.Net/CalendarComponents/RecurringComponent.cs
+++ b/Ical.Net/CalendarComponents/RecurringComponent.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
@@ -10,6 +10,7 @@ using System.Runtime.Serialization;
 using Ical.Net.DataTypes;
 using Ical.Net.Evaluation;
 using Ical.Net.Proxies;
+using Ical.Net.Utility;
 using NodaTime;
 
 namespace Ical.Net.CalendarComponents;
@@ -209,8 +210,72 @@ public abstract class RecurringComponent : UniqueComponent, IRecurringComponent
         return RecurrenceUtil.GetOccurrences(this, timeZone, startTime, options);
     }
 
-    public virtual IList<AlarmOccurrence> PollAlarms(DateTimeZone timeZone) => PollAlarms(timeZone, null, null);
+    /// <summary>
+    /// Gets a streaming sequence of <see cref="AlarmOccurrence"/>s for all <see cref="Alarms"/>
+    /// on this component, with fire times in the range [<paramref name="startTime"/>, <paramref name="endTime"/>).
+    /// </summary>
+    /// <param name="timeZone">The time zone used to evaluate component occurrences.</param>
+    /// <param name="startTime">Lower bound (inclusive) on alarm fire times, or <c>null</c> for no lower bound.</param>
+    /// <param name="endTime">Upper bound (exclusive) on alarm fire times, or <c>null</c> for no upper bound.</param>
+    /// <remarks>
+    /// Component occurrences are evaluated once and shared across all alarms.
+    /// When <paramref name="endTime"/> is <c>null</c> and the component has an unbounded recurrence rule,
+    /// evaluation will continue indefinitely; callers must apply their own termination condition.
+    /// </remarks>
+    public virtual IEnumerable<AlarmOccurrence> GetAlarmOccurrences(DateTimeZone timeZone, Instant? startTime = null, Instant? endTime = null, EvaluationOptions? options = null)
+    {
+        if (!Alarms.Any()) return [];
 
-    public virtual IList<AlarmOccurrence> PollAlarms(DateTimeZone timeZone, Instant? startTime, Instant? endTime)
-        => Alarms.SelectMany(a => a.Poll(timeZone, startTime).TakeWhile(p => (endTime == null) || (p.Start.ToInstant() < endTime))).ToList();
+        var rawOccurrences = GetOccurrences(timeZone, startTime, options);
+        // materialize the component occurrences once and share the list across all alarms
+        var occurrences = endTime == null
+            ? rawOccurrences.ToList()
+            : rawOccurrences.TakeWhile(o => o.Start.ToInstant() <= endTime).ToList();
+
+        return Alarms
+            .Select(a => GetAlarmOccurrenceStream(a, occurrences))
+            .OrderedMergeMany()
+            .SkipWhile(ao => startTime != null && ao.Start.ToInstant() < startTime)
+            .TakeWhile(ao => endTime == null || ao.Start.ToInstant() < endTime);
+    }
+
+    private IEnumerable<AlarmOccurrence> GetAlarmOccurrenceStream(Alarm alarm, IList<Occurrence> occurrences)
+    {
+        if (alarm.Trigger == null) return [];
+
+        if (alarm.Trigger.IsRelative)
+        {
+            var period = alarm.Trigger.Duration!.Value.ToPeriod();
+
+            if (string.Equals(alarm.Trigger.Related, TriggerRelation.End, TriggerRelation.Comparison))
+            {
+                // Occurrences are ordered by start, but END-relative fire times may not follow the same
+                // order when occurrence durations differ (e.g. PERIOD RDATEs). Sort explicitly.
+                // This is safe because occurrences is always a materialized list.
+                return occurrences
+                    .SelectMany(o =>
+                    {
+                        var baseFireTime = o.End.LocalDateTime.Plus(period).InZoneLeniently(o.End.Zone);
+                        return alarm.GetFireTimes(baseFireTime)
+                            .Select(ft => new AlarmOccurrence(alarm, ft, this));
+                    })
+                    .OrderBy(ao => ao.Start.ToInstant());
+            }
+
+            return occurrences
+                .Select(o =>
+                {
+                    var baseFireTime = o.Start.LocalDateTime.Plus(period).InZoneLeniently(o.Start.Zone);
+                    return alarm.GetFireTimes(baseFireTime)
+                        .Select(ft => new AlarmOccurrence(alarm, ft, this));
+                })
+                .OrderedNestedMergeMany();
+        }
+
+        // else the trigger is absolute, so we ignore the component occurrences
+        var dt = alarm.Trigger.DateTime?.ToZonedDateTime();
+        if (dt == null) return [];
+        return alarm.GetFireTimes(dt.Value)
+            .Select(ft => new AlarmOccurrence(alarm, ft, this));
+    }
 }

--- a/Ical.Net/DataTypes/AlarmOccurrence.cs
+++ b/Ical.Net/DataTypes/AlarmOccurrence.cs
@@ -1,8 +1,9 @@
-﻿//
+//
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
 
+using System;
 using Ical.Net.CalendarComponents;
 using NodaTime;
 
@@ -16,7 +17,7 @@ namespace Ical.Net.DataTypes;
 /// the alarm occurs, the <see cref="Alarm"/> that fired, and the
 /// component on which the alarm fired.
 /// </remarks>
-public class AlarmOccurrence
+public class AlarmOccurrence : IComparable<AlarmOccurrence>
 {
     public ZonedDateTime Start { get; private set; }
 
@@ -36,5 +37,11 @@ public class AlarmOccurrence
         Alarm = a;
         Start = start;
         Component = rc;
+    }
+
+    public int CompareTo(AlarmOccurrence? other)
+    {
+        if (other is null) return 1;
+        return Start.ToInstant().CompareTo(other.Start.ToInstant());
     }
 }

--- a/Ical.Net/Utility/CollectionHelpers.cs
+++ b/Ical.Net/Utility/CollectionHelpers.cs
@@ -276,6 +276,26 @@ internal static class CollectionHelpers
         }
     }
 
+    /// <summary>
+    /// Merge the given ordered sequence of ordered sequences into a single ordered sequence.
+    /// </summary>
+    /// <remarks>
+    /// The inner as well as the outer sequences must be ordered according to the default comparer.
+    /// The outer sequence must be ordered by the first item of the inner sequences.
+    ///
+    /// The method operates in a streaming manner on both, the outer as well as the inner sequences,
+    /// meaning it only enumerates the input sequences while the output sequence is being enumerated.
+    /// Both, the outer as well as the inner sequences may therefore be unbounded.
+    ///
+    /// The behavior is similar to that of <see cref="OrderedMergeMany{T}(IEnumerable{IEnumerable{T}}, IComparer{T})"/>,
+    /// with following differences:
+    /// * Additionally to the inner sequences, also the outer sequences must be ordered. They must be ordered
+    ///   by the head of the inner sequence according to the default comparer.
+    /// * The outer sequence is enumerated in a streaming manner, only as far as the outer is enumerated.
+    /// </remarks>
+    public static IEnumerable<T> OrderedNestedMergeMany<T>(this IEnumerable<IEnumerable<T>> sequences)
+        => OrderedNestedMergeMany(sequences, Comparer<T>.Default);
+
     private readonly struct DictKey<T>(T value, long idx)
     {
         public readonly T Value = value;
@@ -290,29 +310,9 @@ internal static class CollectionHelpers
     /// Merge the given ordered sequence of ordered sequences into a single ordered sequence.
     /// </summary>
     /// <remarks>
-    /// The inner as well as the outer sequences must be ordered according to the type's default comparer.
-    /// The outer sequence must be ordered by the first item of the inner sequences.
-    ///
-    /// The method operates in a streaming manner on both, the outer as well as the inner sequences,
-    /// meaning it only enumerates the input sequences while the output sequence is being enumerated.
-    /// Both, the outer as well as the inner sequences may therefore be unbounded.
-    ///
-    /// The behavior is similar to that of <see cref="OrderedMergeMany{T}(IEnumerable{IEnumerable{T}}, IComparer{T})"/>,
-    /// with following differences:
-    /// * Additionally to the inner sequences, also the outer sequences must be ordered. They must be ordered
-    ///   by the head of the inner sequence according to the given comparer.
-    /// * The outer sequence is enumerated in a streaming manner, only as far as the outer is enumerated.
-    /// </remarks>
-    public static IEnumerable<T> OrderedNestedMergeMany<T>(this IEnumerable<IEnumerable<T>> sequences)
-        => OrderedNestedMergeMany(sequences, Comparer<T>.Default);
-
-    /// <summary>
-    /// Merge the given ordered sequence of ordered sequences into a single ordered sequence.
-    /// </summary>
-    /// <remarks>
     /// The inner as well as the outer sequences must be ordered according to the given comparer.
     /// The outer sequence must be ordered by the first item of the inner sequences.
-    ///
+    /// 
     /// The method operates in a streaming manner on both, the outer as well as the inner sequences,
     /// meaning it only enumerates the input sequences while the output sequence is being enumerated.
     /// Both, the outer as well as the inner sequences may therefore be unbounded.
@@ -325,51 +325,66 @@ internal static class CollectionHelpers
     /// </remarks>
     public static IEnumerable<T> OrderedNestedMergeMany<T>(this IEnumerable<IEnumerable<T>> sequences, IComparer<T> comparer)
     {
-        using var outer = sequences.GetEnumerator();
-        var keyComparer = Comparer<DictKey<T>>.Create((a, b) =>
-        {
-            var res = comparer.Compare(a.Value, b.Value);
-            if (res != 0) return res;
-            return a.Idx.CompareTo(b.Idx);
-        });
-
-        var active = new SortedDictionary<DictKey<T>, IEnumerator<T>>(keyComparer);
+        using var outer = GetNonEmptyEnumerators().GetEnumerator();
 
         var pending = NextNonEmpty();
         if (pending == null)
             yield break;
 
+        var active = new SortedDictionary<DictKey<T>, IEnumerator<T>>(Comparer<DictKey<T>>.Create((a, b) =>
+        {
+            var res = comparer.Compare(a.Value, b.Value);
+            if (res != 0) return res;
+
+            return a.Idx.CompareTo(b.Idx);
+        }));
+
         try
         {
-            long uniqueIdx = 0;
-            while ((active.Count > 0) || (pending != null))
+            while (true)
             {
                 KeyValuePair<DictKey<T>, IEnumerator<T>> first;
-                if (active.Count == 0)
+                using var activeIt = active.GetEnumerator();
+                if (!activeIt.MoveNext())
                 {
-                    first = new(new(pending!.Current, uniqueIdx++), pending);
-                    active.Add(first.Key, first.Value);
-                    pending = NextNonEmpty();
+                    pending ??= NextNonEmpty();
+                    if (pending == null)
+                        break;
+
+                    first = new(new(pending.Value.it.Current, pending.Value.idx), pending.Value.it);
+                    pending = null;
                 }
                 else
                 {
-                    first = active.First();
-
-                    if ((pending != null) && (comparer.Compare(pending.Current, first.Value.Current) < 0))
+                    first = activeIt.Current;
+                    pending ??= NextNonEmpty();
+                    if ((pending != null) && (comparer.Compare(pending.Value.it.Current, first.Value.Current) < 0))
                     {
-                        first = new(new(pending.Current, uniqueIdx++), pending);
-                        active.Add(first.Key, first.Value);
-                        pending = NextNonEmpty();
+                        first = new(new(pending.Value.it.Current, pending.Value.idx), pending.Value.it);
+                        pending = null;
+                    }
+                    else
+                    {
+                        if (!active.Remove(first.Key))
+                            throw new InvalidOperationException();
                     }
                 }
 
-                yield return first.Key.Value;
+                IDisposable? disposeFinally = first.Value;
+                try
+                {
+                    yield return first.Key.Value;
 
-                active.Remove(first.Key);
-                if (first.Value.MoveNext())
-                    active.Add(new(first.Value.Current, uniqueIdx++), first.Value);
-                else
-                    first.Value.Dispose();
+                    if (first.Value.MoveNext())
+                    {
+                        active.Add(new(first.Value.Current, first.Key.Idx), first.Value);
+                        disposeFinally = null;
+                    }
+                }
+                finally
+                {
+                    disposeFinally?.Dispose();
+                }
             }
         }
         finally
@@ -377,21 +392,22 @@ internal static class CollectionHelpers
             foreach (var enumerator in active.Values)
                 enumerator.Dispose();
 
-            pending?.Dispose();
+            pending?.it.Dispose();
         }
 
-        IEnumerator<T>? NextNonEmpty()
+        IEnumerable<(IEnumerator<T> it, long idx)> GetNonEmptyEnumerators()
         {
-            while (outer.MoveNext())
+            long idx = 0;
+            foreach (var sequence in sequences)
             {
-                var enumerator = outer.Current?.GetEnumerator();
+                var enumerator = sequence?.GetEnumerator();
                 if (enumerator?.MoveNext() == true)
-                    return enumerator;
-
-                enumerator?.Dispose();
+                    yield return (enumerator, idx++);
+                else
+                    enumerator?.Dispose();
             }
-
-            return null;
         }
+
+        (IEnumerator<T> it, long idx)? NextNonEmpty() => outer.MoveNext() ? outer.Current : null;
     }
 }

--- a/Ical.Net/Utility/CollectionHelpers.cs
+++ b/Ical.Net/Utility/CollectionHelpers.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
@@ -273,6 +273,125 @@ internal static class CollectionHelpers
             }
 
             yield return enumerator.Current;
+        }
+    }
+
+    private readonly struct DictKey<T>(T value, long idx)
+    {
+        public readonly T Value = value;
+
+        /// <summary>
+        /// The index is there, because the key of a SortedDictionary or SortedList must be unique.
+        /// </summary>
+        public readonly long Idx = idx;
+    }
+
+    /// <summary>
+    /// Merge the given ordered sequence of ordered sequences into a single ordered sequence.
+    /// </summary>
+    /// <remarks>
+    /// The inner as well as the outer sequences must be ordered according to the type's default comparer.
+    /// The outer sequence must be ordered by the first item of the inner sequences.
+    ///
+    /// The method operates in a streaming manner on both, the outer as well as the inner sequences,
+    /// meaning it only enumerates the input sequences while the output sequence is being enumerated.
+    /// Both, the outer as well as the inner sequences may therefore be unbounded.
+    ///
+    /// The behavior is similar to that of <see cref="OrderedMergeMany{T}(IEnumerable{IEnumerable{T}}, IComparer{T})"/>,
+    /// with following differences:
+    /// * Additionally to the inner sequences, also the outer sequences must be ordered. They must be ordered
+    ///   by the head of the inner sequence according to the given comparer.
+    /// * The outer sequence is enumerated in a streaming manner, only as far as the outer is enumerated.
+    /// </remarks>
+    public static IEnumerable<T> OrderedNestedMergeMany<T>(this IEnumerable<IEnumerable<T>> sequences)
+        => OrderedNestedMergeMany(sequences, Comparer<T>.Default);
+
+    /// <summary>
+    /// Merge the given ordered sequence of ordered sequences into a single ordered sequence.
+    /// </summary>
+    /// <remarks>
+    /// The inner as well as the outer sequences must be ordered according to the given comparer.
+    /// The outer sequence must be ordered by the first item of the inner sequences.
+    ///
+    /// The method operates in a streaming manner on both, the outer as well as the inner sequences,
+    /// meaning it only enumerates the input sequences while the output sequence is being enumerated.
+    /// Both, the outer as well as the inner sequences may therefore be unbounded.
+    ///
+    /// The behavior is similar to that of <see cref="OrderedMergeMany{T}(IEnumerable{IEnumerable{T}}, IComparer{T})"/>,
+    /// with following differences:
+    /// * Additionally to the inner sequences, also the outer sequences must be ordered. They must be ordered
+    ///   by the head of the inner sequence according to the given comparer.
+    /// * The outer sequence is enumerated in a streaming manner, only as far as the outer is enumerated.
+    /// </remarks>
+    public static IEnumerable<T> OrderedNestedMergeMany<T>(this IEnumerable<IEnumerable<T>> sequences, IComparer<T> comparer)
+    {
+        using var outer = sequences.GetEnumerator();
+        var keyComparer = Comparer<DictKey<T>>.Create((a, b) =>
+        {
+            var res = comparer.Compare(a.Value, b.Value);
+            if (res != 0) return res;
+            return a.Idx.CompareTo(b.Idx);
+        });
+
+        var active = new SortedDictionary<DictKey<T>, IEnumerator<T>>(keyComparer);
+
+        var pending = NextNonEmpty();
+        if (pending == null)
+            yield break;
+
+        try
+        {
+            long uniqueIdx = 0;
+            while ((active.Count > 0) || (pending != null))
+            {
+                KeyValuePair<DictKey<T>, IEnumerator<T>> first;
+                if (active.Count == 0)
+                {
+                    first = new(new(pending!.Current, uniqueIdx++), pending);
+                    active.Add(first.Key, first.Value);
+                    pending = NextNonEmpty();
+                }
+                else
+                {
+                    first = active.First();
+
+                    if ((pending != null) && (comparer.Compare(pending.Current, first.Value.Current) < 0))
+                    {
+                        first = new(new(pending.Current, uniqueIdx++), pending);
+                        active.Add(first.Key, first.Value);
+                        pending = NextNonEmpty();
+                    }
+                }
+
+                yield return first.Key.Value;
+
+                active.Remove(first.Key);
+                if (first.Value.MoveNext())
+                    active.Add(new(first.Value.Current, uniqueIdx++), first.Value);
+                else
+                    first.Value.Dispose();
+            }
+        }
+        finally
+        {
+            foreach (var enumerator in active.Values)
+                enumerator.Dispose();
+
+            pending?.Dispose();
+        }
+
+        IEnumerator<T>? NextNonEmpty()
+        {
+            while (outer.MoveNext())
+            {
+                var enumerator = outer.Current?.GetEnumerator();
+                if (enumerator?.MoveNext() == true)
+                    return enumerator;
+
+                enumerator?.Dispose();
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
Changes:
- Introduce GetAlarmOccurrences for streaming, ordered alarm fire times with optional time bounds, replacing PollAlarms/Poll.
- Refactor Alarm to use GetFireTimes for RFC 5545-compliant repetition logic.
- Merge and order alarm occurrences across all alarms, handling RELATED=END and RDATE periods correctly.
- Add OrderedNestedMergeMany for efficient streaming merge of ordered sequences.
- Make AlarmOccurrence comparable by fire time.
- Add more AlarmTests

BREAKING CHANGE: `IAlarmContainer.PollAlarms(DateTimeZone, Instant?, Instant?)` has been removed. Replace calls with `GetAlarmOccurrences(timeZone, startTime, endTime, options)`. The new method returns `IEnumerable<AlarmOccurrence>` ordered by fire time, accepts an optional `EvaluationOptions` argument, and correctly handles `RELATED=END` triggers on PERIOD RDATEs with varying durations.

Credits to @minichma for providing the code for streaming `Alarm` occurrences (https://github.com/minichma/ical.net/tree/xp/alarm_streaming)

Resolves #943 