### PR TITLE
v5: Escape backslash for TEXT values

### DIFF
--- a/Ical.Net.Tests/SerializationTests.cs
+++ b/Ical.Net.Tests/SerializationTests.cs
@@ -645,4 +645,33 @@ public class SerializationTests
             Assert.That(HasBom(withBomBytes), Is.True, "Stream should contain a UTF-8 BOM");
         });
     }
+
+    [TestCase(@"Lab, Training", @"Lab\, Training")]
+    [TestCase(@"Lab; Training", @"Lab\; Training")]
+    [TestCase(@"Lab \ Training", @"Lab \\ Training")]
+    [TestCase(@"Lab \\ Training", @"Lab \\\\ Training")]
+    [TestCase(@"Orientation\New Hire", @"Orientation\\New Hire")]
+    [TestCase(@"Orientation\new Hire", @"Orientation\\new Hire")]
+    [TestCase(@"\\StartsWithSlash", @"\\\\StartsWithSlash")]
+    [TestCase(@"\\", @"\\\\")]
+    [TestCase(@",;\\", @"\,\;\\\\")]
+    [TestCase("Line1\rLine2", @"Line1\nLine2", "Line1\nLine2")]
+    [TestCase("Line1\nLine2", @"Line1\nLine2")]
+    [TestCase("Line1\r\nLine2", @"Line1\nLine2", "Line1\nLine2")]
+    [TestCase("Line1\r\r\nLine2", @"Line1\n\nLine2", "Line1\n\nLine2")]
+    [TestCase("Line1\n\r\r\nLine2", @"Line1\n\n\nLine2", "Line1\n\n\nLine2")]
+    [TestCase("Line1\n\r\r\nLine2\r", @"Line1\n\n\nLine2\n", "Line1\n\n\nLine2\n")]
+    [TestCase(@"Ends\With;Slash\", @"Ends\\With\;Slash\\", "Ends\\With;Slash\\")]
+    public void TextValueEscapesSpecialCharacters(string originalText, string serializedText, string? deserializedText = null)
+    {
+        var calendar = new Calendar();
+        var calEvent = new CalendarEvent { Description = originalText };
+        calendar.Events.Add(calEvent);
+
+        var result = new CalendarSerializer().SerializeToString(calendar);
+        Assert.That(result, Does.Contain($"DESCRIPTION:{serializedText}"));
+
+        var resultCal = Calendar.Load(result)!;
+        Assert.That(resultCal.Events[0]!.Description, Is.EqualTo(deserializedText ?? originalText));
+    }
 }

--- a/Ical.Net.Tests/SimpleDeserializationTests.cs
+++ b/Ical.Net.Tests/SimpleDeserializationTests.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
@@ -517,5 +517,29 @@ END:VCALENDAR
 
         for (var i = 0; i < props.Count; i++)
             Assert.That(props[i].Value, Is.EqualTo("2." + i));
+    }
+
+    [Test]
+    public void EscapedTextWithTrailingSlash()
+    {
+        var s = new StringSerializer();
+
+        var input = @"Ends\\With\;Slash\";
+        var reader = new StringReader(input);
+        var result = s.Deserialize(reader);
+
+        Assert.That(result, Is.EqualTo(@"Ends\With;Slash\"));
+    }
+
+    [Test]
+    public void DoubleQuoteIsUnescaped()
+    {
+        // Double quotes aren't escaped in RFC2445, but are in Mozilla Sunbird (0.5-)
+        var s = new StringSerializer();
+        var input = @"Value From \""Mozilla Sunbird\""";
+        var reader = new StringReader(input);
+        var result = s.Deserialize(reader);
+
+        Assert.That(result, Is.EqualTo(@"Value From ""Mozilla Sunbird"""));
     }
 }

--- a/Ical.Net/Serialization/DataTypes/StringSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/StringSerializer.cs
@@ -1,13 +1,15 @@
-﻿//
+//
 // Copyright ical.net project maintainers and contributors.
 // Licensed under the MIT license.
 //
 
 using System;
+using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using Ical.Net.DataTypes;
 
