### PR TITLE
Implement RFC 6868 caret encoding for parameter values

### DIFF
--- a/Ical.Net.Tests/Rfc6868Tests.cs
+++ b/Ical.Net.Tests/Rfc6868Tests.cs
@@ -1,0 +1,123 @@
+﻿//
+// Copyright ical.net project maintainers and contributors.
+// Licensed under the MIT license.
+//
+
+using System.Collections.Generic;
+using Ical.Net.CalendarComponents;
+using Ical.Net.DataTypes;
+using Ical.Net.Serialization;
+using NUnit.Framework;
+
+namespace Ical.Net.Tests;
+
+[TestFixture]
+public class Rfc6868Tests
+{
+    // ---- Codec unit tests (RFC 6868 §3.1 / §3.2) ----
+
+    [TestCase("plain text", "plain text")]
+    [TestCase("a^b", "a^^b")]                 // caret -> ^^
+    [TestCase("say \"hi\"", "say ^'hi^'")]    // DQUOTE -> ^'
+    [TestCase("line1\nline2", "line1^nline2")] // LF -> ^n
+    [TestCase("line1\r\nline2", "line1^nline2")] // CRLF collapses to one ^n
+    [TestCase("^n", "^^n")]                   // literal caret+n -> ^^n (the subtle case)
+    [TestCase("^^", "^^^^")]
+    public void Encode_matches_rfc6868(string raw, string expected)
+    {
+        Assert.That(CaretEncoding.Encode(raw), Is.EqualTo(expected));
+    }
+
+    [TestCase("plain text", "plain text")]
+    [TestCase("a^^b", "a^b")]
+    [TestCase("say ^'hi^'", "say \"hi\"")]
+    [TestCase("line1^nline2", "line1\nline2")]
+    [TestCase("^^n", "^n")]                    // ^^ -> ^, then literal n
+    [TestCase("^x", "^x")]                     // lone caret before other char left unchanged (§3.2)
+    [TestCase("trailing^", "trailing^")]       // dangling caret left unchanged
+    public void Decode_matches_rfc6868(string encoded, string expected)
+    {
+        Assert.That(CaretEncoding.Decode(encoded), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void Codec_is_symmetric_for_every_special_case()
+    {
+        var samples = new[]
+        {
+            "plain",
+            "a^b",           // caret
+            "line1\nline2",  // newline
+            "John \"JD\" Doe", // DQUOTE
+            "^n",            // literal caret+n
+            "^^",            // literal double caret
+            "^'",            // literal caret+quote
+            "mix ^ \" \n end",
+            "",
+            "^",
+        };
+
+        foreach (var v in samples)
+        {
+            var round = CaretEncoding.Decode(CaretEncoding.Encode(v));
+            Assert.That(round, Is.EqualTo(v), $"decode(encode(x)) must equal x for [{v}]");
+        }
+    }
+
+    // ---- Public-API round-trip self-oracle: Load(Serialize()) ----
+
+    private static string Serialize(Calendar cal) => new CalendarSerializer().SerializeToString(cal)!;
+
+    private static string RoundTripParam(string paramValue)
+    {
+        var cal = new Calendar();
+        var ev = new CalendarEvent { Summary = "s" };
+        var att = new Attendee("mailto:a@b.com");
+        att.Parameters.Set("CN", paramValue);
+        ev.Attendees.Add(att);
+        cal.Events.Add(ev);
+
+        var serialized = Serialize(cal);
+        var loaded = Calendar.Load(serialized)!; // must not throw
+        return loaded.Events[0].Attendees[0].Parameters.Get("CN");
+    }
+
+    [TestCase("line1\nline2")]         // newline: threw before the fix (unparseable output)
+    [TestCase("John \"JD\" Doe")]      // DQUOTE: was silently stripped before the fix
+    [TestCase("50% off ^_^")]          // bare carets: must survive ^ -> ^^ -> ^
+    [TestCase("^n")]                   // literal caret+n must not become a newline
+    [TestCase("Doe, John")]            // comma value stays intact (still DQUOTE-wrapped)
+    [TestCase("a^b,c")]                // caret and comma together
+    [TestCase("plain name")]
+    public void Param_value_roundtrips_through_public_api(string value)
+    {
+        Assert.That(RoundTripParam(value), Is.EqualTo(value));
+    }
+
+    [Test]
+    public void Plain_param_value_is_not_altered()
+    {
+        // RFC 6868 only transforms ^, DQUOTE and newline; ordinary values are byte-identical.
+        var cal = new Calendar();
+        var ev = new CalendarEvent { Summary = "s" };
+        var att = new Attendee("mailto:a@b.com");
+        att.Parameters.Set("CN", "John Doe");
+        ev.Attendees.Add(att);
+        cal.Events.Add(ev);
+
+        var serialized = Serialize(cal);
+        Assert.That(serialized, Does.Contain("CN=John Doe"));
+        Assert.That(serialized, Does.Not.Contain("^"));
+    }
+
+    [Test]
+    public void Encoding_targets_the_value_not_the_parameter_name()
+    {
+        // A caret in the value is encoded; the structural name/=/: are untouched.
+        var encoded = CaretEncoding.Encode("v^v");
+        Assert.That(encoded, Is.EqualTo("v^^v"));
+        // The serializer only ever feeds VALUES to the codec (see ParameterSerializer).
+        var recovered = RoundTripParam("v^v");
+        Assert.That(recovered, Is.EqualTo("v^v"));
+    }
+}

--- a/Ical.Net/Serialization/CaretEncoding.cs
+++ b/Ical.Net/Serialization/CaretEncoding.cs
@@ -1,0 +1,73 @@
+﻿//
+// Copyright ical.net project maintainers and contributors.
+// Licensed under the MIT license.
+//
+
+using System.Text;
+
+namespace Ical.Net.Serialization;
+
+/// <summary>
+/// RFC 6868 caret encoding for property parameter values.
+/// </summary>
+internal static class CaretEncoding
+{
+    private static readonly char[] Special = { '^', '"', '\r', '\n' };
+
+    /// <summary>
+    /// Encodes a parameter value per RFC 6868 §3.1 (single left-to-right pass).
+    /// </summary>
+    public static string Encode(string value)
+    {
+        if (value.IndexOfAny(Special) < 0)
+            return value;
+
+        var sb = new StringBuilder(value.Length + 8);
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            switch (c)
+            {
+                case '^': sb.Append("^^"); break;
+                case '"': sb.Append("^'"); break;
+                case '\r':
+                    sb.Append("^n");
+                    // Collapse a CRLF pair into a single ^n.
+                    if (i + 1 < value.Length && value[i + 1] == '\n') i++;
+                    break;
+                case '\n': sb.Append("^n"); break;
+                default: sb.Append(c); break;
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Decodes a parameter value per RFC 6868 §3.2 (single left-to-right pass, inverse of <see cref="Encode"/>).
+    /// </summary>
+    public static string Decode(string value)
+    {
+        if (value.IndexOf('^') < 0)
+            return value;
+
+        var sb = new StringBuilder(value.Length);
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            if (c == '^' && i + 1 < value.Length)
+            {
+                switch (value[i + 1])
+                {
+                    case 'n': sb.Append('\n'); i++; continue;
+                    case '\'': sb.Append('"'); i++; continue;
+                    case '^': sb.Append('^'); i++; continue;
+                }
+                // A caret before any other char is left unchanged (§3.2).
+            }
+            sb.Append(c);
+        }
+
+        return sb.ToString();
+    }
+}

--- a/Ical.Net/Serialization/ParameterSerializer.cs
+++ b/Ical.Net/Serialization/ParameterSerializer.cs
@@ -27,9 +27,8 @@ public class ParameterSerializer : SerializerBase
         var builder = new StringBuilder();
         builder.Append(p.Name + "=");
 
-        // "Section 3.2:  Property parameter values MUST NOT contain the DQUOTE character."
-        // Therefore, let's strip any double quotes from the value.
-        var values = string.Join(",", p.Values).Replace("\"", string.Empty);
+        // RFC 6868 caret-encode each value, so ^, DQUOTE and newlines survive round-trips.
+        var values = string.Join(",", System.Linq.Enumerable.Select(p.Values, v => CaretEncoding.Encode(v ?? string.Empty)));
 
         // Surround the parameter value with double quotes, if the value
         // contains any problematic characters.

--- a/Ical.Net/Serialization/SimpleDeserializer.cs
+++ b/Ical.Net/Serialization/SimpleDeserializer.cs
@@ -221,7 +221,8 @@ public class SimpleDeserializer
             // Unquote the value if necessary
             pValueSpan = Unquote(pValueSpan);
 
-            parameter.AddValue(pValueSpan.ToString());
+            // RFC 6868 caret-decode the unquoted value (inverse of ParameterSerializer).
+            parameter.AddValue(CaretEncoding.Decode(pValueSpan.ToString()));
             valueStart = i + 1;
 
             // If we hit (another) ';' or ':', we are done with this parameter


### PR DESCRIPTION
A newline in a property parameter value makes `Calendar.Load(Serialize(cal))` throw: the raw newline terminates the content line, so ical.net emits output its own parser rejects.

    att.Parameters.Set("CN", "line1\nline2");
    // Load(Serialize(cal)) -> SerializationException: missing colon

RFC 6868 is the standard remedy and was unimplemented. This adds the symmetric codec: encode `^`->`^^`, DQUOTE->`^'`, newline->`^n` on serialization (§3.1) and the exact inverse when parsing parameter values (§3.2), each a single left-to-right pass.

DQUOTE was previously stripped, under a comment that parameter values MUST NOT contain DQUOTE. RFC 6868 `^'` keeps that guarantee (no literal DQUOTE reaches the wire) while round-tripping the character instead of dropping it, so I implemented that half too.

Tests cover `decode(encode(v)) == v` for `^`, newline, DQUOTE, a literal `^n`/`^^` and mixed values, the `Load(Serialize())` round-trip through the public API, and that plain values stay byte-identical. Full suite passes on net10.0; net8.0/net48 build (no net8 runtime on my machine to run them).
