### PR TITLE
Remove obsolete RecurrenceId

### DIFF
--- a/Ical.Net.Tests/RecurrenceIdentifierTests.cs
+++ b/Ical.Net.Tests/RecurrenceIdentifierTests.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
@@ -75,36 +75,6 @@ internal class RecurrenceIdentifierTests
         {
             Assert.That(recurrenceId!.StartTime, Is.EqualTo(new CalDateTime(dt)));
             Assert.That(recurrenceId.Range, Is.EqualTo(expected));
-        }
-    }
-
-    [Test]
-    public void RecurrenceId_IsCompatibleWith_RecurrenceIdentifier()
-    {
-        var dt = new CalDateTime("20250930");
-        var evt1 = new CalendarEvent
-        {
-            RecurrenceId = dt
-        };
-
-        var evt2 = new CalendarEvent
-        {
-            RecurrenceIdentifier = new RecurrenceIdentifier(dt)
-        };
-        
-        var evtFuture = new CalendarEvent
-        {
-            RecurrenceIdentifier = new RecurrenceIdentifier(dt, RecurrenceRange.ThisAndFuture)
-        };
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(evt1.RecurrenceId, Is.EqualTo(evt1.RecurrenceIdentifier?.StartTime));
-            Assert.That(evt2.RecurrenceId, Is.EqualTo(evt2.RecurrenceIdentifier.StartTime));
-            Assert.That(evt1.RecurrenceIdentifier?.Range, Is.EqualTo(RecurrenceRange.ThisInstance));
-            // RecurrenceId only supports ThisInstance implicitly,
-            // so RecurrenceInstance with ThisAndFuture returns null
-            Assert.That(evtFuture.RecurrenceId, Is.Null);
         }
     }
 

--- a/Ical.Net.Tests/RecurrenceTests.cs
+++ b/Ical.Net.Tests/RecurrenceTests.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
@@ -3927,7 +3927,7 @@ END:VCALENDAR";
         var occurrences = cal
             .GetOccurrences<CalendarEvent>(tz).ToList();
 
