### PR TITLE
Stop using culture-specific string handling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,6 +22,8 @@ insert_final_newline = true
 csharp_new_line_before_members_in_anonymous_types = true
 
 [*.cs]
+#Specify CultureInfo
+dotnet_diagnostic.CA1304.severity = warning
 #parsing and formatting should be implemented in a culture-invariant manner
 dotnet_diagnostic.CA1305.severity = warning
 

--- a/Ical.Net.Tests/SerializationTests.cs
+++ b/Ical.Net.Tests/SerializationTests.cs
@@ -580,7 +580,8 @@ public class SerializationTests
     [TestCase("th-TH")] // Thai (Thailand)
     [TestCase("ru-RU")] // Russian (Russia)
     [TestCase("ko-KR")] // Korean (Korea)
-    public void TestConvertToInt32WithNegativeNumberInDifferentCultures(string cultureStr)
+    [TestCase("tr-TR")] // Turkish (Turkey)
+    public void TestSerializationInDifferentCultures(string cultureStr)
     {
         var originalCulture = CultureInfo.CurrentCulture;
         try
@@ -596,12 +597,14 @@ public class SerializationTests
                     BEGIN:VCALENDAR
                     BEGIN:VEVENT
                     DTSTART:20251231
-                    RRULE:FREQ=YEARLY;BYYEARDAY=-1
+                    RRULE:FREQ=YEARLY;BYYEARDAY=-1;UNTIL=20260622
                     END:VEVENT
                     END:VCALENDAR
                     """), Throws.Nothing);
+
                 // Serialize
                 Assert.That(() => new DurationSerializer().SerializeToString(new Duration(null, -1)), Is.EqualTo("-P1D"));
+                Assert.That(() => new RecurrenceRuleSerializer().SerializeToString(new RecurrencePattern() { Frequency = FrequencyType.Daily, Until = new CalDateTime(2026, 6, 22) }).Contains("UNTIL=20260622"), Is.True);
 
             });
         }    

--- a/Ical.Net/DataTypes/CalendarDataType.cs
+++ b/Ical.Net/DataTypes/CalendarDataType.cs
@@ -94,7 +94,7 @@ public abstract class CalendarDataType : ICalendarDataType
     }
 
     public virtual void SetValueType(string type) =>
-        _proxy.Set("VALUE", type.ToUpper());
+        _proxy.Set("VALUE", type.ToUpperInvariant());
 
     public virtual ICalendarObject? AssociatedObject
     {

--- a/Ical.Net/Serialization/CalendarComponentFactory.cs
+++ b/Ical.Net/Serialization/CalendarComponentFactory.cs
@@ -12,7 +12,7 @@ public class CalendarComponentFactory
     public virtual ICalendarComponent Build(string objectName)
     {
         ICalendarComponent c;
-        var name = objectName.ToUpper();
+        var name = objectName.ToUpperInvariant();
 
         switch (name)
         {

--- a/Ical.Net/Serialization/DataTypes/RecurrenceRuleSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/RecurrenceRuleSerializer.cs
@@ -20,7 +20,7 @@ public class RecurrenceRuleSerializer : EncodableDataTypeSerializer
 
     public static DayOfWeek GetDayOfWeek(string value)
     {
-        return value.ToUpper() switch
+        return value.ToUpperInvariant() switch
         {
             "SU" => DayOfWeek.Sunday,
             "MO" => DayOfWeek.Monday,
@@ -115,7 +115,7 @@ public class RecurrenceRuleSerializer : EncodableDataTypeSerializer
         SerializationContext.Push(recur);
         var values = new List<string>
         {
-            $"FREQ={recur.Frequency.ToString().ToUpper()}"
+            $"FREQ={recur.Frequency.ToString().ToUpperInvariant()}"
         };
 
         //-- FROM RFC2445 --
@@ -139,7 +139,7 @@ public class RecurrenceRuleSerializer : EncodableDataTypeSerializer
 
         if (recur.FirstDayOfWeek != DayOfWeek.Monday)
         {
-            values.Add($"WKST={Enum.GetName(typeof(DayOfWeek), recur.FirstDayOfWeek)?.ToUpper().Substring(0, 2)}");
+            values.Add($"WKST={Enum.GetName(typeof(DayOfWeek), recur.FirstDayOfWeek)?.ToUpperInvariant().Substring(0, 2)}");
         }
 
         if (recur.Count.HasValue)
@@ -240,7 +240,7 @@ public class RecurrenceRuleSerializer : EncodableDataTypeSerializer
                 freqPartExists = true;
             }
 
-            ProcessKeyValuePair(keyValues[0].ToLower(), keyValues[1], r, factory);
+            ProcessKeyValuePair(keyValues[0].ToLowerInvariant(), keyValues[1], r, factory);
         }
 
         if (!freqPartExists)

--- a/Ical.Net/Serialization/DataTypes/WeekDaySerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/WeekDaySerializer.cs
@@ -37,7 +37,7 @@ public class WeekDaySerializer : EncodableDataTypeSerializer
             var name = Enum.GetName(typeof(DayOfWeek), ds.DayOfWeek);
             if (name == null) return null;
 
-            value += name.ToUpper().Substring(0, 2);
+            value += name.ToUpperInvariant().Substring(0, 2);
         }
         catch
         {

--- a/Ical.Net/Serialization/EncodingProvider.cs
+++ b/Ical.Net/Serialization/EncodingProvider.cs
@@ -63,7 +63,7 @@ internal class EncodingProvider : IEncodingProvider
     /// <exception cref="SerializationException">Decoder not supported.</exception>
     protected virtual DecoderDelegate GetDecoderFor(string encoding)
     {
-        return encoding.ToUpper() switch
+        return encoding.ToUpperInvariant() switch
         {
             "8BIT" => Decode8Bit,
             "BASE64" => DecodeBase64,
@@ -99,7 +99,7 @@ internal class EncodingProvider : IEncodingProvider
     /// <exception cref="SerializationException">Encoder not supported.</exception>
     protected virtual EncoderDelegate GetEncoderFor(string encoding)
     {
-        return encoding.ToUpper() switch
+        return encoding.ToUpperInvariant() switch
         {
             "8BIT" => Encode8Bit,
             "BASE64" => EncodeBase64,


### PR DESCRIPTION
Stop using culture-specific string handling, particularly `.ToUpper()` and `.ToLower()`, use the invariant versions instead. Add a reproducer for the problem that `UNTIL` couldn't be deserialized in culture `tr-TR`. Enable warnings for `CS1304` 'Specify CultureInfo'.

Fixes #792 
