### PR TITLE
Split multi-value TEXT on unescaped separator commas

### DIFF
--- a/Ical.Net.Tests/SerializationTests.cs
+++ b/Ical.Net.Tests/SerializationTests.cs
@@ -654,4 +654,32 @@ public class SerializationTests
         var resultCal = Calendar.Load(result)!;
         Assert.That(resultCal.Events[0]!.Description, Is.EqualTo(deserializedText ?? originalText));
     }
+
+    private static readonly object[] MultiValueSeparatorCases =
+    {
+        // categories, expected serialized CATEGORIES line
+        new object[] { new[] { "a", "b" }, @"CATEGORIES:a,b" },                 // plain separator
+        new object[] { new[] { "a,b", "c" }, @"CATEGORIES:a\,b,c" },            // escaped comma stays inside a value
+        new object[] { new[] { @"a\", "b" }, @"CATEGORIES:a\\,b" },             // escaped backslash before a separator
+        new object[] { new[] { @"a\,b" }, @"CATEGORIES:a\\\,b" },               // escaped backslash + escaped comma = one value
+        new object[] { new[] { @"a\\", "b" }, @"CATEGORIES:a\\\\,b" },          // two escaped backslashes before a separator
+        new object[] { new[] { "a", @"b\" }, @"CATEGORIES:a,b\\" },             // trailing backslash on the last value
+        new object[] { new[] { @"x\", @"y\", "z" }, @"CATEGORIES:x\\,y\\,z" },  // several escaped backslashes before separators
+    };
+
+    [TestCaseSource(nameof(MultiValueSeparatorCases))]
+    public void MultiValueTextRoundTripsAcrossEscapedSeparators(string[] categories, string serializedLine)
+    {
+        var calendar = new Calendar();
+        var calEvent = new CalendarEvent { Summary = "x" };
+        foreach (var category in categories)
+            calEvent.Categories.Add(category);
+        calendar.Events.Add(calEvent);
+
+        var result = new CalendarSerializer().SerializeToString(calendar);
+        Assert.That(result, Does.Contain(serializedLine));
+
+        var roundTripped = Calendar.Load(result)!.Events[0]!.Categories.ToList();
+        Assert.That(roundTripped, Is.EqualTo(categories));
+    }
 }

--- a/Ical.Net/Serialization/DataTypes/StringSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/StringSerializer.cs
@@ -10,7 +10,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using Ical.Net.DataTypes;
 
 namespace Ical.Net.Serialization.DataTypes;
@@ -342,7 +341,45 @@ public class StringSerializer : EncodableDataTypeSerializer
         return string.Join(",", values);
     }
 
-    internal static readonly Regex UnescapedCommas = new Regex(@"(?<!\\),", RegexOptions.Compiled, RegexDefaults.Timeout);
+    // A value scan stops at an unescaped comma (a separator) or a backslash
+    // (which escapes the following character).
+    private static readonly char[] _valueSeparators = ['\\', ','];
+
+    /// <summary>
+    /// Splits a serialized multi-value TEXT property on its separator commas. A comma
+    /// separates values only when it is not escaped; a backslash escapes the following
+    /// character, so a comma preceded by an odd number of backslashes belongs to a value
+    /// (RFC 5545 3.1.1). Mirrors the left-to-right consumption used by <see cref="Unescape"/>.
+    /// </summary>
+    internal static IEnumerable<string> SplitOnUnescapedCommas(string value)
+    {
+        var start = 0;
+        var pos = 0;
+
+        while (pos < value.Length)
+        {
+            var next = value.IndexOfAny(_valueSeparators, pos);
+            if (next < 0)
+            {
+                break;
+            }
+
+            if (value[next] == '\\')
+            {
+                // Backslash escapes the next character; skip the pair.
+                pos = next + 2;
+            }
+            else
+            {
+                yield return value.Substring(start, next - start);
+                start = next + 1;
+                pos = next + 1;
+            }
+        }
+
+        yield return value.Substring(start);
+    }
+
     public override object? Deserialize(TextReader? tr)
     {
         if (tr == null)
@@ -367,9 +404,8 @@ public class StringSerializer : EncodableDataTypeSerializer
             AssociatedObject = context.Peek() as ICalendarObject
         };
 
-        var encodedValues = serializeAsList ? UnescapedCommas.Split(value) : new[] { value };
-        var escapedValues = encodedValues.Select(v => Decode(dt, v)).ToList();
-        var values = escapedValues.Select(Unescape).ToList();
+        var encodedValues = serializeAsList ? SplitOnUnescapedCommas(value) : Enumerable.Repeat(value, 1);
+        var values = encodedValues.Select(v => Unescape(Decode(dt, v))).ToList();
 
         if (values.Count == 1)
         {

--- a/Ical.Net/Serialization/DataTypes/StringSerializer.cs
+++ b/Ical.Net/Serialization/DataTypes/StringSerializer.cs
@@ -404,13 +404,14 @@ public class StringSerializer : EncodableDataTypeSerializer
             AssociatedObject = context.Peek() as ICalendarObject
         };
 
-        var encodedValues = serializeAsList ? SplitOnUnescapedCommas(value) : Enumerable.Repeat(value, 1);
-        var values = encodedValues.Select(v => Unescape(Decode(dt, v))).ToList();
-
-        if (values.Count == 1)
+        if (!serializeAsList)
         {
-            return values[0];
+            return Unescape(Decode(dt, value));
         }
-        return values;
+
+        var values = SplitOnUnescapedCommas(value)
+            .Select(v => Unescape(Decode(dt, v)))
+            .ToList();
+        return values.Count == 1 ? values[0] : values;
     }
 }


### PR DESCRIPTION
### Problem

Multi-valued TEXT properties (CATEGORIES, RESOURCES, ...) are split on separator commas with a single-character negative lookbehind:

```csharp
internal static readonly Regex UnescapedCommas = new Regex(@"(?<!\\),", ...);
```

The lookbehind only inspects the one character before the comma, so it cannot count backslash parity. A value that ends in a backslash is escaped to end in `\\` (an escaped backslash), so the serialized stream contains `...\\,` where the comma is a genuine value separator. The lookbehind sees the trailing `\` and refuses to split.

This is a direct sibling of the backslash-escaping fix merged in #965: the encoder now correctly emits `\\` before a list separator, but the splitter was never updated to cope with it, so a list whose values contain backslashes no longer round-trips.

Concretely, `[a\, b]` serializes to `CATEGORIES:a\\,b` (correct) but deserializes back to the single value `a\,b` instead of the two values `a\` and `b`.

### Truth table

A comma is a separator iff preceded by an **even** number (incl. 0) of backslashes; the old regex splits only when preceded by **zero**:

| encoded | values | old | fixed |
|---|---|---|---|
| `a,b` | `a`, `b` | 2 ✓ | 2 ✓ |
| `a\,b` | `a,b` | 1 ✓ | 1 ✓ |
| `a\\,b` | `a\`, `b` | **1 ✗** | 2 ✓ |
| `a\\\,b` | `a\,b` | 1 ✓ | 1 ✓ |
| `a\\\\,b` | `a\\`, `b` | **1 ✗** | 2 ✓ |

### Fix

Replace the lookbehind regex with an escape-aware left-to-right scan that counts backslash parity, mirroring the consumption already used by `Unescape`: a backslash escapes the following character, so a comma is a separator only when it is not escaped.

The single fix site governs every multi-valued TEXT property (`GetPropertyAllowsMultipleValues`), so this repairs the whole class, not just CATEGORIES. The other `Split(',')`/`Split(';')` calls in the serializers operate on structured non-TEXT grammars with no backslash escaping and are unaffected; the lookbehind splitter was the only one of its kind.

### Tests

Added a round-trip test over CATEGORIES covering the full truth table above (plain separator, escaped comma inside a value, escaped backslash before a separator, escaped backslash + escaped comma, two escaped backslashes, trailing backslash on the last value, and several separators in one line). The three escaped-backslash cases fail on `main` and pass with the fix; the escaped-comma cases are the opposite-direction controls that must not over-split. Full suite green (2469 tests, net10.0).