-        var overrideOcc = occurrences.FirstOrDefault(o => o.Source.RecurrenceId == new CalDateTime(2025, 11, 3));
+        var overrideOcc = occurrences.FirstOrDefault(o => o.Source.RecurrenceIdentifier?.StartTime == new CalDateTime(2025, 11, 3));
 
         using (Assert.EnterMultipleScope())
         {
@@ -3979,7 +3979,7 @@ END:VCALENDAR";
         var occurrences = cal
             .GetOccurrences<CalendarEvent>(tz).ToList();
 
-        var overrideOcc = occurrences.FirstOrDefault(o => o.Source.RecurrenceId == new CalDateTime(2025, 11, 3));
+        var overrideOcc = occurrences.FirstOrDefault(o => o.Source.RecurrenceIdentifier?.StartTime == new CalDateTime(2025, 11, 3));
 
         using (Assert.EnterMultipleScope())
         {
@@ -4033,7 +4033,7 @@ END:VCALENDAR";
         var occurrences = cal
             .GetOccurrences<CalendarEvent>(tz).ToList();
 
-        var overrideOcc = occurrences.FirstOrDefault(o => o.Source.RecurrenceId == new CalDateTime(2025, 11, 3));
+        var overrideOcc = occurrences.FirstOrDefault(o => o.Source.RecurrenceIdentifier?.StartTime == new CalDateTime(2025, 11, 3));
 
         using (Assert.EnterMultipleScope())
         {

--- a/Ical.Net.Tests/VTimeZoneTest.cs
+++ b/Ical.Net.Tests/VTimeZoneTest.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
@@ -262,44 +262,6 @@ public class VTimeZoneTest
             Assert.That(serialized, Does.Contain("DTSTART:20070311T020000"), "DTSTART:20070311T020000 was not serialized");
             Assert.That(serialized, Does.Contain("DTSTART:20071104T020000"), "DTSTART:20071104T020000 was not serialized");
         }
-    }
-
-    [Test, Category("VTimeZone")]
-    public void RecurrenceId_IsCompatibleWith_RecurrenceInstance()
-    {
-#pragma warning disable CS0618 // Type or member is obsolete
-        var dt = new CalDateTime("20250930");
-
-        var iCal = CreateTestCalendar("America/Detroit");
-
-        var tzInfo1 = iCal.TimeZones.First().TimeZoneInfos.First();
-        tzInfo1.RecurrenceIdentifier = new RecurrenceIdentifier(dt);
-
-        iCal = CreateTestCalendar("America/Detroit");
-        var tzInfo2 = iCal.TimeZones.First().TimeZoneInfos.First();
-        tzInfo2.RecurrenceId = dt.Date.PlusDays(1).ToCalDateTime();
-
-        iCal = CreateTestCalendar("America/Detroit");
-        var tzInfo3 = iCal.TimeZones.First().TimeZoneInfos.First();
-        tzInfo3.RecurrenceIdentifier = new RecurrenceIdentifier(dt, RecurrenceRange.ThisAndFuture);
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(tzInfo1.RecurrenceId, Is.EqualTo(tzInfo1.RecurrenceIdentifier.StartTime));
-            Assert.That(tzInfo1.RecurrenceIdentifier.Range, Is.EqualTo(RecurrenceRange.ThisInstance));
-
-            Assert.That(tzInfo1.TzId, Is.EqualTo("America/Detroit"));
-
-            Assert.That(tzInfo2.RecurrenceIdentifier!.StartTime, Is.EqualTo(dt.Date.PlusDays(1).ToCalDateTime()));
-            Assert.That(tzInfo2.RecurrenceId, Is.EqualTo(dt.Date.PlusDays(1).ToCalDateTime()));
-            Assert.That(tzInfo2.RecurrenceIdentifier.Range, Is.EqualTo(RecurrenceRange.ThisInstance));
-
-            // RecurrenceId only supports ThisInstance implicitly,
-            // so RecurrenceInstance with ThisAndFuture returns null
-            Assert.That(tzInfo3.RecurrenceIdentifier.Range, Is.EqualTo(RecurrenceRange.ThisAndFuture));
-            Assert.That(tzInfo3.RecurrenceId, Is.Null);
-        }
-#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     private static Calendar CreateTestCalendar(string tzId, DateTime? earliestTime = null, bool includeHistoricalData = true)

--- a/Ical.Net.Tests/WikiSamples/RecurrenceWikiTests.cs
+++ b/Ical.Net.Tests/WikiSamples/RecurrenceWikiTests.cs
@@ -442,7 +442,7 @@ internal class RecurrenceWikiTests
             DtStart = startMoved,
             DtEnd = new(startMoved.ToZonedDateTime().PlusMinutes(13)),
             // Set the original date of the occurrence (2025-07-14 09:00:00).
-            RecurrenceId = new(2025, 07, 14, 09, 00, 00, timeZoneId),
+            RecurrenceIdentifier = new(new(2025, 07, 14, 09, 00, 00, timeZoneId)),
             // The first change for this RecurrenceId
             Sequence = 1
         };