@@ -19,47 +21,277 @@ public class StringSerializer : EncodableDataTypeSerializer
 
     public StringSerializer(SerializationContext ctx) : base(ctx) { }
 
-    internal static readonly Regex SingleBackslashMatch = new Regex(@"(?<!\\)\\(?!\\)", RegexOptions.Compiled, RegexDefaults.Timeout);
-
     protected virtual string? Unescape(string? value)
     {
-        if (string.IsNullOrWhiteSpace(value))
+        // Skip values that do not need to be unescaped
+        if (value == null)
         {
             return value;
         }
 
-        value = value.Replace(@"\n", "\n");
-        value = value.Replace(@"\N", "\n");
-        value = value.Replace(@"\;", ";");
-        value = value.Replace(@"\,", ",");
-        // NOTE: double quotes aren't escaped in RFC2445, but are in Mozilla Sunbird (0.5-)
-        value = value.Replace("\\\"", "\"");
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        return UnescapeWithSpan(value);
+#else
 
-        // Replace all single-backslashes with double-backslashes.
-        value = SingleBackslashMatch.Replace(value, "\\\\");
+        var pos = value.IndexOf('\\');
+        if (pos == -1)
+        {
+            // Nothing to unescape
+            return value;
+        }
 
-        // Unescape double backslashes
-        value = value.Replace(@"\\", @"\");
-        return value;
+        var sb = new StringBuilder(value.Length);
+
+        // Copy up to first backslash
+        sb.Append(value, 0, pos);
+
+        while (pos < value.Length)
+        {
+            if (pos + 1 == value.Length)
+            {
+                // Last character is a backslash that escapes nothing.
+                // Include backslash in result.
+                sb.Append('\\');
+                break;
+            }
+
+            var next = value[pos + 1];
+            var consumed = ConsumeEscaped(next, sb);
+
+            pos += consumed;
+
+            // Check for next escaped value
+            var nextPos = value.IndexOf('\\', pos);
+            if (nextPos == -1)
+            {
+                sb.Append(value, pos, value.Length - pos);
+                break;
+            }
+
+            sb.Append(value, pos, nextPos - pos);
+            pos = nextPos;
+        }
+
+        return sb.ToString();
+#endif
     }
+
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+    private static string UnescapeWithSpan(string valueToUnescape)
+    {
+        var value = valueToUnescape.AsSpan();
+
+        var pos = value.IndexOf('\\');
+        if (pos == -1)
+        {
+            // Nothing to unescape
+            return valueToUnescape;
+        }
+
+        var sb = new StringBuilder(value.Length);
+        sb.Append(value[..pos]);
+        value = value[pos..];
+
+        while (!value.IsEmpty)
+        {
+            if (value.Length == 1)
+            {
+                // Last character is a backslash that escapes nothing.
+                // Include backslash in result.
+                sb.Append('\\');
+                break;
+            }
+
+            var next = value[1];
+            var consumed = ConsumeEscaped(next, sb);
+
+            value = value[consumed..];
+
+            // Check for next escaped value
+            pos = value.IndexOf('\\');
+            if (pos == -1)
+            {
+                sb.Append(value);
+                break;
+            }
+
+            sb.Append(value[..pos]);
+            value = value[pos..];
+        }
+
+        return sb.ToString();
+    }
+#endif
+
+    /// <summary>
+    /// Adds the escaped character to the StringBuilder.
+    /// </summary>
+    /// <param name="escaped"></param>
+    /// <param name="sb"></param>
+    /// <returns>The number of characters consumed, including the backslash.</returns>
+    private static int ConsumeEscaped(char escaped, StringBuilder sb)
+    {
+        if (escaped is 'n' or 'N')
+        {
+            sb.Append('\n');
+            return 2;
+        }
+
+        // Double quotes aren't escaped in RFC2445, but are in Mozilla Sunbird (0.5-)
+        if (escaped is '\\' or ';' or ',' or '"')
+        {
+            sb.Append(escaped);
+            return 2;
+        }
+
+        // Backslash is escaping an invalid character, just
+        // include the backslash and leave it unchanged.
+        sb.Append('\\');
+        return 1;
+    }
+
+    /// <summary>
+    /// Characters that must be escaped for TEXT values. Note that \r is also
+    /// included even though it is not specified in the RFC - it is treated as
+    /// a \n value.
+    /// </summary>
+#if NET8_0_OR_GREATER
+    private static readonly SearchValues<char> _textEscapeChars = SearchValues.Create("\\;,\n\r");
+#else
+    private static readonly char[] _textEscapeChars = ['\\', ';', ',', '\n', '\r'];
+#endif
 
     protected virtual string? Escape(string? value)
     {
-        if (string.IsNullOrWhiteSpace(value))
+        if (value == null)
         {
             return value;
         }
 
-        // NOTE: fixed a bug that caused text parsing to fail on
-        // programmatically entered strings.
-        // SEE unit test SERIALIZE25().
-        value = value.Replace(SerializationConstants.LineBreak, @"\n");
-        value = value.Replace("\r", @"\n");
-        value = value.Replace("\n", @"\n");
-        value = value.Replace(";", @"\;");
-        value = value.Replace(",", @"\,");
-        return value;
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        return EscapeWithSearchValues(value);
+#else
+        // Skip escaping if there are no characters to escape. This improves
+        // the performance of the more common case of short TEXT values with
+        // no characters to escape.
+        var pos = value.IndexOfAny(_textEscapeChars);
+        if (pos == -1)
+        {
+            // Nothing to escape
+            return value;
+        }
+
+        var sb = new StringBuilder(value.Length);
+
+        // Copy up to first character that needs to be escaped
+        sb.Append(value, 0, pos);
+
+        while (pos < value.Length)
+        {
+            // Escape the character
+            sb.Append('\\');
+
+            var toEscape = value[pos];
+            var consumed = 1;
+
+            if (toEscape == '\r')
+            {
+                // Treat \r as \n
+                sb.Append('n');
+
+                // Treat \r\n as \n
+                if (pos + 1 < value.Length && value[pos + 1] == '\n')
+                {
+                    consumed = 2;
+                }
+            }
+            else if (toEscape == '\n')
+            {
+                sb.Append('n');
+            }
+            else
+            {
+                sb.Append(toEscape);
+            }
+
+            pos += consumed;
+
+            // Check for next value to escape
+            var nextPos = value.IndexOfAny(_textEscapeChars, pos);
+            if (nextPos == -1)
+            {
+                sb.Append(value, pos, value.Length - pos);
+                break;
+            }
+
+            sb.Append(value, pos, nextPos - pos);
+            pos = nextPos;
+        }
+
+        return sb.ToString();
+#endif
     }
+
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+    private static string EscapeWithSearchValues(string valueToEscape)
+    {
+        var value = valueToEscape.AsSpan();
+
+        var pos = value.IndexOfAny(_textEscapeChars);
+        if (pos == -1)
+        {
+            // Nothing to escape
+            return valueToEscape;
+        }
+
+        var sb = new StringBuilder(value.Length);
+        sb.Append(value[..pos]);
+        value = value[pos..];
+
+        while (!value.IsEmpty)
+        {
+            // Escape the character
+            sb.Append('\\');
+
+            var toEscape = value[0];
+            var consumed = 1;
+
+            if (toEscape == '\r')
+            {
+                // Treat \r as \n
+                sb.Append('n');
+
+                // Treat \r\n as \n
+                if (value.Length > 1 && value[1] == '\n')
+                {
+                    consumed = 2;
+                }
+            }
+            else if (toEscape == '\n')
+            {
+                sb.Append('n');
+            }
+            else
+            {
+                sb.Append(toEscape);
+            }
+
+            value = value[consumed..];
+
+            pos = value.IndexOfAny(_textEscapeChars);
+            if (pos == -1)
+            {
+                sb.Append(value);
+                break;
+            }
+
+            sb.Append(value[..pos]);
+            value = value[pos..];
+        }
+
+        return sb.ToString();
+    }
+#endif
 
     public override Type TargetType => typeof(string);
 


### PR DESCRIPTION
v5 fix for escaping backslash. This is partial cherry-pick of #965 with some changes to handle the target frameworks of v5.

This also improves escape/unescape performance and reduces allocations.

Fixes #963