--- a/Ical.Net/Calendar.cs
+++ b/Ical.Net/Calendar.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
@@ -236,8 +236,9 @@ public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, I
     private static Dictionary<(string? Uid, DateTime RecurrenceId), IUniqueComponent> GetRecurrenceIdsAndUids(IEnumerable<ICalendarObject> children)
     {
         return children.OfType<IRecurrable>()
-            .Where(r => r.RecurrenceId != null)
-            .Select(r => (Component: r as IUniqueComponent, Uid: (r as IUniqueComponent)?.Uid, RecurrenceId: r.RecurrenceId!.Value))
+            // Filter by range of ThisInstance because ThisAndFuture is not supported yet
+            .Where(r => r.RecurrenceIdentifier != null && r.RecurrenceIdentifier.Range == RecurrenceRange.ThisInstance)
+            .Select(r => (Component: r as IUniqueComponent, Uid: (r as IUniqueComponent)?.Uid, RecurrenceId: r.RecurrenceIdentifier!.StartTime.Value))
             .Where(x => x is { Uid: not null, Component: not null })
             // Assure we have only one component per (UID, RECURRENCE-ID) pair
             .GroupBy(x => (x.Uid, x.RecurrenceId))
@@ -265,8 +266,10 @@ public class Calendar : CalendarComponent, IGetOccurrencesTyped, IGetFreeBusy, I
         {
             // If the occurrence is a modified instance (has RecurrenceId and Uid)
             // and the source is the last modified instance for this RecurrenceId/Uid,
-            IUniqueComponent { Uid: not null } uc when r.Source.RecurrenceId != null =>
-                recurrenceIdsAndUids.TryGetValue((uc.Uid, r.Source.RecurrenceId.Value),
+            IUniqueComponent { Uid: not null } uc
+                // Filter by range of ThisInstance because ThisAndFuture is not supported yet
+                when r.Source.RecurrenceIdentifier != null && r.Source.RecurrenceIdentifier.Range == RecurrenceRange.ThisInstance =>
+                recurrenceIdsAndUids.TryGetValue((uc.Uid, r.Source.RecurrenceIdentifier.StartTime.Value),
                     out var lastComponent) && ReferenceEquals(lastComponent, r.Source),
 
             // If not a modified occurrence, keep if:

--- a/Ical.Net/CalendarComponents/IRecurrable.cs
+++ b/Ical.Net/CalendarComponents/IRecurrable.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
@@ -21,7 +21,7 @@ public interface IRecurrable : IGetOccurrences
 
     RecurrenceRule? RecurrenceRule { get; set; }
 
-    CalDateTime? RecurrenceId { get; set; }
+    RecurrenceIdentifier? RecurrenceIdentifier { get; set; }
 
     IEvaluator? Evaluator { get; }
 }

--- a/Ical.Net/CalendarComponents/RecurringComponent.cs
+++ b/Ical.Net/CalendarComponents/RecurringComponent.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
@@ -105,18 +105,6 @@ public abstract class RecurringComponent : UniqueComponent, IRecurringComponent
     {
         get => Properties.Get<RecurrenceRule>("RRULE");
         set => Properties.Set("RRULE", value);
-    }
-
-    /// <summary>
-    /// Gets or sets the recurrence identifier for a specific instance of a recurring event.
-    /// </summary>
-    /// <remarks>Use <see cref="RecurrenceIdentifier"/> instead, which
-    /// supports the RANGE parameter for recurring events.</remarks>
-    [Obsolete("Use RecurrenceIdentifier instead, which supports the RANGE parameter.")]
-    public virtual CalDateTime? RecurrenceId
-    {
-        get => RecurrenceIdentifier?.Range == RecurrenceRange.ThisInstance ? RecurrenceIdentifier.StartTime : null;
-        set => RecurrenceIdentifier = value is null ? null : new RecurrenceIdentifier(value, RecurrenceRange.ThisInstance);
     }
 
     /// <summary>

--- a/Ical.Net/VTimeZoneInfo.cs
+++ b/Ical.Net/VTimeZoneInfo.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
@@ -123,18 +123,6 @@ public class VTimeZoneInfo : CalendarComponent, IRecurrable
     {
         get => Properties.Get<RecurrenceRule>("RRULE");
         set => Properties.Set("RRULE", value);
-    }
-
-    /// <summary>
-    /// Gets or sets the recurrence identifier for a specific instance of a recurring event.
-    /// </summary>
-    /// <remarks>Use <see cref="RecurrenceIdentifier"/> instead, which
-    /// supports the RANGE parameter for recurring events.</remarks>
-    [Obsolete("Use RecurrenceIdentifier instead, which supports the RANGE parameter.")]
-    public virtual CalDateTime? RecurrenceId
-    {
-        get => RecurrenceIdentifier?.Range == RecurrenceRange.ThisInstance ? RecurrenceIdentifier.StartTime : null;
-        set => RecurrenceIdentifier = value is null ? null : new RecurrenceIdentifier(value, RecurrenceRange.ThisInstance);
     }
 
     /// <summary>


### PR DESCRIPTION
Remove obsolete `RecurrenceId`.

Added `RecurrenceIdentifier` to `IRecurrable` - this probably should have been done in v5. Any reason to do this in v5 now? Using `IRecurrable` directly is probably not very common.

This still ignores THISANDFUTURE in the same way as before.

Related #909, #455